### PR TITLE
feat: add base_url to browser_open.html template

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1675,7 +1675,7 @@ class ServerApp(JupyterApp):
 
         jinja2_env = self.web_app.settings['jinja2_env']
         template = jinja2_env.get_template('browser-open.html')
-        fh.write(template.render(open_url=url))
+        fh.write(template.render(open_url=url, base_url=self.base_url))
 
     def remove_browser_open_file(self):
         """Remove the nbserver-<pid>-open.html file created for this server.


### PR DESCRIPTION
As @martinRenou argues in https://github.com/voila-dashboards/voila/pull/413 it makes sense to include base_url for this template, so all templates are access to the same variables.
Since we will rely on jupyter_server, it would be nice to keep this feature.