### PR TITLE
Remove win-py38 ipykernel patch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,6 @@ jobs:
     - name: Install the Python dependencies
       run: |
         pip install -e .[test]
-    - name: ipykernel fix on windows 3.8
-      if: matrix.os == 'windows-latest' && matrix.python-version == '3.8'
-      run: |
-        pip install --upgrade git+https://github.com/ipython/ipykernel.git
     - name: Run the tests
       run: |
         pytest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,6 @@ install:
   - cmd: conda create -y -q -n test-env-%CONDA_PY% python=%CONDA_PY_SPEC% pip pyzmq tornado jupyter_client nbformat nbconvert nose
   - cmd: conda activate test-env-%CONDA_PY%
   - cmd: pip install -e .[test]
-# FIXME: Use patch for python 3.8, windows issues (https://github.com/ipython/ipykernel/pull/456) - remove once released
-  - IF %CONDA_PY% == 38 pip install --upgrade git+https://github.com/ipython/ipykernel.git
 
 test_script:
   - pytest -s -v

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ for more information.
     ],
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'pytest', 'pytest-cov', 'pytest-tornasync', 'pytest-console-scripts'],
+                 'pytest==5.3.2', 'pytest-cov', 'pytest-tornasync', 'pytest-console-scripts'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
     python_requires = '>=3.5',


### PR DESCRIPTION
Now that ipykernel 5.1.4 is available and includes the windows/python 3.8 event loop fix, we can drop our workarounds to pull from github.