### PR TITLE
Add localhost to list of default local_hostnames

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -423,7 +423,7 @@ class JupyterHandler(AuthenticatedHandler):
             addr = ipaddress.ip_address(host)
         except ValueError:
             # Not an IP address: check against hostnames
-            allow = host in self.settings.get('local_hostnames', [])
+            allow = host in self.settings.get('local_hostnames', ['localhost'])
         else:
             allow = addr.is_loopback
 


### PR DESCRIPTION
To mirror the same logic in the [notebook](https://github.com/jupyter/notebook/blob/9560e0cf4c3a3612f7e0f869035e7e3eeb5853a0/notebook/base/handlers.py#L490), this adds localhost to the default list of `local_hostnames`.  Without this, jupyter_server extensions get a 403, unless they set `ServerApp.allow_remote_access = True`.  Instead, the error case on line 430 is hit, stating something like:
```
Blocking request with non-local 'Host' localhost (localhost:52620). If the server should be accessible at that name, set ServerApp.allow_remote_access to disable the check.
```
This fixes it!