### PR TITLE
WIP - Enable kernel message filtering

### DIFF
--- a/jupyter_server/services/api/tests/test_api.py
+++ b/jupyter_server/services/api/tests/test_api.py
@@ -29,4 +29,4 @@ class KernelAPITest(ServerTestBase):
         assert data['kernels'] == 0
         assert data['last_activity'].endswith('Z')
         assert data['started'].endswith('Z')
-        assert data['started'] == isoformat(self.notebook.web_app.settings['started'])
+        assert data['started'] == isoformat(self.server.web_app.settings['started'])

--- a/jupyter_server/services/contents/tests/test_contents_api.py
+++ b/jupyter_server/services/contents/tests/test_contents_api.py
@@ -681,7 +681,7 @@ class APITest(ServerTestBase):
         """
         Temporarily patch the root dir of our checkpoint manager.
         """
-        cpm = self.notebook.contents_manager.checkpoints
+        cpm = self.server.contents_manager.checkpoints
         old_dirname = cpm.root_dir
         cpm.root_dir = dirname
         try:
@@ -717,7 +717,7 @@ class GenericFileCheckpointsAPITest(APITest):
     def test_config_did_something(self):
 
         self.assertIsInstance(
-            self.notebook.contents_manager.checkpoints,
+            self.server.contents_manager.checkpoints,
             GenericFileCheckpoints,
         )
 

--- a/jupyter_server/services/kernels/tests/test_kernels_api.py
+++ b/jupyter_server/services/kernels/tests/test_kernels_api.py
@@ -3,6 +3,8 @@
 import json
 import time
 
+from traitlets.config import Config
+
 from tornado.httpclient import HTTPRequest
 from tornado.ioloop import IOLoop
 from tornado.websocket import websocket_connect
@@ -184,3 +186,20 @@ class KernelAPITest(ServerTestBase):
                 break
         model = self.kern_api.get(kid).json()
         self.assertEqual(model['connections'], 0)
+
+
+class KernelFilterTest(ServerTestBase):
+    # A special install of ServerTestBase where only `kernel_info_request`
+    # messages are allowed.
+
+    config = Config({
+        'ServerApp': {
+            'MappingKernelManager': {
+                'allowed_message_types': ['kernel_info_request']
+            }
+        }
+    })
+
+    # Sanity check verifying that the configurable was properly set.
+    def test_config(self):
+        self.assertEqual(self.server.kernel_manager.allowed_message_types, ['kernel_info_request'])

--- a/jupyter_server/tests/test_files.py
+++ b/jupyter_server/tests/test_files.py
@@ -57,7 +57,7 @@ class FilesTest(ServerTestBase):
                 r = self.request('GET', url_path_join('files', d, foo))
                 self.assertEqual(r.status_code, 404)
 
-        self.notebook.contents_manager.allow_hidden = True
+        self.server.contents_manager.allow_hidden = True
         try:
             for d in not_hidden:
                 path = pjoin(rootdir, d.replace('/', os.sep))
@@ -75,7 +75,7 @@ class FilesTest(ServerTestBase):
                     r.raise_for_status()
                     self.assertEqual(r.text, foo)
         finally:
-            self.notebook.contents_manager.allow_hidden = False
+            self.server.contents_manager.allow_hidden = False
 
     def test_contents_manager(self):
         "make sure ContentsManager returns right files (ipynb, bin, txt)."


### PR DESCRIPTION
Fixes #17.

To change that parameter: first

```shell
jupyter server --generate-config
```

to generate a configuration file, then change the list of allowed message types.

```python
c.MappingKernelManager.allowed_message_types = ['kernel_info_request']
```

will cause e.g. `execute_request` message to trigger the warning:

"Received message of type "kernel_info_request", which is not allowed. Ignoring."