### PR TITLE
Remove Python 2 support, require 3.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.cache/pip
 python:
     - 3.6
-    - 2.7
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ environment:
   matrix:
     - CONDA_PY: 36
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
-    - CONDA_PY: 27
-      CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
 
 platform:
   - x64

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -5,12 +5,9 @@
 
 import re
 import os
-
-try:
-    from urllib.parse import urlparse # Py 3
-except ImportError:
-    from urlparse import urlparse # Py 2
 import uuid
+
+from urllib.parse import urlparse
 
 from tornado.escape import url_escape
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -14,18 +14,9 @@ import sys
 import traceback
 import types
 import warnings
-try:
-    # py3
-    from http.client import responses
-    from http.cookies import Morsel
-except ImportError:
-    from httplib import responses
-    from Cookie import Morsel
-try:
-    from urllib.parse import urlparse # Py 3
-except ImportError:
-    from urlparse import urlparse # Py 2
-
+from http.client import responses
+from http.cookies import Morsel
+from urllib.parse import urlparse
 from jinja2 import TemplateNotFound
 from tornado import web, gen, escape, httputil
 from tornado.log import app_log

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -9,13 +9,9 @@ import json
 import struct
 import warnings
 import sys
-
-try:
-    from urllib.parse import urlparse # Py 3
-except ImportError:
-    from urlparse import urlparse # Py 2
-
 import tornado
+
+from urllib.parse import urlparse
 from tornado import gen, ioloop, web
 from tornado.websocket import WebSocketHandler
 

--- a/jupyter_server/files/handlers.py
+++ b/jupyter_server/files/handlers.py
@@ -6,10 +6,7 @@
 import mimetypes
 import json
 
-try: #PY3
-    from base64 import decodebytes
-except ImportError: #PY2
-    from base64 import decodestring as decodebytes
+from base64 import decodebytes
 
 from tornado import web
 

