### PR TITLE
Remove 'coded redirect' to default_url

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1569,8 +1569,7 @@ class ServerApp(JupyterApp):
                 relpath = os.path.relpath(self.file_to_run, self.root_dir)
                 uri = url_escape(url_path_join('notebooks', *relpath.split(os.sep)))
             else:
-                # default_url contains base_url, but so does connection_url
-                uri = self.default_url[len(self.base_url):]
+                uri = self.base_url
             if self.one_time_token:
                 uri = url_concat(uri, {'token': self.one_time_token})
             if browser:


### PR DESCRIPTION
When investigating https://github.com/jupyter/jupyter_server/pull/72, it was noticed that `--ServerApp.open_browser=True` (the default) did not exhibit the bug. And the browser would open the `default_url` as expected.

This is because the `open_browser` logic effectively redirects to the `default_url` in code.

I propose changing the `open_browser` logic to simply open the `base_url`, and allowing the redirect logic (if specified) to handling redirecting to the `default_url`. Rather than emulating this behavior in code.
