### PR TITLE
Minor enhancements to the fixtures

### DIFF
--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -163,6 +163,7 @@ def serverapp(configurable_serverapp, config, argv):
 
 @pytest.fixture
 def app(serverapp):
+    """app fixture is needed by pytest_tornasync plugin"""
     return serverapp.web_app
 
 
@@ -177,7 +178,7 @@ def http_port(http_server_port):
 
 
 @pytest.fixture
-def base_url(http_server_port):
+def base_url():
     return "/"
 
 

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -244,9 +244,6 @@ def kernelspecs(data_dir):
         sample_kernel_resources.write_text(some_resource)
 
 
-# contents_manager_atomic = pytest.fixture(lambda tmp_path: FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=True))
-# contents_manager_nonatomic = pytest.fixture(lambda tmp_path: FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=False))
-
 @pytest.fixture(params=[True, False])
 def contents_manager(request, tmp_path):
     return FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=request.param)

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -15,14 +15,6 @@ from ...utils import expected_http_error
 
 # -------------- Functions ----------------------------
 
-# contents_manager_atomic = pytest.fixture(lambda tmp_path: FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=True))
-# contents_manager_nonatomic = pytest.fixture(lambda tmp_path: FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=False))
-
-@pytest.fixture(params=[True, False])
-def contents_manager(request, tmp_path):
-    return FileContentsManager(root_dir=str(tmp_path), use_atomic_writing=request.param)
-
-
 def _make_dir(contents_manager, api_path):
     """
     Make a directory.

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -13,30 +13,6 @@ from jupyter_server.utils import url_path_join
 from ...utils import expected_http_error
 
 
-@pytest.fixture
-def ws_fetch(auth_header, http_port):
-    """fetch fixture that handles auth, base_url, and path"""
-    def client_fetch(*parts, headers={}, params={}, **kwargs):
-        # Handle URL strings
-        path = url_escape(url_path_join(*parts), plus=False)
-        urlparts = urllib.parse.urlparse('ws://localhost:{}'.format(http_port))
-        urlparts = urlparts._replace(
-            path=path,
-            query=urllib.parse.urlencode(params)
-        )
-        url = urlparts.geturl()
-        # Add auth keys to header
-        headers.update(auth_header)
-        # Make request.
-        req = tornado.httpclient.HTTPRequest(
-            url,
-            headers=auth_header,
-            connect_timeout=120
-        )
-        return tornado.websocket.websocket_connect(req)
-    return client_fetch
-
-
 async def test_no_kernels(fetch):
     r = await fetch(
         'api', 'kernels',

--- a/tests/services/kernelspecs/test_api.py
+++ b/tests/services/kernelspecs/test_api.py
@@ -3,30 +3,11 @@ import json
 
 import tornado
 
+from jupyter_server.pytest_plugin import some_resource
+
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
 
 from ...utils import expected_http_error
-
-
-sample_kernel_json = {
-    'argv':['cat', '{connection_file}'],
-    'display_name':'Test kernel',
-}
-some_resource = u"The very model of a modern major general"
-
-
-@pytest.fixture
-def kernelspecs(data_dir):
-    spec_names = ['sample', 'sample 2']
-    for name in spec_names:
-        sample_kernel_dir = data_dir.joinpath('kernels', name)
-        sample_kernel_dir.mkdir(parents=True)
-        # Create kernel json file
-        sample_kernel_file = sample_kernel_dir.joinpath('kernel.json')
-        sample_kernel_file.write_text(json.dumps(sample_kernel_json))
-        # Create resources text
-        sample_kernel_resources = sample_kernel_dir.joinpath('resource.txt')
-        sample_kernel_resources.write_text(some_resource)
 
 
 async def test_list_kernelspecs_bad(fetch, kernelspecs, data_dir):


### PR DESCRIPTION
While reading the tests, I found a few minor enhancements like removing the param from base_url fixture and adding doc to app fixture.\

I may push in the coming day more minore udpates.

My understanding is that only the fixtures defined in `pytest_plugin.py` are usable in other projects (like nbclassic). Then, how do we decide which fixture to expose? e.g. I can see a use of `ws_fetch` defined in `test_api.py` in kernel related projects but today this is not possible.