### PR TITLE
Travis CI: Upgrade from Py37 preresease to production release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,9 @@ matrix:
           env: GROUP=python
         - python: 3.5
           env: GROUP=python
-        - python: "3.7-dev"
+        - python: "3.7"
           env: GROUP=python
+          dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
         - python: 3.6
           env: GROUP=docs
 


### PR DESCRIPTION
Upgrade to production Python 3.7 in alignment with travis-ci/travis-ci#9069