### PR TITLE
Revert back to python 3.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.6', '3.7', '3.8' ]
+        python-version: [ '3.5', '3.6', '3.7', '3.8' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ matrix:
           env: GROUP=python
         - python: 3.8
           env: GROUP=python
+        - python: 3.5
+          env: GROUP=docs
         - python: 3.6
           env: GROUP=docs
         - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ script:
 
 matrix:
     include:
+        - python: 3.5
+          env: GROUP=python
         - python: 3.6
           env: GROUP=python
         - python: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ matrix:
 
 environment:
   matrix:
+    - CONDA_PY: 35
+      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 36
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
     - CONDA_PY: 37

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import sys
 name = "jupyter_server"
 
 # Minimal Python version sanity check
-if sys.version_info < (3,6):
+if sys.version_info < (3,5):
     error = "ERROR: %s requires Python version 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ name = "jupyter_server"
 
 # Minimal Python version sanity check
 if sys.version_info < (3,6):
-    error = "ERROR: %s requires Python version 3.6 or above." % name
+    error = "ERROR: %s requires Python version 3.5 or above." % name
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -67,6 +67,7 @@ for more information.
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
@@ -94,7 +95,7 @@ for more information.
                  'nbval', 'nose-exclude', 'selenium', 'pytest', 'pytest-cov'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
-    python_requires = '>=3.6',
+    python_requires = '>=3.5',
     entry_points = {
         'console_scripts': [
             'jupyter-server = jupyter_server.serverapp:main',


### PR DESCRIPTION
This is a follow up of https://github.com/jupyter/jupyter_server/pull/142 to renable python 3.5 support in preparation of the 0.2.0 release.

jupyter server 0.3.0 would only support python 3.6.