### PR TITLE
Add standalone mode to server

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -152,8 +152,8 @@ class ExtensionApp(JupyterApp):
         the object to the webapp's settings as `<extension_name>_config`.  
         """
         traits = self.class_own_traits().keys()
-        self.config = Config({t: getattr(self, t) for t in traits})
-        self.settings['{}_config'.format(self.extension_name)] = self.config
+        self.extension_config = Config({t: getattr(self, t) for t in traits})
+        self.settings['{}_config'.format(self.extension_name)] = self.extension_config
 
     def _prepare_settings(self):
         # Make webapp settings accessible to initialize_settings method
@@ -279,7 +279,6 @@ class ExtensionApp(JupyterApp):
         # Configure and initialize extension.
         extension = cls()
         extension.initialize(serverapp, argv=argv)
-
         return extension
 
     @classmethod
@@ -290,7 +289,6 @@ class ExtensionApp(JupyterApp):
         """
         # Load the extension
         extension = cls.load_jupyter_server_extension(serverapp, argv=argv, **kwargs)
-        
         # Start the browser at this extensions default_url, unless user
         # configures ServerApp.default_url on command line.
         try:
@@ -313,11 +311,10 @@ class ExtensionApp(JupyterApp):
         # arguments trigger actions from the extension not the server.
         _preparse_command_line(cls)
         # Handle arguments.
-        if argv is not None:
+        if argv is None:
             args = sys.argv[1:]  # slice out extension config.
         else:
             args = []
-        
         # Get a jupyter server instance.
         serverapp = cls.initialize_server(argv=args)
         extension = cls._prepare_launch(serverapp, argv=args, **kwargs)

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -20,6 +20,10 @@ class ExtensionHandler(JupyterHandler):
         return self.settings["{}_config".format(self.extension_name)]
 
     @property
+    def server_config(self):
+        return self.settings["config"]
+
+    @property
     def static_url_prefix(self):
         return "/static/{extension_name}/".format(
             extension_name=self.extension_name)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -492,6 +492,11 @@ flags['allow-root']=(
     _("Allow the server to be run from root user.")
 )
 
+flags['standalone']=(
+    {'ServerApp' : {'standalone' : True}},
+    _("Run the server without enabling extensions.")
+)
+
 # Add notebook manager flags
 flags.update(boolean_flag('script', 'FileContentsManager.save_script',
                'DEPRECATED, IGNORED',
@@ -1138,6 +1143,12 @@ class ServerApp(JupyterApp):
          is not available.
          """))
 
+    standalone = Bool(
+        False,
+        config=True,
+        help="Run the server without enabling extensions."
+    )
+
     def parse_command_line(self, argv=None):
         super(ServerApp, self).parse_command_line(argv)
 
@@ -1469,7 +1480,8 @@ class ServerApp(JupyterApp):
         self.init_webapp()
         self.init_terminals()
         self.init_signal()
-        self.init_server_extensions()
+        if self.standalone is False:
+            self.init_server_extensions()
         self.init_mime_overrides()
         self.init_shutdown_no_activity()
 


### PR DESCRIPTION
This is one way to implement "standalone" mode #64. 

This adds standalone mode *to the ServerApp* itself (not just extensions). Extensions can then run a standalone server by exposing a flag that sets `ServerApp.standalone=True`.