### PR TITLE
Allow the path of a kernel to be set in POST

### DIFF
--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -453,7 +453,7 @@ paths:
                 description: Kernel spec name (defaults to default kernel spec for server)
               path:
                 type: string
-                description: path the cwd of the kernel
+                description: API path from root to the cwd of the kernel
       responses:
         201:
           description: Kernel started

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -441,14 +441,19 @@ paths:
       tags:
         - kernels
       parameters:
-        - name: name
+        - name: options
           in: body
-          description: Kernel spec name (defaults to default kernel spec for server)
           schema:
             type: object
+            required:
+              - name
             properties:
               name:
                 type: string
+                description: Kernel spec name (defaults to default kernel spec for server)
+              path:
+                type: string
+                description: path the cwd of the kernel
       responses:
         201:
           description: Kernel started

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -45,7 +45,8 @@ class MainKernelHandler(APIHandler):
         else:
             model.setdefault('name', km.default_kernel_name)
 
-        kernel_id = yield maybe_future(km.start_kernel(kernel_name=model['name']))
+        kernel_id = yield maybe_future(km.start_kernel(kernel_name=model['name'],
+                                                       path=model.get('path')))
         model = yield maybe_future(km.kernel_model(kernel_id))
         location = url_path_join(self.base_url, 'api', 'kernels', url_escape(kernel_id))
         self.set_header('Location', location)

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -138,6 +138,18 @@ async def test_main_kernel_handler(fetch):
     assert restarted_kernel['id'] == kernel2['id']
     assert restarted_kernel['name'] == kernel2['name']
 
+    # Start a kernel with a path
+    r = await fetch(
+        'api', 'kernels',
+        method='POST',
+                body=json.dumps({
+            'name': NATIVE_KERNEL_NAME,
+            'path': '/foo'
+        })
+    )
+    kernel3 = json.loads(r.body.decode())
+    assert isinstance(kernel3, dict)
+
 
 async def test_kernel_handler(fetch):
     # Create a kernel


### PR DESCRIPTION
Allow kernels to be started in a given API `path` even if they are not managed by a session.

This is useful if one is using `jupyter_server` as a limited `kernel` provider but still want to set the `cwd` of the started kernel.