### PR TITLE
[MRG] Configurable server extension applications

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -101,7 +101,6 @@ class ExtensionApp(JupyterApp):
             "{}_static_paths".format(self.extension_name): self.static_paths,
         })
 
-
         # Get setting defined by subclass using initialize_settings method.
         self.initialize_settings()
 
@@ -110,7 +109,6 @@ class ExtensionApp(JupyterApp):
 
     def _prepare_handlers(self):
         webapp = self.serverapp.web_app
-        print(webapp.default_router.rules)
 
         # Get handlers defined by extension subclass.
         self.initialize_handlers()
@@ -139,7 +137,7 @@ class ExtensionApp(JupyterApp):
         webapp.add_handlers('.*$', new_handlers)
 
     def _prepare_templates(self):
-
+        # Add templates to web app settings if extension has templates.
         if len(self.template_paths) > 0:
             self.settings.update({
                 "{}_template_paths".format(self.extension_name): self.template_paths
@@ -147,10 +145,10 @@ class ExtensionApp(JupyterApp):
         self.initialize_templates()
 
     @staticmethod
-    def initialize_server():
+    def initialize_server(argv=None):
         """Add handlers to server."""
-        serverapp = ServerApp.instance()
-        serverapp.initialize()
+        serverapp = ServerApp()
+        serverapp.initialize(argv=argv)
         return serverapp
 
     def initialize(self, serverapp, argv=None):
@@ -174,7 +172,7 @@ class ExtensionApp(JupyterApp):
         Properly orders the steps to initialize and start the server and extension.
         """
         # Initialize the server
-        serverapp = cls.initialize_server()
+        serverapp = cls.initialize_server(argv=argv)
 
         # Load the extension nk
         extension = cls.load_jupyter_server_extension(serverapp, argv=argv, **kwargs)
@@ -195,7 +193,7 @@ class ExtensionApp(JupyterApp):
         extension = cls()
         extension.initialize(serverapp, argv=argv)
 
-        # Initialize settings
+        # Initialize extension template, settings, and handlers.
         extension._prepare_templates()
         extension._prepare_settings()
         extension._prepare_handlers()

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -1,7 +1,5 @@
 import sys
 
-from traitlets.config.application import catch_config_error
-from traitlets.config.configurable import Configurable
 from traitlets import (
     Unicode, 
     List, 
@@ -13,9 +11,8 @@ from traitlets import (
 from jupyter_core.application import JupyterApp
 
 from jupyter_server.serverapp import ServerApp, aliases, flags
-from jupyter_server.transutils import trans, _
+from jupyter_server.transutils import _
 from jupyter_server.utils import url_path_join
-from jupyter_server.base.handlers import FileFindHandler
 
 
 # Remove alias for nested classes in ServerApp.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -1,0 +1,159 @@
+import sys
+
+from traitlets.config.application import catch_config_error
+from traitlets.config.configurable import Configurable
+from traitlets import (
+    Unicode, 
+    List, 
+    Dict, 
+    default, 
+    validate
+)
+
+from jupyter_core.application import JupyterApp
+
+from jupyter_server.serverapp import ServerApp
+from jupyter_server.transutils import trans, _
+from jupyter_server.utils import url_path_join
+from jupyter_server.base.handlers import FileFindHandler
+
+
+class ExtensionApp(JupyterApp):
+    """A base class for writing configurable Jupyter Server extension applications.
+
+    These applications can be loaded using jupyter_server's 
+    extension load mechanism or launched using Jupyter's command line interface.
+    """
+    # Name of the extension
+    extension_name = Unicode(
+        "",
+        help="Name of extension."
+    )
+
+    @default("extension_name")
+    def _default_extension_name(self):
+        raise Exception("The extension must be given a `name`.")
+
+    @validate("extension_name")
+    def _default_extension_name(self, obj, value):
+        if isinstance(name, str):
+            # Validate that extension_name doesn't contain any invalid characters.
+            for char in [' ', '.', '+', '/']:
+                self.error(obj, value)
+            return value
+        self.error(obj, value) 
+
+    # Extension can configure the ServerApp from the command-line
+    classes = [
+        ServerApp
+    ]
+
+    static_file_path = List(Unicode(),
+        help="""paths to search for serving static files.
+        
+        This allows adding javascript/css to be available from the notebook server machine,
+        or overriding individual files in the IPython
+        """
+    ).tag(config=True)
+
+    template_path = List(Unicode(), 
+        help=_("""Paths to search for serving jinja templates.
+
+        Can be used to override templates from notebook.templates.""")
+    ).tag(config=True)
+
+    settings = Dict(
+        help=_("""Settings that will passed to the server.""")
+    )
+
+    handlers = List(
+        help=_("""Handlers appended to the server.""")
+    )
+
+    default_url = Unicode('/', config=True,
+        help=_("The default URL to redirect to from `/`")
+    )
+
+    def initialize_static_handler(self):
+        # Check to see if 
+        if len(self.static_file_path) > 0:
+            # Append the extension's static directory to server handlers.
+            static_url = url_path_join("/static", self.extension_name, "(.*)")
+
+            # Construct handler.
+            handler = (static_url, FileFindHandler, {'path': self.static_file_path})
+            self.handlers.append(handler)
+
+            # Add the file paths to webapp settings.
+            self.settings.update({
+                "{}_static_path".format(self.extension_name): self.static_file_path,
+                "{}_template_path".format(self.extension_name): self.template_path
+            })
+
+    def initialize_handlers(self):
+        """Override this method to append handlers to a Jupyter Server."""
+        pass
+
+    def initialize_templates(self):
+        """"""
+        pass
+
+    def initialize_settings(self):
+        """"""
+        pass
+
+    @staticmethod
+    def initialize_server():
+        """Add handlers to server."""
+        serverapp = ServerApp()
+        serverapp.initialize()
+        return serverapp
+
+    def initialize(self, serverapp, argv=None):
+        super(ExtensionApp, self).initialize(argv=argv)
+        self.serverapp = serverapp
+
+    def start(self, **kwargs):
+        # Start the server.
+        self.serverapp.start()
+
+    @classmethod
+    def launch_instance(cls, argv=None, **kwargs):
+        """Lśunch the ServerApp and Server Extension Application. 
+        
+        Properly orders the steps to initialize and start the server and extension.
+        """
+        # Initialize the server
+        serverapp = cls.initialize_server()
+
+        # Load the extension
+        extension = cls.load_jupyter_server_extension(serverapp, argv=argv, **kwargs)
+        
+        # Start the browser at this extensions default_url.
+        serverapp.default_url = extension.default_url
+
+        # Start the application.
+        extension.start()
+
+    @classmethod
+    def load_jupyter_server_extension(cls, serverapp, argv=None, **kwargs):
+        """Load this extension following the server extension loading mechanism."""
+        # Get webapp from the server.
+        webapp = serverapp.web_app
+        
+        # Create an instance and initialize extension.
+        extension = cls()
+        extension.initialize(serverapp, argv=argv)
+        extension.initialize_settings()
+        extension.initialize_handlers()
+        extension.initialize_static_handler()
+        extension.initialize_templates()
+
+        # Make extension settings accessible to handlers inside webapp settings.
+        webapp.settings.update(**extension.settings)
+        webapp.settings.update(**)
+
+        # Add handlers to serverapp.
+        webapp.add_handlers('.*$', extension.handlers)
+
+        return extension

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -48,12 +48,18 @@ class ExtensionApp(JupyterApp):
         ServerApp
     ]
 
-    static_file_path = List(Unicode(),
-        help="""paths to search for serving static files for the extension."""
+    static_paths = List(Unicode(),
+        help="""paths to search for serving static files.
+        
+        This allows adding javascript/css to be available from the notebook server machine,
+        or overriding individual files in the IPython
+        """
     ).tag(config=True)
 
-    template_path = List(Unicode(), 
-        help=_("""Paths to search for serving jinja templates for the extension.""")
+    template_paths = List(Unicode(), 
+        help=_("""Paths to search for serving jinja templates.
+
+        Can be used to override templates from notebook.templates.""")
     ).tag(config=True)
 
     settings = Dict(
@@ -70,18 +76,18 @@ class ExtensionApp(JupyterApp):
 
     def initialize_static_handler(self):
         # Check to see if 
-        if len(self.static_file_path) > 0:
+        if len(self.static_paths) > 0:
             # Append the extension's static directory to server handlers.
             static_url = url_path_join("/static", self.extension_name, "(.*)")
 
             # Construct handler.
-            handler = (static_url, FileFindHandler, {'path': self.static_file_path})
+            handler = (static_url, FileFindHandler, {'path': self.static_paths})
             self.handlers.append(handler)
 
             # Add the file paths to webapp settings.
             self.settings.update({
-                "{}_static_path".format(self.extension_name): self.static_file_path,
-                "{}_template_path".format(self.extension_name): self.template_path
+                "{}_static_paths".format(self.extension_name): self.static_paths,
+                "{}_template_paths".format(self.extension_name): self.template_paths
             })
 
     def initialize_handlers(self):
@@ -147,7 +153,6 @@ class ExtensionApp(JupyterApp):
 
         # Make extension settings accessible to handlers inside webapp settings.
         webapp.settings.update(**extension.settings)
-        webapp.settings.update(**)
 
         # Add handlers to serverapp.
         webapp.add_handlers('.*$', extension.handlers)

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -49,17 +49,11 @@ class ExtensionApp(JupyterApp):
     ]
 
     static_file_path = List(Unicode(),
-        help="""paths to search for serving static files.
-        
-        This allows adding javascript/css to be available from the notebook server machine,
-        or overriding individual files in the IPython
-        """
+        help="""paths to search for serving static files for the extension."""
     ).tag(config=True)
 
     template_path = List(Unicode(), 
-        help=_("""Paths to search for serving jinja templates.
-
-        Can be used to override templates from notebook.templates.""")
+        help=_("""Paths to search for serving jinja templates for the extension.""")
     ).tag(config=True)
 
     settings = Dict(
@@ -95,11 +89,11 @@ class ExtensionApp(JupyterApp):
         pass
 
     def initialize_templates(self):
-        """"""
+        """Override this method to add handling of template files."""
         pass
 
     def initialize_settings(self):
-        """"""
+        """Override this method to add handling of settings."""
         pass
 
     @staticmethod
@@ -110,16 +104,18 @@ class ExtensionApp(JupyterApp):
         return serverapp
 
     def initialize(self, serverapp, argv=None):
+        """Initialize the extension app."""
         super(ExtensionApp, self).initialize(argv=argv)
         self.serverapp = serverapp
 
     def start(self, **kwargs):
+        """Start the extension app."""
         # Start the server.
         self.serverapp.start()
 
     @classmethod
     def launch_instance(cls, argv=None, **kwargs):
-        """Lśunch the ServerApp and Server Extension Application. 
+        """Launch the ServerApp and Server Extension Application. 
         
         Properly orders the steps to initialize and start the server and extension.
         """

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -24,8 +24,9 @@ except KeyError:
 
 
 def _preparse_command_line(Application):
-    """Looks for 'help' or 'version' commands in command line. If found,
-    raises the help and version of current Application.
+    """Looks for 'help', 'version', and 'generate-config; commands 
+    in command line. If found, raises the help and version of 
+    current Application.
 
     This is useful for traitlets applications that have to parse
     the command line multiple times, but want to control when
@@ -164,9 +165,20 @@ class ExtensionApp(JupyterApp):
 
         # prepend base_url onto the patterns that we match
         new_handlers = []
-        for handler in self.handlers:
-            pattern = url_path_join(webapp.settings['base_url'], handler[0])
-            new_handler = tuple([pattern] + list(handler[1:]))
+        for handler_items in self.handlers:
+            # Build url pattern including base_url
+            pattern = url_path_join(webapp.settings['base_url'], handler_items[0])
+            handler = handler_items[1]
+            
+            # Get handler kwargs, if given
+            kwargs = {}
+            try: 
+                kwargs.update(handler_items[2])
+            except IndexError:
+                pass
+            kwargs['extension_name'] = self.extension_name
+
+            new_handler = (pattern, handler, kwargs)
             new_handlers.append(new_handler)
 
         # Add static endpoint for this extension, if static paths are given.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -118,11 +118,11 @@ class ExtensionApp(JupyterApp):
 
     settings = Dict(
         help=_("""Settings that will passed to the server.""")
-    )
+    ).tag(config=True)
 
     handlers = List(
         help=_("""Handlers appended to the server.""")
-    )
+    ).tag(config=True)
 
     default_url = Unicode('/', config=True,
         help=_("The default URL to redirect to from `/`")

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -2,7 +2,7 @@ from jupyter_server.base.handlers import JupyterHandler, FileFindHandler
 from traitlets import Unicode, default
 
 
-class ExtensionHandler(JupyterHandler):
+class ServerHandlerExtensionBase(JupyterHandler):
     """Base class for Jupyter server extension handlers. 
 
     Subclasses can serve static files behind a namespaced 

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -2,7 +2,7 @@ from jupyter_server.base.handlers import JupyterHandler, FileFindHandler
 from traitlets import Unicode, default
 
 
-class ServerHandlerExtensionBase(JupyterHandler):
+class ExtensionHandler(JupyterHandler):
     """Base class for Jupyter server extension handlers. 
 
     Subclasses can serve static files behind a namespaced 
@@ -12,7 +12,7 @@ class ServerHandlerExtensionBase(JupyterHandler):
     their own namespace and avoid intercepting requests for 
     other extensions. 
     """
-    extension_name = Unicode(help="Name of the extenxsion")
+    extension_name = Unicode("",help="Name of the extenxsion")
 
     @default('extension_name')
     def _default_extension_name(self):
@@ -47,7 +47,7 @@ class ServerHandlerExtensionBase(JupyterHandler):
         key = "{}_static_paths".format(self.extension_name)
         try:
             self.require_setting(key, "static_url")
-        except e:
+        except Exception as e:
             if key in self.settings:
                 raise Exception(
                     "This extension doesn't have any static paths listed. Check that the "
@@ -74,4 +74,5 @@ class ServerHandlerExtensionBase(JupyterHandler):
             "static_path": self.static_path,
             "static_url_prefix": self.static_url_prefix
         }
+
         return base + get_url(settings, path, **kwargs)

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -25,7 +25,7 @@ class ExtensionHandler(JupyterHandler):
 
     @property
     def static_path(self):
-        return self.settings['{}_static_path'.format(self.extension_name)]
+        return self.settings['{}_static_paths'.format(self.extension_name)]
 
     def static_url(self, path, include_host=None, **kwargs):
         """Returns a static URL for the given relative static file path.
@@ -44,7 +44,17 @@ class ExtensionHandler(JupyterHandler):
         that value will be used as the default for all `static_url`
         calls that do not pass ``include_host`` as a keyword argument.
         """
-        self.require_setting("{}_static_path".format(self.extension_name), "static_url")
+        key = "{}_static_paths".format(self.extension_name)
+        try:
+            self.require_setting(key, "static_url")
+        except e:
+            if key in self.settings:
+                raise Exception(
+                    "This extension doesn't have any static paths listed. Check that the "
+                    "extension's `static_paths` trait is set."
+                )
+            else:
+                raise e
 
         get_url = self.settings.get(
             "static_handler_class", FileFindHandler

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,0 +1,67 @@
+from jupyter_server.base.handlers import JupyterHandler, FileFindHandler
+from traitlets import Unicode, default
+
+
+class ExtensionHandler(JupyterHandler):
+    """Base class for Jupyter server extension handlers. 
+
+    Subclasses can serve static files behind a namespaced 
+    endpoint: "/static/<extension_name>/" 
+
+    This allows multiple extensions to serve static files under
+    their own namespace and avoid intercepting requests for 
+    other extensions. 
+    """
+    extension_name = Unicode(help="Name of the extenxsion")
+
+    @default('extension_name')
+    def _default_extension_name(self):
+        raise Exception("extension_name must be set in {}.".format(self.__class__))
+
+    @property
+    def static_url_prefix(self):
+        return "/static/{extension_name}/".format(
+            extension_name=self.extension_name)
+
+    @property
+    def static_path(self):
+        return self.settings['{}_static_path'.format(self.extension_name)]
+
+    def static_url(self, path, include_host=None, **kwargs):
+        """Returns a static URL for the given relative static file path.
+        This method requires you set the ``{extension_name}_static_path`` 
+        setting in your extension (which specifies the root directory 
+        of your static files).
+        This method returns a versioned url (by default appending
+        ``?v=<signature>``), which allows the static files to be
+        cached indefinitely.  This can be disabled by passing
+        ``include_version=False`` (in the default implementation;
+        other static file implementations are not required to support
+        this, but they may support other options).
+        By default this method returns URLs relative to the current
+        host, but if ``include_host`` is true the URL returned will be
+        absolute.  If this handler has an ``include_host`` attribute,
+        that value will be used as the default for all `static_url`
+        calls that do not pass ``include_host`` as a keyword argument.
+        """
+        self.require_setting("{}_static_path".format(self.extension_name), "static_url")
+
+        get_url = self.settings.get(
+            "static_handler_class", FileFindHandler
+        ).make_static_url
+
+        if include_host is None:
+            include_host = getattr(self, "include_host", False)
+
+        if include_host:
+            base = self.request.protocol + "://" + self.request.host
+        else:
+            base = ""
+
+        # Hijack settings dict to send extension templates to extension
+        # static directory.
+        settings = {
+            "static_path": self.static_path,
+            "static_url_prefix": self.static_url_prefix
+        }
+        return base + get_url(settings, path, **kwargs)

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -12,11 +12,9 @@ class ExtensionHandler(JupyterHandler):
     their own namespace and avoid intercepting requests for 
     other extensions. 
     """
-    extension_name = Unicode("",help="Name of the extenxsion")
-
-    @default('extension_name')
-    def _default_extension_name(self):
-        raise Exception("extension_name must be set in {}.".format(self.__class__))
+    def initialize(self, extension_name, **kwargs):
+        self.extension_name = extension_name
+        super(ExtensionHandler, self).initialize(**kwargs)
 
     @property
     def static_url_prefix(self):


### PR DESCRIPTION
This is an initial implementation of a "Jupyter server extension application" class. Pinging @SylvainCorlay @takluyver @kevin-bates @lresende @rolweber @maartenbreddels for review.

## What?

This PR introduces the `ExtensionApp` to the Jupyter server, a base class for creating configurable, front-end client applications as extensions of the jupyter server. 

**Details**

`ExtensionApp` subclasses `JupyterApp` from `jupyter_core`. Extensions that subclass this class can be:
* launched and configured from the command line with `jupyter <extension_name> ...`
* configured by a file named `jupyter_<extension_name>_config.py`. 

When an extension application is launched, it
1. starts and launches an instance of the Jupyter server.
2. calls `self.load_jupyter_server_extension()` method.
3. loads configuration from config files+command line.
3. appends the extension's handlers to the main web application.
4. appends a `/static/<extension_name>/` endpoint where it serves static files (i.e. js, css, etc.).

## Why?

There are various frontends that depend on the classic Notebook Server (i.e. notebook, nteract, lab, and voila). However, the Notebook frontend is deeply coupled with the Notebook server, forcing other clients to work around it. Jupyter Server separates out the server from the notebook, so all front-end applications are first-class citizens to the server. 

*This PR makes it much easier to write client applications that depend on the Jupyter Server.*

## How?

1. Subclass the `ExtensionApp`. Set the following traits:
    * `extension_name`: name of the extension.
    * `static_paths`: path to static files directory
    * `template_paths`: path to templates directory.
    
    and define (optional) the following methods:
    * `initialize_handlers()`: append handlers to `self.handlers`.
    * `initialize_templates()`: setup your html templating options.
    * `initialize_settings()`: add extensions settings to the webapp using `self.settings`.

    **Example**
    ```python
    # application.py
    from jupyter_server.extension.application import ExtensionApp

    class MyExtension(ExtensionApp):
        
        # Name of the extension
        extension_name = "my_extension"

        # Local path to static files directory.
        static_paths = [
            "/path/to/static/dir/"
        ]

        # Local path to templates directory.
        template_paths = [
            "/path/to/template/dir/"
        ]

        def initialize_handlers(self):
            self.handlers.append(
                (r'/myextension', MyExtensionHandler)
            )

        def initialize_templates(self):
            ...

        def initialize_settings(self):
            ...

    ```

2. Define handlers by subclassing the `ExtensionHandler`. 

    **Example**
    ```python
    # handler.py
    from jupyter_server.extension.handler import ExtensionHandler


    class MyExtensionHandler(ExtensionHandler):
        
        def get(self):
            ...
    ```


3. Point Jupyter server to the extension. We need to define two things:
    * `_jupyter_server_extension_paths()`: a function defining what module to load the extension from.
    * `load_jupyter_server_extension()`: point there server to the extension's loading function mechansim.

    **Example**
    ```python
    # __init__.py
    from .extension import MyExtension


    EXTENSION_NAME = "my_extension"

    def _jupyter_server_extension_paths():
        return [{"module": EXTENSION_NAME}]

    load_jupyter_server_extension = MyExtension.load_jupyter_server_extension
    ```

4. Add the following configuration to your jupyter configuration directory to enable the extension.

    ```json
    {
      "ServerApp": {
        "jpserver_extensions": {
          "notebook": true
        }
      }
    }
    ```
5. Add entry point in `setup.py`.
