### PR TITLE
[WIP] Various updates from trying to make a Voila extension.

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -82,7 +82,10 @@ class ExtensionApp(JupyterApp):
 
     @default("extension_name")
     def _default_extension_name(self):
-        raise ValueError("The extension must be given a `name`.")
+        try:
+            return self.name
+        except AttributeError:
+            raise ValueError("The extension must be given a `name`.")
 
     INVALID_EXTENSION_NAME_CHARS = [' ', '.', '+', '/']
 
@@ -253,25 +256,20 @@ class ExtensionApp(JupyterApp):
         self._prepare_settings()
         self._prepare_handlers()
 
-    def listen(self):
-        """Extension doesn't listen for anything. IOLoop lives
-        in the attached server.
-        """
-        pass
-
-    def start(self):
-        """Extension has nothing to `start`. See `start_server`
-        for starting the jupyter server application.
-        """
-        pass
-
-    def start_server(self, **kwargs):
-        """Start the Jupyter server.
+    def start(self, **kwargs):
+        """Start the underlying Jupyter server.
         
         Server should be started after extension is initialized.
         """
+        # Start the browser at this extensions default_url.
+        self.serverapp.default_url = self.default_url
         # Start the server.
-        self.serverapp.start(**kwargs)
+        self.serverapp.start(**kwargs) 
+
+    def stop(self):
+        """Stop the underlying Jupyter server.
+        """
+        self.serverapp.stop()
 
     @classmethod
     def load_jupyter_server_extension(cls, serverapp, argv=[], **kwargs):
@@ -281,25 +279,6 @@ class ExtensionApp(JupyterApp):
         # Configure and initialize extension.
         extension = cls()
         extension.initialize(serverapp, argv=argv)
-        return extension
-
-    @classmethod
-    def _prepare_launch(cls, serverapp, argv=[], **kwargs):
-        """Prepare the extension application for launch by 
-        configuring the server and the extension from argv.
-        Does not start the ioloop.
-        """
-        # Load the extension
-        extension = cls.load_jupyter_server_extension(serverapp, argv=argv, **kwargs)
-        # Start the browser at this extensions default_url, unless user
-        # configures ServerApp.default_url on command line.
-        try:
-            server_config = extension.config['ServerApp']
-            if 'default_url' not in server_config:
-                serverapp.default_url = extension.default_url
-        except KeyError: 
-            pass
-
         return extension
 
     @classmethod
@@ -329,7 +308,7 @@ class ExtensionApp(JupyterApp):
                 "other extensions.".format(ext_name=cls.extension_name)
             )
 
-        extension = cls._prepare_launch(serverapp, argv=args, **kwargs)
+        extension = cls.load_jupyter_server_extension(serverapp, argv=args, **kwargs)
         # Start the ioloop.
-        extension.start_server()
+        extension.start()
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -837,7 +837,7 @@ class ServerApp(JupyterApp):
        """
     )
 
-    open_browser = Bool(True, config=True,
+    open_browser = Bool(False, config=True,
                         help="""Whether to open in a browser after starting.
                         The specific browser used is platform dependent and
                         determined by the python standard library `webbrowser`


### PR DESCRIPTION
Various minor changes while trying to [make Voila a jupyter_server extension](https://github.com/QuantStack/voila/pull/270) using the ExtensionApp API.

I'll be updating this list as I work on the Voila example.

- [x] `open_browser = False` is default for jupyter_server
- [x] get `extension_name` from `name` property if not set by extension developer
- [x] simplify launching mechanism
- [x] add `start` and `stop` methods to look more like a `JupyterApp`
- [ ] other stuff...