### PR TITLE
Enforce Python 3.6 in setup.py to support JKM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
       else
           true
       fi
-    - 'if [[ $GROUP == python ]]; then nosetests -v --with-coverage --cover-package=jupyter_server jupyter_server; fi'
+    - 'if [[ $GROUP == python ]]; then nosetests -v jupyter_server; fi'
     - |
       if [[ $GROUP == docs ]]; then
         EXIT_STATUS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
     - pip freeze
     - wget https://github.com/jgm/pandoc/releases/download/1.19.1/pandoc-1.19.1-1-amd64.deb && sudo dpkg -i pandoc-1.19.1-1-amd64.deb
 
-
 script:
     - jupyter kernelspec list
     - |
@@ -50,7 +49,6 @@ script:
 
         exit $EXIT_STATUS
       fi
-
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ cache:
     directories:
         - $HOME/.cache/bower
         - $HOME/.cache/pip
-python:
-    - 3.6
-
 env:
   global:
     - PATH=$TRAVIS_BUILD_DIR/pandoc:$PATH
@@ -57,13 +54,17 @@ script:
 
 matrix:
     include:
-        - python: 3.5
+        - python: 3.6
           env: GROUP=python
         - python: 3.7
           env: GROUP=python
         - python: 3.8
           env: GROUP=python
         - python: 3.6
+          env: GROUP=docs
+        - python: 3.7
+          env: GROUP=docs
+        - python: 3.8
           env: GROUP=docs
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,10 @@ environment:
   matrix:
     - CONDA_PY: 36
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 37
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+    - CONDA_PY: 38
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ install:
   - cmd: pip install .[test]
 
 test_script:
-  - nosetests  -v jupyter_server --exclude-dir notebook\tests\selenium
+  - nosetests  -v jupyter_server --exclude-dir jupyter_server\tests\selenium

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ import sys
 name = "jupyter_server"
 
 # Minimal Python version sanity check
-if sys.version_info < (3,5):
-    error = "ERROR: %s requires Python version 3.5 or above." % name
+if sys.version_info < (3,6):
+    error = "ERROR: %s requires Python version 3.6 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -67,7 +67,6 @@ for more information.
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
@@ -95,7 +94,7 @@ for more information.
                  'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
-    python_requires = '>=3.5',
+    python_requires = '>=3.6',
     entry_points = {
         'console_scripts': [
             'jupyter-server = jupyter_server.serverapp:main',


### PR DESCRIPTION
jupyter_kernel_mgmt 0.5.0 has [just been released](https://github.com/takluyver/jupyter_kernel_mgmt/issues/33). It does not run on python 3.5.

This PR enforce a minimum version of 3.6 for Python.

Regarding EOL of 3.5:

- Official [still alive until 2020-09-13](https://devguide.python.org/#status-of-python-branches)
- In practice it seems like all latest standard platforms [don't use 3.5 anymore](https://github.com/python-trio/trio/issues/75#issuecomment-559917654)
- Numpy also recommend [to not support 3.5](https://numpy.org/neps/nep-0029-deprecation_policy.html)
