### PR TITLE
Added secure_write to function for cookie / token saves

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -40,6 +40,7 @@ except ImportError: #PY2
 from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.transutils import trans, _
+from jupyter_server.utils import secure_write
 
 # Install the pyzmq ioloop. This has to be done before anything else from
 # tornado is imported.
@@ -678,7 +679,7 @@ class ServerApp(JupyterApp):
     def _default_cookie_secret(self):
         if os.path.exists(self.cookie_secret_file):
             with io.open(self.cookie_secret_file, 'rb') as f:
-                key =  f.read()
+                key = f.read()
         else:
             key = encodebytes(os.urandom(32))
             self._write_cookie_secret_file(key)
@@ -690,18 +691,11 @@ class ServerApp(JupyterApp):
         """write my secret to my secret_file"""
         self.log.info(_("Writing notebook server cookie secret to %s"), self.cookie_secret_file)
         try:
-            with io.open(self.cookie_secret_file, 'wb') as f:
+            with secure_write(self.cookie_secret_file) as f:
                 f.write(secret)
         except OSError as e:
             self.log.error(_("Failed to write cookie secret to %s: %s"),
                            self.cookie_secret_file, e)
-        try:
-            os.chmod(self.cookie_secret_file, 0o600)
-        except OSError:
-            self.log.warning(
-                _("Could not set permissions on %s"),
-                self.cookie_secret_file
-            )
 
     token = Unicode('<generated>',
         help=_("""Token used for authenticating first-time connections to the server.

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -691,7 +691,7 @@ class ServerApp(JupyterApp):
         """write my secret to my secret_file"""
         self.log.info(_("Writing notebook server cookie secret to %s"), self.cookie_secret_file)
         try:
-            with secure_write(self.cookie_secret_file) as f:
+            with secure_write(self.cookie_secret_file, True) as f:
                 f.write(secret)
         except OSError as e:
             self.log.error(_("Failed to write cookie secret to %s: %s"),

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1506,7 +1506,7 @@ class ServerApp(JupyterApp):
     def write_server_info_file(self):
         """Write the result of server_info() to the JSON file info_file."""
         try:
-            with open(self.info_file, 'w') as f:
+            with secure_write(self.info_file) as f:
                 json.dump(self.server_info(), f, indent=2, sort_keys=True)
         except OSError as e:
             self.log.error(_("Failed to write server-info to %s: %s"),

--- a/jupyter_server/tests/test_utils.py
+++ b/jupyter_server/tests/test_utils.py
@@ -101,7 +101,7 @@ def test_secure_write():
         with secure_write(fname) as f:
             f.write('test 1')
         mode = os.stat(fname).st_mode
-        nt.assert_equal('0o600', oct(stat.S_IMODE(mode)))
+        nt.assert_equal('0600', oct(stat.S_IMODE(mode)).replace('0o', '0'))
         with open(fname, 'r') as f:
             nt.assert_equal(f.read(), 'test 1')
 
@@ -110,7 +110,7 @@ def test_secure_write():
         with secure_write(fname) as f:
             f.write('test 2')
         mode = os.stat(fname).st_mode
-        nt.assert_equal('0o600', oct(stat.S_IMODE(mode)))
+        nt.assert_equal('0600', oct(stat.S_IMODE(mode)).replace('0o', '0'))
         with open(fname, 'r') as f:
             nt.assert_equal(f.read(), 'test 2')
     finally:

--- a/jupyter_server/tests/test_utils.py
+++ b/jupyter_server/tests/test_utils.py
@@ -5,6 +5,7 @@
 
 import ctypes
 import os
+import re
 import stat
 import shutil
 import tempfile
@@ -15,7 +16,7 @@ from traitlets.tests.utils import check_help_all_output
 from jupyter_server.utils import url_escape, url_unescape, is_hidden, is_file_hidden, secure_write
 from ipython_genutils.py3compat import cast_unicode
 from ipython_genutils.tempdir import TemporaryDirectory
-from ipython_genutils.testing.decorators import skip_if_not_win32
+from ipython_genutils.testing.decorators import skip_if_not_win32, skip_win32
 
 
 def test_help_output():
@@ -94,7 +95,50 @@ def test_is_hidden_win32():
         assert is_hidden(subdir1, root)
         assert is_file_hidden(subdir1)
 
-def test_secure_write():
+@skip_if_not_win32
+def test_secure_write_win32():
+    def fetch_win32_permissions(filename):
+        '''Extracts file permissions on windows using icacls'''
+        role_permissions = {}
+        for index, line in enumerate(os.popen("icacls %s" % filename).read().splitlines()):
+            if index == 0:
+                line = line.split(filename)[-1].strip().lower()
+            match = re.match(r'\s*([^:]+):\(([^\)]*)\)', line)
+            if match:
+                usergroup, permissions = match.groups()
+                usergroup = usergroup.lower().split('\\')[-1]
+                permissions = set(p.lower() for p in permissions.split(','))
+                role_permissions[usergroup] = permissions
+            elif not line.strip():
+                break
+        return role_permissions
+
+    def check_user_only_permissions(fname):
+        # Windows has it's own permissions ACL patterns
+        import win32api
+        username = win32api.GetUserName().lower()
+        permissions = fetch_win32_permissions(fname)
+        print(permissions) # for easier debugging
+        nt.assert_true(username in permissions)
+        nt.assert_equal(permissions[username], set(['r', 'w']))
+        nt.assert_true('administrators' in permissions)
+        nt.assert_equal(permissions['administrators'], set(['f']))
+        nt.assert_true('everyone' not in permissions)
+        nt.assert_equal(len(permissions), 2)
+
+    directory = tempfile.mkdtemp()
+    fname = os.path.join(directory, 'check_perms')
+    try:
+        with secure_write(fname) as f:
+            f.write('test 1')
+        check_user_only_permissions(fname)
+        with open(fname, 'r') as f:
+            nt.assert_equal(f.read(), 'test 1')
+    finally:
+        shutil.rmtree(directory)
+
+@skip_win32
+def test_secure_write_unix():
     directory = tempfile.mkdtemp()
     fname = os.path.join(directory, 'check_perms')
     try:

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -282,7 +282,7 @@ def secure_write(fname):
     """
     try:
         os.remove(fname)
-    except IOError:
+    except (IOError, OSError):
         # Skip any issues with file not existing
         pass
 

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -235,7 +235,7 @@ def is_hidden(abs_path, abs_root=''):
     return False
 
 @contextmanager
-def secure_write(fname):
+def secure_write(fname, binary=False):
     """
     Opens a file in the most restricted pattern available for
     writing content. This limits the file mode to `600` and yields
@@ -247,8 +247,9 @@ def secure_write(fname):
     fname : unicode
         The path to the file to write
     """
+    mode = 'wb' if binary else 'w'
     try:
-        with os.fdopen(os.open(fname, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), 'w') as f:
+        with os.fdopen(os.open(fname, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), mode) as f:
             yield f
     finally:
         try:

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -269,7 +269,7 @@ def win32_restrict_file_to_user(fname):
 
 # TODO: Move to jupyter_core
 @contextmanager
-def secure_write(fname):
+def secure_write(fname, binary=False):
     """Opens a file in the most restricted pattern available for
     writing content. This limits the file mode to `600` and yields
     the resulting opened filed handle.
@@ -280,6 +280,7 @@ def secure_write(fname):
     fname : unicode
         The path to the file to write
     """
+    mode = 'wb' if binary else 'w'
     try:
         os.remove(fname)
     except (IOError, OSError):
@@ -298,7 +299,7 @@ def secure_write(fname):
         # Enforce that the file got the requested permissions.
         assert '0600' == oct(stat.S_IMODE(os.stat(fname).st_mode)).replace('0o', '0')
 
-    with os.fdopen(os.open(fname, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), 'w') as f:
+    with os.fdopen(os.open(fname, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), mode) as f:
         yield f
 
 def samefile_simple(path, other_path):

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,8 @@ for more information.
         'ipykernel', # bless IPython kernel for now
         'Send2Trash',
         'terminado>=0.8.1',
-        'prometheus_client'
+        'prometheus_client',
+        "pywin32>=1.0 ; sys_platform == 'win32'"
     ],
     extras_require = {
         ':python_version == "2.7"': ['ipaddress'],


### PR DESCRIPTION
This follows an advisory suggesting this change be made to help protect the secret files from being exposed to other users on a box running jupyter.