--- a/jupyter_server/nbconvert/tests/test_nbconvert_handlers.py
+++ b/jupyter_server/nbconvert/tests/test_nbconvert_handlers.py
@@ -16,10 +16,7 @@ from nbformat.v4 import (
 
 from ipython_genutils.testing.decorators import onlyif_cmds_exist
 
-try: #PY3
-    from base64 import encodebytes
-except ImportError: #PY2
-    from base64 import encodestring as encodebytes
+from base64 import encodebytes
 
 
 class NbconvertAPI(object):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -31,12 +31,7 @@ import time
 import warnings
 import webbrowser
 
-try: #PY3
-    from base64 import encodebytes
-except ImportError: #PY2
-    from base64 import encodestring as encodebytes
-
-
+from base64 import encodebytes
 from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.transutils import trans, _
@@ -69,12 +64,6 @@ from jupyter_server import (
     DEFAULT_TEMPLATE_PATH_LIST,
     __version__,
 )
-
-# py23 compatibility
-try:
-    raw_input = raw_input
-except NameError:
-    raw_input = input
 
 from .base.handlers import MainHandler, RedirectWithParams, Template404
 from .log import log_request

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -24,24 +24,13 @@ from ipython_genutils.py3compat import str_to_unicode
 from traitlets.config import Configurable
 from traitlets import Bool
 
-try: #PY3
-    from base64 import encodebytes, decodebytes
-except ImportError: #PY2
-    from base64 import encodestring as encodebytes, decodestring as decodebytes
+from base64 import encodebytes, decodebytes
 
 
 def replace_file(src, dst):
     """ replace dst with src
-
-    switches between os.replace or os.rename based on python 2.7 or python 3
     """
-    if hasattr(os, 'replace'): # PY3
-        os.replace(src, dst)
-    else:
-        if os.name == 'nt' and os.path.exists(dst):
-            # Rename over existing file doesn't work on Windows
-            os.remove(dst)
-        os.rename(src, dst)
+    os.replace(src, dst)
 
 def copy2_safe(src, dst, log=None):
     """copy src to dst

--- a/jupyter_server/services/contents/tests/test_contents_api.py
+++ b/jupyter_server/services/contents/tests/test_contents_api.py
@@ -27,10 +27,7 @@ from nbformat import v2
 from ipython_genutils import py3compat
 from ipython_genutils.tempdir import TemporaryDirectory
 
-try: #PY3
-    from base64 import encodebytes, decodebytes
-except ImportError: #PY2
-    from base64 import encodestring as encodebytes, decodestring as decodebytes
+from base64 import encodebytes, decodebytes
 
 
 def uniq_stable(elems):

--- a/jupyter_server/tests/launchserver.py
+++ b/jupyter_server/tests/launchserver.py
@@ -13,11 +13,7 @@ from unittest import TestCase
 
 pjoin = os.path.join
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch #py2
-
+from unittest.mock import patch
 import requests
 from tornado.ioloop import IOLoop
 import zmq

--- a/jupyter_server/tests/test_extensions.py
+++ b/jupyter_server/tests/test_extensions.py
@@ -2,10 +2,7 @@ import imp
 import os
 import sys
 from unittest import TestCase
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch # py2
+from unittest.mock import patch
 
 from ipython_genutils.tempdir import TemporaryDirectory
 from ipython_genutils import py3compat
@@ -17,13 +14,7 @@ from jupyter_core import paths
 from jupyter_server.extensions import toggle_serverextension_python, _get_config_dir
 from jupyter_server import extensions, extensions_base
 from jupyter_server.serverapp import ServerApp
-
-if sys.version_info > (3,):
-    from types import SimpleNamespace
-else:
-    class SimpleNamespace(object):
-        pass
-
+from types import SimpleNamespace
 from collections import OrderedDict
 
 def test_help_output():

--- a/jupyter_server/tests/test_paths.py
+++ b/jupyter_server/tests/test_paths.py
@@ -4,13 +4,6 @@ import nose.tools as nt
 
 from jupyter_server.base.handlers import path_regex
 
-try: # py3
-    assert_regex = nt.assert_regex
-    assert_not_regex = nt.assert_not_regex
-except AttributeError: # py2
-    assert_regex = nt.assert_regexp_matches
-    assert_not_regex = nt.assert_not_regexp_matches
-
 
 # build regexps that tornado uses:
 path_pat = re.compile('^' + '/x%s' % path_regex + '$')
@@ -24,7 +17,7 @@ def test_path_regex():
         '/x/foo/bar',
         '/x/foo/bar.txt',
     ):
-        assert_regex(path, path_pat)
+        nt.assert_regex(path, path_pat)
 
 def test_path_regex_bad():
     for path in (
@@ -37,4 +30,4 @@ def test_path_regex_bad():
         '/y',
         '/y/x/foo',
     ):
-        assert_not_regex(path, path_pat)
+        nt.assert_not_regex(path, path_pat)

--- a/jupyter_server/tests/test_serverapp.py
+++ b/jupyter_server/tests/test_serverapp.py
@@ -8,11 +8,7 @@ import signal
 from subprocess import Popen, PIPE, STDOUT
 import sys
 from tempfile import NamedTemporaryFile
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch # py2
+from unittest.mock import patch
 
 import nose.tools as nt
 

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -27,11 +27,7 @@ except ImportError:
         """If concurrent.futures isn't importable, nothing will be a c.f.Future"""
         pass
 
-try:
-    from urllib.parse import quote, unquote, urlparse
-except ImportError:
-    from urllib import quote, unquote
-    from urlparse import urlparse
+from urllib.parse import quote, unquote, urlparse
 
 # tornado.concurrent.Future is asyncio.Future
 # in tornado >=5 with Python 3

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,8 @@ import sys
 name = "jupyter_server"
 
 # Minimal Python version sanity check
-v = sys.version_info
-if v[:2] < (2,7) or (v[0] >= 3 and v[:2] < (3,3)):
-    error = "ERROR: %s requires Python version 2.7 or 3.3 or above." % name
+if sys.version_info < (3,5):
+    error = "ERROR: %s requires Python version 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -67,8 +66,10 @@ for more information.
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     zip_safe = False,
     install_requires = [
@@ -90,12 +91,11 @@ for more information.
         "pywin32>=1.0 ; sys_platform == 'win32'"
     ],
     extras_require = {
-        ':python_version == "2.7"': ['ipaddress'],
-        'test:python_version == "2.7"': ['mock'],
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
                  'nbval', 'nose-exclude', 'selenium'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
+    python_requires='>=3.5',
     entry_points = {
         'console_scripts': [
             'jupyter-server = jupyter_server.serverapp:main',


### PR DESCRIPTION
Adjust dependencies and conditional imports/functions that distinguished
between Python versions 2 and 3.

I purposely skipped adjusting code like [the following](https://github.com/jupyter/jupyter_server/blob/master/jupyter_server/services/kernels/kernelmanager.py#L189-L190) since that should be part of a general native coroutine sweep (see #93).

```python
# py2-compat
raise gen.Return(kernel_id)
```

Closes: #63