### PR TITLE
Fix default_url redirect with default 'main' handler

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -869,7 +869,6 @@ path_regex = r"(?P<path>(?:(?:/[^/]+)+|/?))"
 
 default_handlers = [
     (r".*/", TrailingSlashHandler),
-    (r"/", MainHandler),
     (r"api", APIVersionHandler),
     (r'/(robots\.txt|favicon\.ico)', web.StaticFileHandler),
     (r'/metrics', PrometheusMetricsHandler)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -75,7 +75,7 @@ try:
 except NameError:
     raw_input = input
 
-from .base.handlers import Template404, RedirectWithParams
+from .base.handlers import MainHandler, RedirectWithParams, Template404
 from .log import log_request
 from .services.kernels.kernelmanager import MappingKernelManager
 from .services.config import ConfigManager
@@ -304,13 +304,18 @@ class ServerWebApplication(web.Application):
         )
         # register base handlers last
         handlers.extend(load_handlers('jupyter_server.base.handlers'))
-        # set the URL that will be redirected from `/`
-        handlers.append(
-            (r'/?', RedirectWithParams, {
-                'url' : settings['default_url'],
-                'permanent': False, # want 302, not 301
-            })
-        )
+
+        if settings['default_url'] != '/':
+            # set the URL that will be redirected from `/`
+            handlers.append(
+                (r'/?', RedirectWithParams, {
+                    'url' : settings['default_url'],
+                    'permanent': False, # want 302, not 301
+                })
+            )
+        else:
+            handlers.append(
+                (r"/", MainHandler))
 
         # prepend base_url onto the patterns that we match
         new_handlers = []


### PR DESCRIPTION
The expected behavior of `ServerApp.default_url` is to redirect to (base_url +) `default_url` when the base url (`/`) is requested.

But I think https://github.com/jupyter/jupyter_server/pull/54 broke this by adding a `/` handler. Which seems to prevent the [redirect handler](https://github.com/jupyter/jupyter_server/blob/master/jupyter_server/serverapp.py#L308) from working.

To fix, I propose conditionally setting the root url handler based on whether `default_url` is specified in config.

To reproduce: `jupyter server --ServerApp.default_url='/please_redirect_here' --ServerApp.token='' --ServerApp.open_browser=False`, and navigate to `localhost:8888`.

Note: the `--ServerApp.open_browser=False` option is required, as `open_browser` emulates the redirect logic [here](https://github.com/jupyter/jupyter_server/blob/master/jupyter_server/serverapp.py#L1573). I'll propose removing this logic in a separate PR.