### PR TITLE
Fix default extension_name and validation

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -154,6 +154,7 @@ class ExtensionApp(JupyterApp):
         help="Name of extension."
     )
 
+    @default('extension_name')
     def _extension_name_default(self):
         try:
             return self.name
@@ -163,8 +164,8 @@ class ExtensionApp(JupyterApp):
     INVALID_EXTENSION_NAME_CHARS = [' ', '.', '+', '/']
 
     @validate('extension_name')
-    def _validate_extension_name(self, value):
-        #value = self.extension_name
+    def _validate_extension_name(self, proposal):
+        value = proposal['value']
         if isinstance(value, str):
             # Validate that extension_name doesn't contain any invalid characters.
             for c in ExtensionApp.INVALID_EXTENSION_NAME_CHARS:


### PR DESCRIPTION
Trying out the [`ExtensionApp` PR in voila](https://github.com/voila-dashboards/voila/pull/492), it looks like the default value for `extension_name` was not picking up `name`.

Also the validation should extract the value from the proposal.