### PR TITLE
Include missing templates in package

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -113,7 +113,10 @@ def find_package_data():
     os.chdir(cwd)
 
     package_data = {
+        'jupyter_server' : ['templates/*'],
         'jupyter_server.bundler.tests': ['resources/*', 'resources/*/*', 'resources/*/*/.*'],
+        'jupyter_server.services.api': ['api.yaml'],
+        'jupyter_server.i18n': ['*/LC_MESSAGES/*.*'],
     }
 
     return package_data


### PR DESCRIPTION
I was a bit too agressive on the `package_data` cleanup. Now re-adding HTML templates.