### PR TITLE
Unpin zeromq

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ install:
   - cmd: conda config --set show_channel_urls true
   - cmd: conda config --add channels conda-forge
   #- cmd: conda update --yes --quiet conda
-  - cmd: conda install -y pyzmq zeromq=4.3.1 tornado jupyter_client nbformat nbconvert ipykernel pip nose
+  - cmd: conda install -y pyzmq tornado jupyter_client nbformat nbconvert ipykernel pip nose
   - cmd: pip install .[test]
 
 test_script:


### PR DESCRIPTION
The issue with zeromq 4.2.3 on conda-forge was fixed. We should be able to unpin it.