### PR TITLE
Remove python 2 specific code after NB port

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -26,7 +26,7 @@ from jupyter_server._sysinfo import get_sys_info
 
 from traitlets.config import Application
 from ipython_genutils.path import filefind
-from ipython_genutils.py3compat import string_types, PY3
+from ipython_genutils.py3compat import string_types
 
 import jupyter_server
 from jupyter_server._tz import utcnow
@@ -404,10 +404,6 @@ class JupyterHandler(AuthenticatedHandler):
         # Browsers format IPv6 addresses like [::1]; we need to remove the []
         if host.startswith('[') and host.endswith(']'):
             host = host[1:-1]
-
-        if not PY3:
-            # ip_address only accepts unicode on Python 2
-            host = host.decode('utf8', 'replace')
 
         try:
             addr = ipaddress.ip_address(host)


### PR DESCRIPTION
One of the commits ported from Notebook reverted previous changes to drop support for python 2.

This change is the only known issue stemming from the batched port exercise.

Closes: #96