### PR TITLE
Include date in log statements

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -596,14 +596,9 @@ class ServerApp(JupyterApp):
     def _default_log_level(self):
         return logging.INFO
 
-    @default('log_datefmt')
-    def _default_log_datefmt(self):
-        """Exclude date from default date format"""
-        return "%H:%M:%S"
-
     @default('log_format')
     def _default_log_format(self):
-        """override default log format to include time"""
+        """override default log format to include date & time"""
         return u"%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s]%(end_color)s %(message)s"
 
     # file to be opened in the Jupyter server


### PR DESCRIPTION
Notebook overrides the logger date format to not include the date in
log entries and, as a result, Server followed suit.  Since we expect
Server to run multiple days on end, and the log will typically be
redirected, etc., we should use the default date format - which
includes the date.  As a result, entries will look like the following...

[D 2020-01-13 15:52:01.768 ServerApp] Looking for jupyter_config in /etc/jupyter