### PR TITLE
Fix packages of exceptions catched by gateway manager

### DIFF
--- a/jupyter_server/tests/test_gateway.py
+++ b/jupyter_server/tests/test_gateway.py
@@ -4,7 +4,8 @@ import json
 import uuid
 from datetime import datetime
 from tornado import gen
-from tornado.httpclient import HTTPRequest, HTTPResponse, HTTPError
+from tornado.web import HTTPError
+from tornado.httpclient import HTTPRequest, HTTPResponse
 from ipython_genutils.py3compat import str_to_unicode
 from .launchserver import ServerTestBase
 from jupyter_server.gateway.managers import GatewayClient


### PR DESCRIPTION
`gateway_request` in `gateway.manager` raises `tornado.web.HTTPError` exceptions, but the callers, such as `GatewayKernelManager.get_kernel`, catch `tornado.httpclient.HTTPError`, instead of `tornado.web.HTTPError`. Therefore, the callers can not handle exceptions during gateway interactions.

This causes that, for example, when Jupyter Enterprise Gateway culled a kernel by idle timeout, the gateway manager can not handle the kernel's absent appropriately. As a result, notebook users see ambiguous "Kernel Error" and can not restart the kernel or start a new kernel.

(This is the same as jupyter/notebook#5055.)