### PR TITLE
Stop building a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [bdist_wheel]
-universal=1
 
 [metadata]
 license_file = COPYING.md


### PR DESCRIPTION
No need to build a py2.py3 wheel if we don't support py2.  This should have been part of #94.