### PR TITLE
List server version in initial log and server-info file

### DIFF
--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -9,5 +9,5 @@ store the current version info of the server.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
-version_info = (0, 1, 1, '')
+version_info = (0, 2, 0, '.dev0')
 __version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1493,7 +1493,8 @@ class ServerApp(JupyterApp):
             info += kernel_msg % n_kernels
             info += "\n"
         # Format the info so that the URL fits on a single line in 80 char display
-        info += _("The Jupyter Server is running at:\n%s") % self.display_url
+        info += _("Jupyter Server {version} is running at:\n{url}".
+                  format(version=ServerApp.version, url=self.display_url))
         return info
 
     def server_info(self):
@@ -1507,6 +1508,7 @@ class ServerApp(JupyterApp):
                 'root_dir': os.path.abspath(self.root_dir),
                 'password': bool(self.password),
                 'pid': os.getpid(),
+                'version': ServerApp.version,
                }
 
     def write_server_info_file(self):

--- a/jupyter_server/tests/test_serverapp.py
+++ b/jupyter_server/tests/test_serverapp.py
@@ -45,6 +45,7 @@ def test_server_info_file():
     nt.assert_equal(len(servers), 1)
     nt.assert_equal(servers[0]['port'], svapp.port)
     nt.assert_equal(servers[0]['url'], svapp.connection_url)
+    nt.assert_equal(servers[0]['version'], svapp.version)
     svapp.remove_server_info_file()
     nt.assert_equal(get_servers(), [])
 


### PR DESCRIPTION
To help minimize support round trips, this change adds the server's version information into the informational message logged when the server starts in addition to the server-info file that lives while the server is running.

e.g.,
```
[I 13:10:43.541 ServerApp] Jupyter Server 0.2.0.dev0 is running at:
[I 13:10:43.541 ServerApp] http://localhost:8888/?token=57a4f4fa588cec57429981020b02d154b7439788ec274fe9
```

I also took the liberty of incrementing the version for the next dev iteration and added `.dev0` so we can distinguish dev builds from releases.