### PR TITLE
Separate eventloop init/start from webapp init/start

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -951,7 +951,9 @@ class ServerApp(JupyterApp):
         help=_("Extra keyword arguments to pass to `get_secure_cookie`."
              " See tornado's get_secure_cookie docs for details.")
     )
-    ssl_options = Dict(config=True,
+    ssl_options = Dict(
+            allow_none=True,
+            config=True,
             help=_("""Supply SSL options for the tornado HTTPServer.
             See the tornado docs for details."""))
 


### PR DESCRIPTION
This PR separates the logic for initializing+starting the eventloop from the initializing+starting the main application. This is particularly helpful for writing unit tests.

This enables us to replace the `HttpServer` in `ServerApp` with test server like pytest-tornado's `httpserver` fixture. For an example of such tests, see [Zsailer/jupyter_server_tests](https://github.com/Zsailer/jupyter_server_tests).