### PR TITLE
Support subcommands on server extensions

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -282,11 +282,13 @@ class ExtensionApp(JupyterApp):
         super(ExtensionApp, self).initialize(argv=argv)
         self.serverapp = serverapp
 
-        # Initialize config, settings, templates, and handlers.
-        self._prepare_config()
-        self._prepare_templates()
-        self._prepare_settings()
-        self._prepare_handlers()
+        # Initialize config, settings, templates, and handlers if serverapp has a web_app.
+        # Subcommands may not have a web_app attribute.
+        if hasattr(self.serverapp, 'web_app'):
+            self._prepare_config()
+            self._prepare_templates()
+            self._prepare_settings()
+            self._prepare_handlers()
 
     def start(self):
         """Start the underlying Jupyter server.
@@ -319,6 +321,8 @@ class ExtensionApp(JupyterApp):
         extension = cls()
         extension.initialize(serverapp, argv=argv)
         return extension
+    
+    subcommands = dict()
 
     @classmethod
     def launch_instance(cls, argv=None, **kwargs):
@@ -338,7 +342,8 @@ class ExtensionApp(JupyterApp):
         # Get a jupyter server instance.
         serverapp = cls.initialize_server(
             argv=args, 
-            load_other_extensions=cls.load_other_extensions
+            load_other_extensions=cls.load_other_extensions,
+            subcommands = cls.subcommands
         )
         # Log if extension is blocking other extensions from loading.
         if not cls.load_other_extensions:


### PR DESCRIPTION
This allows to define subcommands of a server extension (needed for e.g. `jupyter lab build` with `jupyter lab` being the `LabApp` server extension when this will be migrated).

Strangely, on subcommand completion, I receive following stacktrace.

```
[LabCleanApp] Cleaning /opt/datalayer/opt/miniconda3/envs/datalayer/share/jupyter/lab...
[LabCleanApp] Success!
Traceback (most recent call last):
  File "/opt/datalayer/opt/miniconda3/envs/datalayer/bin/jupyter-lab", line 11, in <module>
    load_entry_point('jupyterlab', 'console_scripts', 'jupyter-lab')()
  File "/Users/echar4/datalayer/repos/jupyter-server/jupyter_server/extension/application.py", line 357, in launch_instance
    extension.start()
  File "/Users/echar4/datalayer/repos/jupyter-server/jupyter_server/extension/application.py", line 307, in start
    self.serverapp.start() 
  File "/Users/echar4/datalayer/repos/jupyter-server/jupyter_server/serverapp.py", line 1727, in start
    super(ServerApp, self).start()
  File "/opt/datalayer/opt/miniconda3/envs/datalayer/lib/python3.7/site-packages/jupyter_core/application.py", line 258, in start
    raise NoStart()
jupyter_core.application.NoStart
```

This comes from the ExtensionApp section (see comment I have added)

```python
    def start(self):
        """Start the whole thing"""
        if self.subcommand:
            os.execv(self.subcommand, [self.subcommand] + self.argv[1:])
            raise NoStart()
        
        if self.subapp:
            self.subapp.start()
            raise NoStart() # <<<<<< Why do we need to raise a NoStart exception ????
        
        if self.generate_config:
            self.write_default_config()
            raise NoStart()
```

cc/ @Zsailer 