### PR TITLE
Make ExtensionHandler a Mixin

### DIFF
--- a/docs/source/frontends.rst
+++ b/docs/source/frontends.rst
@@ -14,7 +14,7 @@ Writing a frontend application
 Jupyter Server provides two key classes for writing a server frontend: 
 
     - ``ExtensionApp``
-    - ``ExtensionHandler``
+    - ``ExtensionHandlerMixin``
 
 The ExtensionApp:
 
@@ -81,13 +81,13 @@ Properties
 Writing frontend handlers
 -------------------------
 
-To write handlers for an ``ExtensionApp``, use the ``ExtensionHandler`` class. This class routes Tornado's ``static_url`` attribute to the ``/static/<extension_name>/`` namespace where your frontend's static files will be served.
+To write handlers for an ``ExtensionApp``, use the ``ExtensionHandlerMixin`` class. This class routes Tornado's ``static_url`` attribute to the ``/static/<extension_name>/`` namespace where your frontend's static files will be served.
 
 .. code-block:: python
 
-    from jupyter_server.extension import ExtensionHandler
+    from jupyter_server.extension import ExtensionHandlerMixin
 
-    class MyFrontendHandler(ExtensionHandler):
+    class MyFrontendHandler(ExtensionHandlerMixin, JupyterHandler):
 
         urls = ['/myfrontend/hello']
 
@@ -97,7 +97,7 @@ To write handlers for an ``ExtensionApp``, use the ``ExtensionHandler`` class. T
         def post(self):
             ...
 
-ExtensionHandler comes with the following properties:
+ExtensionHandlerMixin comes with the following properties:
 
 * ``config``: the ExtensionApp's config object.
 * ``server_config``: the ServerApp's config object.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -18,7 +18,7 @@ from jupyter_core.application import JupyterApp
 from jupyter_server.serverapp import ServerApp, aliases, flags
 from jupyter_server.transutils import _
 from jupyter_server.utils import url_path_join
-from .handler import ExtensionHandler
+from .handler import ExtensionHandlerMixin
 
 # Remove alias for nested classes in ServerApp.
 # Nested classes are not allowed in ExtensionApp.
@@ -321,7 +321,7 @@ class ExtensionApp(JupyterApp):
             
             # Get handler kwargs, if given
             kwargs = {}
-            if issubclass(handler, ExtensionHandler):
+            if issubclass(handler, ExtensionHandlerMixin):
                 kwargs['extension_name'] = self.extension_name
             try: 
                 kwargs.update(handler_items[2])

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,4 +1,4 @@
-from jupyter_server.base.handlers import JupyterHandler, FileFindHandler
+from jupyter_server.base.handlers import FileFindHandler
 from traitlets import Unicode, default
 
 
@@ -12,7 +12,7 @@ class ExtensionHandlerJinjaMixin:
         return self.settings[env].get_template(name)
 
 
-class ExtensionHandler(JupyterHandler):
+class ExtensionHandlerMixin():
     """Base class for Jupyter server extension handlers. 
 
     Subclasses can serve static files behind a namespaced 

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -4,20 +4,21 @@ from traitlets import Unicode
 
 
 from jupyter_core import paths
+from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.extension import serverextension
 from jupyter_server.extension.serverextension import _get_config_dir
 from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
-from jupyter_server.extension.handler import ExtensionHandler, ExtensionHandlerJinjaMixin
+from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHandlerJinjaMixin
 
 # ----------------- Mock Extension App ----------------------
 
-class MockExtensionHandler(ExtensionHandler):
+class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
 
     def get(self):
         self.finish(self.config.mock_trait)
 
 
-class MockExtensionTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandler):
+class MockExtensionTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler):
 
     def get(self):
         self.write(self.render_template("index.html"))


### PR DESCRIPTION
This is a first dry attempt to support extension handlers needed by JupyterLab https://github.com/jupyterlab/jupyterlab_server/pull/79

The corresponding issue is https://github.com/jupyter/jupyter_server/issues/173

This current changes allow make the jlab extensions operational, but this implementation is suboptimal as it duplicates code (with minor changes) from the base package.