### PR TITLE
pass extension_name to only extension app handlers

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -14,7 +14,7 @@ from jupyter_core.application import JupyterApp
 from jupyter_server.serverapp import ServerApp, aliases, flags
 from jupyter_server.transutils import _
 from jupyter_server.utils import url_path_join
-
+from .handler import ExtensionHandler
 
 # Remove alias for nested classes in ServerApp.
 # Nested classes are not allowed in ExtensionApp.
@@ -181,11 +181,12 @@ class ExtensionApp(JupyterApp):
             
             # Get handler kwargs, if given
             kwargs = {}
+            if issubclass(handler, ExtensionHandler):
+                kwargs['extension_name'] = self.extension_name
             try: 
                 kwargs.update(handler_items[2])
             except IndexError:
                 pass
-            kwargs['extension_name'] = self.extension_name
 
             new_handler = (pattern, handler, kwargs)
             new_handlers.append(new_handler)

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -12,9 +12,8 @@ class ExtensionHandler(JupyterHandler):
     their own namespace and avoid intercepting requests for 
     other extensions. 
     """
-    def initialize(self, extension_name, **kwargs):
+    def initialize(self, extension_name):
         self.extension_name = extension_name
-        super(ExtensionHandler, self).initialize(**kwargs)
 
     @property
     def config(self):


### PR DESCRIPTION
Fixes a bug that was breaking jupyter/notebook#4653.

Passes the `extension_name` arg to *only* handlers that subclass the ExtensionHandler class. This bug was breaking custom static filehandlers in the notebook extension app.