### PR TITLE
Ensure initialize_templates is called by _prepare_templates 

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -351,6 +351,7 @@ class ExtensionApp(JupyterApp):
             self.settings.update({
                 "{}_template_paths".format(self.extension_name): self.template_paths
             })
+        self.initialize_templates()
 
     @staticmethod
     def initialize_server(argv=[], load_other_extensions=True, **kwargs):

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -52,7 +52,7 @@ data_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "data"))
 config_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "config"))
 runtime_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "runtime"))
 root_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "root_dir"))
-template_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "template_dir"))
+template_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "templates"))
 system_jupyter_path = pytest.fixture(
     lambda tmp_path: mkdir(tmp_path, "share", "jupyter")
 )

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -52,6 +52,7 @@ data_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "data"))
 config_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "config"))
 runtime_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "runtime"))
 root_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "root_dir"))
+template_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "template_dir"))
 system_jupyter_path = pytest.fixture(
     lambda tmp_path: mkdir(tmp_path, "share", "jupyter")
 )

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -33,6 +33,14 @@ class MockExtensionApp(ExtensionApp):
             'module': '_mockdestination/index'
         }]
 
+@pytest.fixture
+def make_mock_extension_app(template_dir):
+    def _make_mock_extension_app(**kwargs):
+        kwargs.setdefault('template_paths', [str(template_dir)])
+        return MockExtensionApp(**kwargs)
+
+    return _make_mock_extension_app
+
 
 @pytest.fixture
 def config_file(config_dir):
@@ -43,21 +51,21 @@ def config_file(config_dir):
 
 
 @pytest.fixture
-def extended_serverapp(serverapp):
+def extended_serverapp(serverapp, make_mock_extension_app):
     """"""
-    m = MockExtensionApp()
+    m = make_mock_extension_app()
     m.initialize(serverapp)
     return m
 
 
 @pytest.fixture
-def inject_mock_extension(environ, extension_environ):
+def inject_mock_extension(environ, extension_environ, make_mock_extension_app):
     """Fixture that can be used to inject a mock Jupyter Server extension into the tests namespace.
 
         Usage: inject_mock_extension({'extension_name': ExtensionClass})
     """
     def ext(modulename="mockextension"):
-        sys.modules[modulename] = e = MockExtensionApp()
+        sys.modules[modulename] = e = make_mock_extension_app()
         return e
 
     return ext

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -3,19 +3,17 @@ import pytest
 from jupyter_server.serverapp import ServerApp
 from jupyter_server.extension.application import ExtensionApp
 
-from .conftest import MockExtensionApp
 
-
-def test_instance_creation():
-    mock_extension = MockExtensionApp()
+def test_instance_creation(make_mock_extension_app, template_dir):
+    mock_extension = make_mock_extension_app()
     assert mock_extension.static_paths == []
-    assert mock_extension.template_paths == []
+    assert mock_extension.template_paths == [str(template_dir)]
     assert mock_extension.settings == {}
-    assert mock_extension.handlers == [] 
+    assert mock_extension.handlers == []
 
 
-def test_initialize(serverapp):
-    mock_extension = MockExtensionApp()
+def test_initialize(serverapp, make_mock_extension_app):
+    mock_extension = make_mock_extension_app()
     mock_extension.initialize(serverapp)
     # Check that settings and handlers were added to the mock extension.
     assert isinstance(mock_extension.serverapp, ServerApp)
@@ -35,10 +33,10 @@ traits = [
     'trait_name,trait_value',
     traits
 )
-def test_instance_creation_with_instance_args(trait_name, trait_value):
+def test_instance_creation_with_instance_args(trait_name, trait_value, make_mock_extension_app):
     kwarg = {}
     kwarg.setdefault(trait_name, trait_value)
-    mock_extension = MockExtensionApp(**kwarg)
+    mock_extension = make_mock_extension_app(**kwarg)
     assert getattr(mock_extension, trait_name) == trait_value
 
 
@@ -46,13 +44,13 @@ def test_instance_creation_with_instance_args(trait_name, trait_value):
     'trait_name,trait_value',
     traits
 )
-def test_instance_creation_with_argv(serverapp, trait_name, trait_value):
+def test_instance_creation_with_argv(serverapp, trait_name, trait_value, make_mock_extension_app):
     kwarg = {}
     kwarg.setdefault(trait_name, trait_value)
     argv = [
         '--MockExtensionApp.{name}={value}'.format(name=trait_name, value=trait_value)
     ]
-    mock_extension = MockExtensionApp()
+    mock_extension = make_mock_extension_app()
     mock_extension.initialize(serverapp, argv=argv)
     assert getattr(mock_extension, trait_name) == trait_value
 

--- a/tests/extension/test_entrypoint.py
+++ b/tests/extension/test_entrypoint.py
@@ -3,8 +3,6 @@ import pytest
 from jupyter_core import paths
 from jupyter_server.extension import serverextension
 
-from .conftest import MockExtensionApp
-
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.script_launch_mode('subprocess')
 

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -13,6 +13,14 @@ async def test_handler(fetch, extended_serverapp):
     assert r.body.decode() == 'mock trait'
 
 
+async def test_handler_template(fetch, extended_serverapp):
+    r = await fetch(
+        'mock_template',
+        method='GET'
+    )
+    assert r.code == 200
+
+
 async def test_handler_setting(fetch, serverapp, make_mock_extension_app):
     # Configure trait in Mock Extension.
     m = make_mock_extension_app(mock_trait='test mock trait')

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -1,7 +1,6 @@
 import pytest
 
 from jupyter_server.serverapp import ServerApp
-from .conftest import MockExtensionApp
 
 # ------------------ Start tests -------------------
 
@@ -14,9 +13,9 @@ async def test_handler(fetch, extended_serverapp):
     assert r.body.decode() == 'mock trait'
 
 
-async def test_handler_setting(fetch, serverapp):
+async def test_handler_setting(fetch, serverapp, make_mock_extension_app):
     # Configure trait in Mock Extension.
-    m = MockExtensionApp(mock_trait='test mock trait')
+    m = make_mock_extension_app(mock_trait='test mock trait')
     m.initialize(serverapp)
 
     # Test that the extension trait was picked up by the webapp.
@@ -28,9 +27,9 @@ async def test_handler_setting(fetch, serverapp):
     assert r.body.decode() == 'test mock trait'
 
 
-async def test_handler_argv(fetch, serverapp):
+async def test_handler_argv(fetch, serverapp, make_mock_extension_app):
     # Configure trait in Mock Extension.
-    m = MockExtensionApp()
+    m = make_mock_extension_app()
     argv = ['--MockExtensionApp.mock_trait="test mock trait"']
     m.initialize(serverapp, argv=argv)
 


### PR DESCRIPTION
This PR ensures `initialize_templates` is called by `_prepare_templates`.

It also introduce `make_mock_extension_app` fixture to inject the `template_paths` and adds a test for template handler.
