### PR TITLE
Enable ServerApp to discover ExtensionApps (and their config).

### DIFF
--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -90,9 +90,12 @@ open http://localhost:8888/simple_ext2/params/test?var1=foo
 Optionally, you can copy `simple_ext1.json` and `simple_ext2.json` configuration to your env `etc` folder and start only Extension 1, which will also start Extension 2.
 
 ```bash
-pip uninstall -y jupyter_simple_ext && \
+pip uninstall -y jupyter_server_example && \
   python setup.py install && \
   cp -r ./etc $(dirname $(which jupyter))/..
+```
+
+```bash
 # Start the jupyter server extension simple_ext1, it will also load simple_ext2 because of load_other_extensions = True..
 # When you invoke with the entrypoint, the default url will be opened in your browser.
 jupyter simple-ext1
@@ -102,18 +105,20 @@ jupyter simple-ext1
 
 Stop any running server (with `CTRL+C`) and start with additional configuration on the command line.
 
-The provided settings via CLI will override the configuration that reside in the files (`jupyter_simple_ext1_config.py`...)
+The provided settings via CLI will override the configuration that reside in the files (`jupyter_server_example1_config.py`...)
 
 ```bash
 jupyter simple-ext1 --SimpleApp1.configA="ConfigA from command line"
 ```
 
-Check the log, it should return on startup something like the following base on the trait you have defined in the CLI and in the `jupyter_simple_ext1_config.py`.
+Check the log, it should return on startup print the Config object.
+
+The content of the Config is based on the trait you have defined via the `CLI` and in the `jupyter_server_example1_config.py`.
 
 ```
 [SimpleApp1] Config {'SimpleApp1': {'configA': 'ConfigA from file', 'configB': 'ConfigB from file', 'configC': 'ConfigC from file'}}
 [SimpleApp1] Config {'SimpleApp1': {'configA': 'ConfigA from file', 'configB': 'ConfigB from file', 'configC': 'ConfigC from file'}}
-[SimpleApp2] WARNING | Config option `configD` not recognized by `SimpleApp2`.  Did you mean `config_file`?
+[SimpleApp2] WARNING | Config option `configD` not recognized by `SimpleApp2`.  Did you mean one of: `configA, configB, configC`?
 [SimpleApp2] Config {'SimpleApp2': {'configD': 'ConfigD from file'}}
 [SimpleApp1] Config {'SimpleApp1': {'configA': 'ConfigA from command line', 'configB': 'ConfigB from file', 'configC': 'ConfigC from file'}}
 ```
@@ -133,9 +138,10 @@ Try with the above links to check that only Extension 2 is responding (Extension
 
 `Extension 11` extends `Extension 1` and brings a few more configs.
 
-Run `jupyter simple-ext11 --generate-config && vi ~/.jupyter/jupyter_config.py`.
-
-> TODO `--generate-config` returns an exception `"The ExtensionApp has not ServerApp "`
+```bash
+# TODO `--generate-config` returns an exception `"The ExtensionApp has not ServerApp "`
+jupyter simple-ext11 --generate-config && vi ~/.jupyter/jupyter_config.py`.
+```
 
 The generated configuration should contains the following.
 
@@ -147,8 +153,9 @@ The `hello`, `ignore_js` and `simple11_dir` are traits defined on the SimpleApp1
 
 It also implements additional flags and aliases for these traits.
 
-+ The `--hello` flag will log on startup `Hello Simple11 - You have provided the --hello flag or defined a c.SimpleApp1.hello == True`.
-+ The `--simple11-dir` alias will set `SimpleExt11.simple11_dir` settings.
+- The `--hello` flag will log on startup `Hello Simple11 - You have provided the --hello flag or defined a c.SimpleApp1.hello == True`
+- The `ignore_js` flag
+- The `--simple11-dir` alias will set `SimpleExt11.simple11_dir` settings
 
 Stop any running server and then start the simple-ext11.
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -67,6 +67,12 @@ open http://localhost:8888/simple_ext1/redirect
 open http://localhost:8888/static/simple_ext1/favicon.ico
 ```
 
+You can also start the server extension with python modules.
+
+```bash
+python -m simple_ext1
+```
+
 ## Extension 1 and Extension 2
 
 The following command starts both the `simple_ext1` and `simple_ext2` extensions.

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -152,7 +152,7 @@ jupyter simple-ext11 --generate-config && vi ~/.jupyter/jupyter_config.py`.
 The generated configuration should contains the following.
 
 ```bash
-TBD
+# TODO
 ```
 
 The `hello`, `ignore_js` and `simple11_dir` are traits defined on the SimpleApp11 class.
@@ -167,6 +167,8 @@ Stop any running server and then start the simple-ext11.
 
 ```bash
 jupyter simple-ext11 --hello --simple11-dir any_folder
+# You can also launch with a module
+python -m simple_ext11 --hello
 # TODO FIX the following command, simple11 does not work launching with jpserver_extensions parameter.
 jupyter server --ServerApp.jpserver_extensions="{'simple_ext11': True}" --hello --simple11-dir any_folder
 ```

--- a/examples/simple/jupyter_simple_ext1_config.py
+++ b/examples/simple/jupyter_simple_ext1_config.py
@@ -1,3 +1,4 @@
 c.SimpleApp1.configA = 'ConfigA from file'
 c.SimpleApp1.configB = 'ConfigB from file'
 c.SimpleApp1.configC = 'ConfigC from file'
+c.SimpleApp1.configD = 'ConfigD from file'

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyter-simple-ext",
+  "name": "jupyter-server-example",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/examples/simple/setup.py
+++ b/examples/simple/setup.py
@@ -23,9 +23,9 @@ def get_data_files():
     return data_files
 
 setuptools.setup(
-    name = 'jupyter_simple_ext',
+    name = 'jupyter_server_example',
     version = VERSION,
-    description = 'Jupyter Simple Extension',
+    description = 'Jupyter Server Example',
     long_description = open('README.md').read(),
     packages = find_packages(),
     python_requires = '>=3.5',

--- a/examples/simple/simple_ext1/__init__.py
+++ b/examples/simple/simple_ext1/__init__.py
@@ -1,8 +1,9 @@
 from .application import SimpleApp1
 
 def _jupyter_server_extension_paths():
-    return [
-        {'module': 'simple_ext1'}
-    ]
+    return [{
+        'module': 'simple_ext1',
+        'app': SimpleApp1
+    }]
 
 load_jupyter_server_extension = SimpleApp1.load_jupyter_server_extension

--- a/examples/simple/simple_ext1/__init__.py
+++ b/examples/simple/simple_ext1/__init__.py
@@ -1,9 +1,8 @@
 from .application import SimpleApp1
 
+
 def _jupyter_server_extension_paths():
     return [{
-        'module': 'simple_ext1',
+        'module': 'simple_ext1.application',
         'app': SimpleApp1
     }]
-
-load_jupyter_server_extension = SimpleApp1.load_jupyter_server_extension

--- a/examples/simple/simple_ext1/__main__.py
+++ b/examples/simple/simple_ext1/__main__.py
@@ -1,7 +1,4 @@
-from traitlets import Dict
+from .application import main
 
-from jupyter_server.serverapp import ServerApp
-
-if __name__ is '__main__':
-    ServerApp.jpserver_extensions = Dict({'simple_ext1': True})
-    ServerApp.launch_instance()
+if __name__ == "__main__":
+    main()

--- a/examples/simple/simple_ext1/__main__.py
+++ b/examples/simple/simple_ext1/__main__.py
@@ -1,4 +1,7 @@
-from .application import main
+from traitlets import Dict
+
+from jupyter_server.serverapp import launch_new_instance, ServerApp
 
 if __name__ is '__main__':
-    main()
+    ServerApp.jpserver_extensions = Dict({'simple_ext1': True})
+    launch_new_instance()

--- a/examples/simple/simple_ext1/__main__.py
+++ b/examples/simple/simple_ext1/__main__.py
@@ -1,0 +1,4 @@
+from .application import main
+
+if __name__ is '__main__':
+    main()

--- a/examples/simple/simple_ext1/application.py
+++ b/examples/simple/simple_ext1/application.py
@@ -1,7 +1,7 @@
 import os, jinja2
 from traitlets import Unicode
 from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
-from .handlers import (DefaultHandler, RedirectHandler, 
+from .handlers import (DefaultHandler, RedirectHandler,
   ParameterHandler, TemplateHandler, TypescriptHandler, ErrorHandler)
 
 DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
@@ -13,7 +13,7 @@ class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
     extension_name = "simple_ext1"
 
     # Te url that your extension will serve its homepage.
-    default_url = '/simple_ext1/default'
+    extension_url = '/simple_ext1/default'
 
     # Should your extension expose other server extensions when launched directly?
     load_other_extensions = True

--- a/examples/simple/simple_ext1/application.py
+++ b/examples/simple/simple_ext1/application.py
@@ -8,7 +8,7 @@ DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 DEFAULT_TEMPLATE_FILES_PATH = os.path.join(os.path.dirname(__file__), "templates")
 
 class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
-    
+
     # The name of the extension.
     extension_name = "simple_ext1"
 

--- a/examples/simple/simple_ext1/application.py
+++ b/examples/simple/simple_ext1/application.py
@@ -12,7 +12,7 @@ class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
     # The name of the extension.
     extension_name = "simple_ext1"
 
-    # Te url that your extension will serve its homepage.
+    # The url that your extension will serve its homepage.
     extension_url = '/simple_ext1/default'
 
     # Should your extension expose other server extensions when launched directly?

--- a/examples/simple/simple_ext11/__init__.py
+++ b/examples/simple/simple_ext11/__init__.py
@@ -1,8 +1,11 @@
-from .application import SimpleApp1
+from .application import SimpleApp11
 
 def _jupyter_server_extension_paths():
     return [
-        {'module': 'simple_ext1'}
+        {
+            'module': 'simple_ext11',
+            'app': SimpleApp11
+        }
     ]
 
-load_jupyter_server_extension = SimpleApp1.load_jupyter_server_extension
+load_jupyter_server_extension = SimpleApp11.load_jupyter_server_extension

--- a/examples/simple/simple_ext11/__init__.py
+++ b/examples/simple/simple_ext11/__init__.py
@@ -1,11 +1,10 @@
 from .application import SimpleApp11
 
+
 def _jupyter_server_extension_paths():
     return [
         {
-            'module': 'simple_ext11',
+            'module': 'simple_ext11.application',
             'app': SimpleApp11
         }
     ]
-
-load_jupyter_server_extension = SimpleApp11.load_jupyter_server_extension

--- a/examples/simple/simple_ext11/__main__.py
+++ b/examples/simple/simple_ext11/__main__.py
@@ -1,11 +1,4 @@
-from traitlets import Dict
+from .application import main
 
-from jupyter_server.serverapp import ServerApp
-
-if __name__ is '__main__':
-    ServerApp.jpserver_extensions = Dict({
-        'simple_ext1': False,
-        'simple_ext2': False,
-        'simple_ext11': True,
-        })
-    ServerApp.launch_instance()
+if __name__ == "__main__":
+    main()

--- a/examples/simple/simple_ext11/__main__.py
+++ b/examples/simple/simple_ext11/__main__.py
@@ -1,0 +1,11 @@
+from traitlets import Dict
+
+from jupyter_server.serverapp import ServerApp
+
+if __name__ is '__main__':
+    ServerApp.jpserver_extensions = Dict({
+        'simple_ext1': False,
+        'simple_ext2': False,
+        'simple_ext11': True,
+        })
+    ServerApp.launch_instance()

--- a/examples/simple/simple_ext11/application.py
+++ b/examples/simple/simple_ext11/application.py
@@ -56,8 +56,8 @@ class SimpleApp11(SimpleApp1):
 
     def initialize_settings(self):
         self.log.info('hello: {}'.format(self.hello))
-        if self.config['hello'] == True:
-            self.log.info("Hello Simple11 - You have provided the --hello flag or defined 'c.SimpleApp1.hello == True' in jupyter_server_config.py")
+        if self.hello == True:
+            self.log.info("Hello Simple11: You have launched with --hello flag or defined 'c.SimpleApp1.hello == True' in your config file")
         self.log.info('ignore_js: {}'.format(self.ignore_js))
         super().initialize_settings()
 

--- a/examples/simple/simple_ext11/application.py
+++ b/examples/simple/simple_ext11/application.py
@@ -13,12 +13,12 @@ class SimpleApp11(SimpleApp1):
     aliases.update({
         'simple11-dir': 'SimpleApp11.simple11_dir',
     })
-    
+
     # The name of the extension.
     extension_name = "simple_ext11"
 
     # Te url that your extension will serve its homepage.
-    default_url = '/simple_ext11/default'
+    extension_url = '/simple_ext11/default'
 
     # Local path to static files directory.
     static_paths = [
@@ -37,12 +37,12 @@ class SimpleApp11(SimpleApp1):
 
     hello = Bool(False,
         config=True,
-        help='Say hello', 
+        help='Say hello',
     )
 
     ignore_js = Bool(False,
         config=True,
-        help='Ignore Javascript', 
+        help='Ignore Javascript',
     )
 
     @observe('ignore_js')

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -4,7 +4,7 @@ def _jupyter_server_extension_paths():
     return [
         {
             'module': 'simple_ext2',
-            'app': SimpleApp2,
+            'app': SimpleApp2
         },
     ]
 

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -2,7 +2,10 @@ from .application import SimpleApp2
 
 def _jupyter_server_extension_paths():
     return [
-        {'module': 'simple_ext2'},
+        {
+            'module': 'simple_ext2',
+            'app': SimpleApp2,
+        },
     ]
 
 load_jupyter_server_extension = SimpleApp2.load_jupyter_server_extension

--- a/examples/simple/simple_ext2/__init__.py
+++ b/examples/simple/simple_ext2/__init__.py
@@ -1,11 +1,10 @@
 from .application import SimpleApp2
 
+
 def _jupyter_server_extension_paths():
     return [
         {
-            'module': 'simple_ext2',
+            'module': 'simple_ext2.application',
             'app': SimpleApp2
         },
     ]
-
-load_jupyter_server_extension = SimpleApp2.load_jupyter_server_extension

--- a/examples/simple/simple_ext2/__main__.py
+++ b/examples/simple/simple_ext2/__main__.py
@@ -3,5 +3,8 @@ from traitlets import Dict
 from jupyter_server.serverapp import ServerApp
 
 if __name__ is '__main__':
-    ServerApp.jpserver_extensions = Dict({'simple_ext1': True})
+    ServerApp.jpserver_extensions = Dict({
+        'simple_ext1': True,
+        'simple_ext2': True
+        })
     ServerApp.launch_instance()

--- a/examples/simple/simple_ext2/__main__.py
+++ b/examples/simple/simple_ext2/__main__.py
@@ -1,10 +1,4 @@
-from traitlets import Dict
+from .application import main
 
-from jupyter_server.serverapp import ServerApp
-
-if __name__ is '__main__':
-    ServerApp.jpserver_extensions = Dict({
-        'simple_ext1': True,
-        'simple_ext2': True
-        })
-    ServerApp.launch_instance()
+if __name__ == "__main__":
+    main()

--- a/examples/simple/simple_ext2/application.py
+++ b/examples/simple/simple_ext2/application.py
@@ -7,12 +7,12 @@ DEFAULT_STATIC_FILES_PATH = os.path.join(os.path.dirname(__file__), "static")
 DEFAULT_TEMPLATE_FILES_PATH = os.path.join(os.path.dirname(__file__), "templates")
 
 class SimpleApp2(ExtensionAppJinjaMixin, ExtensionApp):
-    
+
     # The name of the extension.
     extension_name = "simple_ext2"
 
     # Te url that your extension will serve its homepage.
-    default_url = '/simple_ext2'
+    extension_name = '/simple_ext2'
 
     # Should your extension expose other server extensions when launched directly?
     load_other_extensions = True

--- a/examples/simple/simple_ext2/application.py
+++ b/examples/simple/simple_ext2/application.py
@@ -15,7 +15,7 @@ class SimpleApp2(ExtensionAppJinjaMixin, ExtensionApp):
     default_url = '/simple_ext2'
 
     # Should your extension expose other server extensions when launched directly?
-    load_other_extensions = False
+    load_other_extensions = True
 
     # Local path to static files directory.
     static_paths = [

--- a/examples/simple/simple_ext2/application.py
+++ b/examples/simple/simple_ext2/application.py
@@ -12,7 +12,7 @@ class SimpleApp2(ExtensionAppJinjaMixin, ExtensionApp):
     extension_name = "simple_ext2"
 
     # Te url that your extension will serve its homepage.
-    extension_name = '/simple_ext2'
+    extension_url = '/simple_ext2'
 
     # Should your extension expose other server extensions when launched directly?
     load_other_extensions = True

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -154,7 +154,7 @@ class AuthenticatedHandler(web.RequestHandler):
             self.request.host
         ))
         return self.settings.get('cookie_name', default_cookie_name)
-    
+
     @property
     def logged_in(self):
         """Is a user currently logged in?"""
@@ -203,23 +203,23 @@ class JupyterHandler(AuthenticatedHandler):
     def jinja_template_vars(self):
         """User-supplied values to supply to jinja templates."""
         return self.settings.get('jinja_template_vars', {})
-    
+
     #---------------------------------------------------------------
     # URLs
     #---------------------------------------------------------------
-    
+
     @property
     def version_hash(self):
         """The version hash to use for cache hints for static files"""
         return self.settings.get('version_hash', '')
-    
+
     @property
     def mathjax_url(self):
         url = self.settings.get('mathjax_url', '')
         if not url or url_is_absolute(url):
             return url
         return url_path_join(self.base_url, url)
-    
+
     @property
     def mathjax_config(self):
         return self.settings.get('mathjax_config', 'TeX-AMS-MML_HTMLorMML-full,Safe')
@@ -241,11 +241,11 @@ class JupyterHandler(AuthenticatedHandler):
         self.log.debug("Using contents: %s", self.settings.get('contents_js_source',
             'services/contents'))
         return self.settings.get('contents_js_source', 'services/contents')
-    
+
     #---------------------------------------------------------------
     # Manager objects
     #---------------------------------------------------------------
-    
+
     @property
     def kernel_manager(self):
         return self.settings['kernel_manager']
@@ -253,15 +253,15 @@ class JupyterHandler(AuthenticatedHandler):
     @property
     def contents_manager(self):
         return self.settings['contents_manager']
-    
+
     @property
     def session_manager(self):
         return self.settings['session_manager']
-    
+
     @property
     def terminal_manager(self):
         return self.settings['terminal_manager']
-    
+
     @property
     def kernel_spec_manager(self):
         return self.settings['kernel_spec_manager']
@@ -273,7 +273,7 @@ class JupyterHandler(AuthenticatedHandler):
     #---------------------------------------------------------------
     # CORS
     #---------------------------------------------------------------
-    
+
     @property
     def allow_origin(self):
         """Normal Access-Control-Allow-Origin"""
@@ -310,7 +310,7 @@ class JupyterHandler(AuthenticatedHandler):
 
         if self.allow_credentials:
             self.set_header("Access-Control-Allow-Credentials", 'true')
-    
+
     def set_attachment_header(self, filename):
         """Set Content-Disposition: attachment header
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -387,7 +387,7 @@ class ExtensionApp(JupyterApp):
         self.serverapp.clear_instance()
 
     @classmethod
-    def load_jupyter_server_extension(cls, serverapp):
+    def _load_jupyter_server_extension(cls, serverapp):
         """Initialize and configure this extension, then add the extension's
         settings and handlers to the server's web application.
         """

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -91,7 +91,6 @@ class ExtensionAppJinjaMixin:
 
     jinja2_options = Dict(
         help=_("""Options to pass to the jinja2 environment for this
-        extension.
         """)
     ).tag(config=True)
 
@@ -283,6 +282,7 @@ class ExtensionApp(JupyterApp):
         """Builds a Config object from the extension's traits and passes
         the object to the webapp's settings as `<extension_name>_config`.
         """
+        # Verify all traits are up-to-date with config
         self.update_config(self.config)
         traits = self.class_own_traits().keys()
         self.extension_config = Config({t: getattr(self, t) for t in traits})
@@ -382,6 +382,7 @@ class ExtensionApp(JupyterApp):
         # If argv is given, parse and update config.
         if argv:
             self.parse_command_line(argv)
+
         # Load config from file.
         self.load_config_file()
 
@@ -421,7 +422,7 @@ class ExtensionApp(JupyterApp):
         """
         # Configure and initialize extension.
         extension = cls(parent=serverapp)
-        extension.initialize(serverapp)
+        extension.initialize(serverapp=serverapp)
         return extension
 
     @classmethod

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -7,7 +7,6 @@ from traitlets import (
     Unicode,
     List,
     Dict,
-    Bool,
     default,
     validate
 )
@@ -15,21 +14,16 @@ from traitlets.config import Config
 
 from jupyter_core.application import JupyterApp
 
-from jupyter_server.serverapp import ServerApp, aliases, flags
+from jupyter_server.serverapp import ServerApp
 from jupyter_server.transutils import _
 from jupyter_server.utils import url_path_join
 from .handler import ExtensionHandlerMixin
 
-# Remove alias for nested classes in ServerApp.
-# Nested classes are not allowed in ExtensionApp.
-try:
-    aliases.pop('transport')
-except KeyError:
-    pass
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Util functions and classes.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
 
 def _preparse_for_subcommand(Application, argv):
     """Preparse command line to look for subcommands.
@@ -120,16 +114,18 @@ class ExtensionAppJinjaMixin:
             }
         )
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # ExtensionApp
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
 
 class JupyterServerExtensionException(Exception):
     """Exception class for raising for Server extensions errors."""
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # ExtensionApp
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+
 
 class ExtensionApp(JupyterApp):
     """Base class for configurable Jupyter Server Extension Applications.
@@ -344,14 +340,14 @@ class ExtensionApp(JupyterApp):
         # config.
         # ServerApp config ---> ExtensionApp traits
         self.update_config(self.serverapp.config)
-        # Use ExtensionApp's CLI parser to find any extra
-        # args that passed through ServerApp and
-        # now belong to ExtensionApp.
-        self.parse_command_line(self.serverapp.extra_args)
         # Load config from an ExtensionApp's config files.
         # If any config should be passed upstream to the
         # ServerApp, do it here.
         self.load_config_file()
+        # Use ExtensionApp's CLI parser to find any extra
+        # args that passed through ServerApp and
+        # now belong to ExtensionApp.
+        self.parse_command_line(self.serverapp.extra_args)
         # i.e. ServerApp traits <--- ExtensionApp config
         self.serverapp.update_config(self.config)
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -327,7 +327,7 @@ class ExtensionApp(JupyterApp):
         # Add static endpoint for this extension, if static paths are given.
         if len(self.static_paths) > 0:
             # Append the extension's static directory to server handlers.
-            static_url = url_path_join("/static", self.extension_name, "(.*)")
+            static_url = url_path_join(self.static_url_prefix, "(.*)")
 
             # Construct handler.
             handler = (

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -414,8 +414,8 @@ class ExtensionApp(JupyterApp):
         """Initialize and configure this extension, then add the extension's
         settings and handlers to the server's web application.
         """
-        # Configure and initialize extension.
-        extension = cls(parent=serverapp)
+        # Get loaded extension from serverapp.
+        extension = serverapp.enabled_extensions[cls.extension_name]
         extension.initialize(serverapp=serverapp)
         return extension
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -174,6 +174,9 @@ class ExtensionApp(JupyterApp):
             return value
         raise ValueError("Extension name must be a string, found {type}.".format(type=type(value)))
 
+    # Extension URL sets the default landing page for this extension.
+    extension_url = "/"
+
     # Extension can configure the ServerApp from the command-line
     classes = [
         ServerApp,
@@ -212,43 +215,6 @@ class ExtensionApp(JupyterApp):
             return ''
         return 'jupyter_{}_config'.format(self.extension_name.replace('-','_'))
 
-    extension_url = "/"
-
-    # default_url = Unicode('/', config=True,
-    #     help=_("The default URL to redirect to from `/`")
-    # )
-
-    # custom_display_url = Unicode(u'', config=True,
-    #     help=_("""Override URL shown to users.
-
-    #     Replace actual URL, including protocol, address, port and base URL,
-    #     with the given value when displaying URL to the users. Do not change
-    #     the actual connection URL. If authentication token is enabled, the
-    #     token is added to the custom URL automatically.
-
-    #     This option is intended to be used when the URL to display to the user
-    #     cannot be determined reliably by the Jupyter server (proxified
-    #     or containerized setups for example).""")
-    # )
-
-    # @default('custom_display_url')
-    # def _default_custom_display_url(self):
-    #     """URL to display to the user."""
-    #     # Get url from server.
-    #     url = url_path_join(self.serverapp.base_url, self.default_url)
-    #     return self.serverapp.get_url(self.serverapp.ip, url)
-
-    # def _write_browser_open_file(self, url, fh):
-    #     """Use to hijacks the server's browser-open file and open at
-    #     the extension's homepage.
-    #     """
-    #     # Ignore server's url
-    #     del url
-    #     path = url_path_join(self.serverapp.base_url, self.default_url)
-    #     url = self.serverapp.get_url(path=path, token=self.serverapp.token)
-    #     jinja2_env = self.serverapp.web_app.settings['jinja2_env']
-    #     template = jinja2_env.get_template('browser-open.html')
-    #     fh.write(template.render(open_url=url))
 
     def initialize_settings(self):
         """Override this method to add handling of settings."""
@@ -364,7 +330,11 @@ class ExtensionApp(JupyterApp):
     def link_to_serverapp(self, serverapp):
         """Link the ExtensionApp to an initialized ServerApp.
 
-        This adds a serverapp.
+        The ServerApp is stored as an attribute and config
+        is exchanged between ServerApp and `self` in case
+        the command line contains traits for the ExtensionApp
+        or the ExtensionApp's config files have server
+        settings.
         """
         self.serverapp = serverapp
         # ServerApp's config might have picked up

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -178,7 +178,7 @@ class ExtensionApp(JupyterApp):
     @classmethod
     def _jupyter_server_extension_paths(cls):
         return [{
-            "module": cls.__module__.split('.')[0],
+            "module": cls.extension_name,
             "app": cls
         }]
 
@@ -358,8 +358,7 @@ class ExtensionApp(JupyterApp):
         # Get a jupyter server instance
         serverapp = ServerApp.instance(**kwargs)
         # Add extension to jpserver_extensions trait in server.
-        mod = cls._jupyter_server_extension_paths()[0]['module']
-        serverapp.jpserver_extensions.update({mod: True})
+        serverapp.jpserver_extensions.update({cls.extension_name: True})
         # Initialize ServerApp config.
         # Parses the command line looking for
         # ServerApp configuration.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -283,6 +283,7 @@ class ExtensionApp(JupyterApp):
         """Builds a Config object from the extension's traits and passes
         the object to the webapp's settings as `<extension_name>_config`.
         """
+        self.update_config(self.config)
         traits = self.class_own_traits().keys()
         self.extension_config = Config({t: getattr(self, t) for t in traits})
         self.settings['{}_config'.format(self.extension_name)] = self.extension_config
@@ -365,7 +366,7 @@ class ExtensionApp(JupyterApp):
         serverapp.initialize(argv=argv, load_extensions=load_other_extensions)
         return serverapp
 
-    def initialize(self, serverapp, argv=[]):
+    def initialize(self, serverapp, argv=None):
         """Initialize the extension app.
 
         This method:
@@ -377,6 +378,12 @@ class ExtensionApp(JupyterApp):
         """
         # Initialize ServerApp.
         self.serverapp = serverapp
+
+        # If argv is given, parse and update config.
+        if argv:
+            self.parse_command_line(argv)
+        # Load config from file.
+        self.load_config_file()
 
         # Initialize config, settings, templates, and handlers.
         self._prepare_config()

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -329,6 +329,8 @@ class ExtensionApp(JupyterApp):
         settings.
         """
         self.serverapp = serverapp
+        # Load config from an ExtensionApp's config files.
+        self.load_config_file()
         # ServerApp's config might have picked up
         # CLI config for the ExtensionApp. We call
         # update_config to update ExtensionApp's
@@ -336,14 +338,12 @@ class ExtensionApp(JupyterApp):
         # config.
         # ServerApp config ---> ExtensionApp traits
         self.update_config(self.serverapp.config)
-        # Load config from an ExtensionApp's config files.
-        # If any config should be passed upstream to the
-        # ServerApp, do it here.
-        self.load_config_file()
         # Use ExtensionApp's CLI parser to find any extra
         # args that passed through ServerApp and
         # now belong to ExtensionApp.
         self.parse_command_line(self.serverapp.extra_args)
+        # If any config should be passed upstream to the
+        # ServerApp, do it here.
         # i.e. ServerApp traits <--- ExtensionApp config
         self.serverapp.update_config(self.config)
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -228,10 +228,6 @@ class ExtensionApp(JupyterApp):
         """Builds a Config object from the extension's traits and passes
         the object to the webapp's settings as `<extension_name>_config`.
         """
-        # Make sure the ServerApp receives any config.
-        self.serverapp.update_config(self.config)
-        # Verify all traits are up-to-date with config
-        self.update_config(self.config)
         traits = self.class_own_traits().keys()
         self.extension_config = Config({t: getattr(self, t) for t in traits})
         self.settings['{}_config'.format(self.extension_name)] = self.extension_config

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -95,6 +95,9 @@ class ExtensionAppJinjaMixin:
     ).tag(config=True)
 
     def _prepare_templates(self):
+        # Get templates defined in a subclass.
+        self.initialize_templates()
+
         # Add templates to web app settings if extension has templates.
         if len(self.template_paths) > 0:
             self.settings.update({
@@ -109,8 +112,6 @@ class ExtensionAppJinjaMixin:
             **self.jinja2_options
         )
 
-        # Get templates defined in a subclass.
-        self.initialize_templates()
 
         # Add the jinja2 environment for this extension to the tornado settings.
         self.settings.update(
@@ -174,13 +175,6 @@ class ExtensionApp(JupyterApp):
                                      format(name=value, invalid_chars=ExtensionApp.INVALID_EXTENSION_NAME_CHARS))
             return value
         raise ValueError("Extension name must be a string, found {type}.".format(type=type(value)))
-
-    @classmethod
-    def _jupyter_server_extension_paths(cls):
-        return [{
-            "module": cls.extension_name,
-            "app": cls
-        }]
 
     # Extension can configure the ServerApp from the command-line
     classes = [
@@ -296,6 +290,7 @@ class ExtensionApp(JupyterApp):
         # Add static and template paths to settings.
         self.settings.update({
             "{}_static_paths".format(self.extension_name): self.static_paths,
+            "{}".format(self.extension_name): self
         })
 
         # Get setting defined by subclass using initialize_settings method.

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -27,8 +27,7 @@ class ExtensionHandlerMixin:
 
     @property
     def extensionapp(self):
-        key = "{extension_name}".format(extension_name=self.extension_name)
-        return self.settings[key]
+        return self.settings[self.extension_name]
 
     @property
     def serverapp(self):

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -3,27 +3,37 @@ from traitlets import Unicode, default
 
 
 class ExtensionHandlerJinjaMixin:
-    """Mixin class for ExtensionApp handlers that use jinja templating for 
+    """Mixin class for ExtensionApp handlers that use jinja templating for
     template rendering.
     """
-    def get_template(self, name):
+    def get_template(self, name, *ns):
         """Return the jinja template object for a given name"""
         env = '{}_jinja2_env'.format(self.extension_name)
-        return self.settings[env].get_template(name)
+        return self.settings[env].get_template(name, *ns)
 
 
-class ExtensionHandlerMixin():
-    """Base class for Jupyter server extension handlers. 
+class ExtensionHandlerMixin:
+    """Base class for Jupyter server extension handlers.
 
-    Subclasses can serve static files behind a namespaced 
-    endpoint: "/static/<extension_name>/" 
+    Subclasses can serve static files behind a namespaced
+    endpoint: "/static/<extension_name>/"
 
     This allows multiple extensions to serve static files under
-    their own namespace and avoid intercepting requests for 
-    other extensions. 
+    their own namespace and avoid intercepting requests for
+    other extensions.
     """
     def initialize(self, extension_name):
         self.extension_name = extension_name
+
+    @property
+    def extensionapp(self):
+        key = "{extension_name}".format(extension_name=self.extension_name)
+        return self.settings[key]
+
+    @property
+    def serverapp(self):
+        key = "serverapp"
+        return self.settings[key]
 
     @property
     def config(self):
@@ -44,8 +54,8 @@ class ExtensionHandlerMixin():
 
     def static_url(self, path, include_host=None, **kwargs):
         """Returns a static URL for the given relative static file path.
-        This method requires you set the ``{extension_name}_static_path`` 
-        setting in your extension (which specifies the root directory 
+        This method requires you set the ``{extension_name}_static_path``
+        setting in your extension (which specifies the root directory
         of your static files).
         This method returns a versioned url (by default appending
         ``?v=<signature>``), which allows the static files to be

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -6,10 +6,10 @@ class ExtensionHandlerJinjaMixin:
     """Mixin class for ExtensionApp handlers that use jinja templating for
     template rendering.
     """
-    def get_template(self, name, *ns):
+    def get_template(self, name):
         """Return the jinja template object for a given name"""
         env = '{}_jinja2_env'.format(self.extension_name)
-        return self.settings[env].get_template(name, *ns)
+        return self.settings[env].get_template(name)
 
 
 class ExtensionHandlerMixin:

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -13,13 +13,42 @@ from traitlets.utils.importstring import import_item
 
 from jupyter_core.application import JupyterApp
 from jupyter_core.paths import (
-    jupyter_config_dir, 
-    jupyter_config_path, 
-    ENV_CONFIG_PATH, 
+    jupyter_config_dir,
+    jupyter_config_path,
+    ENV_CONFIG_PATH,
     SYSTEM_CONFIG_PATH
 )
 from jupyter_server._version import __version__
 from jupyter_server.config_manager import BaseJSONConfigManager
+
+
+def _get_server_extension_metadata(module):
+    """Load server extension metadata from a module.
+
+    Returns a tuple of (
+        the package as loaded
+        a list of server extension specs: [
+            {
+                "module": "mockextension"
+            }
+        ]
+    )
+
+    Parameters
+    ----------
+
+    module : str
+        Importable Python module exposing the
+        magic-named `_jupyter_server_extension_paths` function
+    """
+
+
+
+
+    m = import_item(module)
+    if not hasattr(m, '_jupyter_server_extension_paths'):
+        raise KeyError(u'The Python module {} does not include any valid server extensions'.format(module))
+    return m, m._jupyter_server_extension_paths()
 
 
 class ArgumentConflict(ValueError):
@@ -113,7 +142,7 @@ class ExtensionValidationError(Exception): pass
 
 
 def validate_server_extension(import_name):
-    """Tries to import the extension module. 
+    """Tries to import the extension module.
     Raises a validation error if module is not found.
     """
     try:
@@ -184,7 +213,7 @@ class ToggleServerExtensionApp(BaseExtensionApp):
     """A base class for enabling/disabling extensions"""
     name = "jupyter server extension enable/disable"
     description = "Enable/disable a server extension using frontend configuration files."
-    
+
     flags = flags
 
     user = Bool(False, config=True, help="Whether to do a user install")
@@ -193,7 +222,7 @@ class ToggleServerExtensionApp(BaseExtensionApp):
     _toggle_value = Bool()
     _toggle_pre_message = ''
     _toggle_post_message = ''
-    
+
     def toggle_server_extension(self, import_name):
         """Change the status of a named server extension.
 
@@ -214,9 +243,9 @@ class ToggleServerExtensionApp(BaseExtensionApp):
 
             # Toggle the server extension to active.
             toggle_server_extension_python(
-                import_name, 
-                self._toggle_value, 
-                parent=self, 
+                import_name,
+                self._toggle_value,
+                parent=self,
                 user=self.user,
                 sys_prefix=self.sys_prefix
             )
@@ -260,7 +289,7 @@ class EnableServerExtensionApp(ToggleServerExtensionApp):
     name = "jupyter server extension enable"
     description = """
     Enable a server extension in configuration.
-    
+
     Usage
         jupyter server extension enable [--system|--sys-prefix]
     """
@@ -274,7 +303,7 @@ class DisableServerExtensionApp(ToggleServerExtensionApp):
     name = "jupyter server extension disable"
     description = """
     Disable a server extension in configuration.
-    
+
     Usage
         jupyter server extension disable [--system|--sys-prefix]
     """
@@ -353,33 +382,6 @@ class ServerExtensionApp(BaseExtensionApp):
 
 main = ServerExtensionApp.launch_instance
 
-# ------------------------------------------------------------------------------
-# Private API
-# ------------------------------------------------------------------------------
-
-def _get_server_extension_metadata(module):
-    """Load server extension metadata from a module.
-
-    Returns a tuple of (
-        the package as loaded
-        a list of server extension specs: [
-            {
-                "module": "mockextension"
-            }
-        ]
-    )
-
-    Parameters
-    ----------
-
-    module : str
-        Importable Python module exposing the
-        magic-named `_jupyter_server_extension_paths` function
-    """
-    m = import_item(module)
-    if not hasattr(m, '_jupyter_server_extension_paths'):
-        raise KeyError(u'The Python module {} does not include any valid server extensions'.format(module))
-    return m, m._jupyter_server_extension_paths()
 
 if __name__ == '__main__':
     main()

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -101,7 +101,7 @@ class BaseExtensionApp(JupyterApp):
 def _get_config_dir(user=False, sys_prefix=False):
     """Get the location of config files for the current context
 
-    Returns the string to the enviornment
+    Returns the string to the environment
 
     Parameters
     ----------

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -111,7 +111,7 @@ def extension_environ(env_config_path, monkeypatch):
 
 @pytest.fixture
 def configurable_serverapp(
-    environ, http_port, tmp_path, home_dir, data_dir, config_dir, runtime_dir, root_dir, io_loop, server_config, **kwargs
+    environ, extension_environ, http_port, tmp_path, home_dir, data_dir, config_dir, runtime_dir, root_dir, io_loop, server_config, **kwargs
 ):
     def serverapp(
         config=server_config,

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -67,7 +67,7 @@ env_config_path = pytest.fixture(
 some_resource = u"The very model of a modern major general"
 sample_kernel_json = {
     'argv':['cat', '{connection_file}'],
-    'display_name':'Test kernel',
+    'display_name': 'Test kernel',
 }
 argv = pytest.fixture(lambda: [])
 
@@ -88,7 +88,7 @@ def environ(
 ):
     monkeypatch.setenv("HOME", str(home_dir))
     monkeypatch.setenv("PYTHONPATH", os.pathsep.join(sys.path))
-    monkeypatch.setenv("JUPYTER_NO_CONFIG", "1")
+    # monkeypatch.setenv("JUPYTER_NO_CONFIG", "1")
     monkeypatch.setenv("JUPYTER_CONFIG_DIR", str(config_dir))
     monkeypatch.setenv("JUPYTER_DATA_DIR", str(data_dir))
     monkeypatch.setenv("JUPYTER_RUNTIME_DIR", str(runtime_dir))
@@ -106,12 +106,17 @@ def environ(
 def extension_environ(env_config_path, monkeypatch):
     """Monkeypatch a Jupyter Extension's config path into each test's environment variable"""
     monkeypatch.setattr(serverextension, "ENV_CONFIG_PATH", [str(env_config_path)])
-    monkeypatch.setattr(serverextension, "ENV_CONFIG_PATH", [str(env_config_path)])
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 def configurable_serverapp(
-    environ, extension_environ, http_port, tmp_path, home_dir, data_dir, config_dir, runtime_dir, root_dir, io_loop, server_config, **kwargs
+    environ,
+    http_port,
+    tmp_path,
+    root_dir,
+    io_loop,
+    server_config,
+    **kwargs
 ):
     def serverapp(
         config=server_config,
@@ -119,10 +124,6 @@ def configurable_serverapp(
         environ=environ,
         http_port=http_port,
         tmp_path=tmp_path,
-        home_dir=home_dir,
-        data_dir=data_dir,
-        config_dir=config_dir,
-        runtime_dir=runtime_dir,
         root_dir=root_dir,
         **kwargs
     ):
@@ -131,12 +132,11 @@ def configurable_serverapp(
         token = hexlify(os.urandom(4)).decode("ascii")
         url_prefix = "/"
         app = ServerApp.instance(
+            # Set the log level to debug for testing purposes
+            log_level='DEBUG',
             port=http_port,
             port_retries=0,
             open_browser=False,
-            config_dir=str(config_dir),
-            data_dir=str(data_dir),
-            runtime_dir=str(runtime_dir),
             root_dir=str(root_dir),
             base_url=url_prefix,
             config=c,

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -47,7 +47,7 @@ def mkdir(tmp_path, *parts):
     return path
 
 
-config = pytest.fixture(lambda: {})
+server_config = pytest.fixture(lambda: {})
 home_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "home"))
 data_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "data"))
 config_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "config"))
@@ -111,10 +111,10 @@ def extension_environ(env_config_path, monkeypatch):
 
 @pytest.fixture
 def configurable_serverapp(
-    environ, http_port, tmp_path, home_dir, data_dir, config_dir, runtime_dir, root_dir, io_loop
+    environ, http_port, tmp_path, home_dir, data_dir, config_dir, runtime_dir, root_dir, io_loop, server_config, **kwargs
 ):
     def serverapp(
-        config={},
+        config=server_config,
         argv=[],
         environ=environ,
         http_port=http_port,
@@ -160,8 +160,8 @@ def configurable_serverapp(
 
 
 @pytest.fixture
-def serverapp(configurable_serverapp, config, argv):
-    app = configurable_serverapp(config=config, argv=argv)
+def serverapp(configurable_serverapp, server_config, argv):
+    app = configurable_serverapp(config=server_config, argv=argv)
     yield app
     app.remove_server_info_file()
     app.remove_browser_open_file()

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -564,8 +564,10 @@ class ServerApp(JupyterApp):
     # This trait is used to track _enabled_extensions. It should remain hidden
     # and not configurable.
     _enabled_extensions = {}
+
     flags = Dict(flags)
     aliases = Dict(aliases)
+
     classes = [
             KernelManager, Session, MappingKernelManager, KernelSpecManager,
             ContentsManager, FileContentsManager, NotebookNotary,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -103,7 +103,7 @@ from jupyter_server._sysinfo import get_sys_info
 from ._tz import utcnow, utcfromtimestamp
 from .utils import url_path_join, check_pid, url_escape, urljoin, pathname2url
 
-from jupyter_server.extension.serverextension import ServerExtensionApp
+from jupyter_server.extension.serverextension import ServerExtensionApp, _get_server_extension_metadata
 
 #-----------------------------------------------------------------------------
 # Module globals
@@ -1494,6 +1494,17 @@ class ServerApp(JupyterApp):
                 self.config.ServerApp.jpserver_extensions.update({modulename: enabled})
                 self.jpserver_extensions.update({modulename: enabled})
 
+        # Load configuration from ExtensionApp's they affect
+        # the ServerApp class.
+        for modulename in sorted(self.jpserver_extensions):
+            _, metadata = _get_server_extension_metadata(modulename)
+            app_obj = metadata[0].get('app', None)
+            if issubclass(app_obj, JupyterApp):
+                app = app_obj(parent=self)
+                app.update_config(app.config)
+                app.load_config_file()
+                self.update_config(app.config)
+
     def init_server_extensions(self):
         """Load any extensions specified by config.
 
@@ -1661,13 +1672,18 @@ class ServerApp(JupyterApp):
             Application. This will set the http_server attribute of this class.
         """
         self._init_asyncio_patch()
+        # Parse command line, load ServerApp config files,
+        # and update ServerApp config.
         super(ServerApp, self).initialize(argv)
+        # Then, use extensions' config loading mechanism to
+        # update config. ServerApp config takes precedence.
+        if load_extensions:
+            self.init_server_extension_config()
+        # Initialize all components of the ServerApp.
         self.init_logging()
         if self._dispatching:
             return
         self.init_configurables()
-        if load_extensions:
-            self.init_server_extension_config()
         self.init_components()
         self.init_webapp()
         if new_httpserver:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1530,13 +1530,14 @@ class ServerApp(JupyterApp):
         # after the ServerApp's Web application object is created.
         for module_name, enabled in sorted(self.jpserver_extensions.items()):
             if enabled:
+                metadata_list = []
                 try:
                     # Load the metadata for this enabled extension. This will
                     # be a list of extension points, each having their own
                     # path to a `_load_jupyter_server_extensions()`function.
                     # Important note: a single extension can have *multiple*
                     # `_load_jupyter_server_extension` functions defined, hence
-                    # _get_server_extension_metadata returns a list.
+                    # _get_server_extension_metadata returns a list of metadata.
                     mod, metadata_list = _get_server_extension_metadata(module_name)
                 except KeyError:
                     # A KeyError suggests that the module does not have a

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -274,6 +274,7 @@ class ServerWebApplication(web.Application):
             server_root_dir=root_dir,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
+            serverapp=self
         )
 
         # allow custom overrides for the tornado web app.
@@ -1531,10 +1532,13 @@ class ServerApp(JupyterApp):
         # Initialize extensions
         for module_name, enabled in sorted(self.jpserver_extensions.items()):
             if enabled:
-                # Look for extensions on jupyter_server_extension_paths
+                # Search for server extensions by loading each extension module
+                # and looking for the `_jupyter_server_extension_paths` function.
                 try:
                     mod, metadata_list = _get_server_extension_metadata(module_name)
                 except KeyError:
+                    # A KeyError suggests that the module does not have a
+                    # _jupyter_server_extension-path.
                     log_msg = _(
                         "Error loading server extension "
                         "{module_name}. There is no `_jupyter_server_extension_path` "
@@ -1548,6 +1552,7 @@ class ServerApp(JupyterApp):
                         raise
                     self.log.warning(_("Error loading server extension %s"), module_name,
                                   exc_info=True)
+
 
                 for metadata in metadata_list:
                     # Check if this server extension is a ExtensionApp object.

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1499,7 +1499,9 @@ class ServerApp(JupyterApp):
         for modulename in sorted(self.jpserver_extensions):
             _, metadata = _get_server_extension_metadata(modulename)
             app_obj = metadata[0].get('app', None)
-            if issubclass(app_obj, JupyterApp):
+            if app_obj:
+                if not issubclass(app_obj, JupyterApp):
+                    raise TypeError(abb_obj.__name__ + "must be a subclass of JupyterApp")
                 # Initialize extension app
                 app = app_obj(parent=self)
                 # Update the app's config, setting

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1500,9 +1500,18 @@ class ServerApp(JupyterApp):
             _, metadata = _get_server_extension_metadata(modulename)
             app_obj = metadata[0].get('app', None)
             if issubclass(app_obj, JupyterApp):
+                # Initialize extension app
                 app = app_obj(parent=self)
+                # Update the app's config, setting
+                # any traits given by the serverapp's
+                # parsed command line args.
                 app.update_config(app.config)
+                # Load any config from an extension's
+                # config file and make update the
+                # app's config again.
                 app.load_config_file()
+                # Pass any relevant config to the
+                # serverapp's (parent) config.
                 self.update_config(app.config)
 
     def init_server_extensions(self):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1544,7 +1544,7 @@ class ServerApp(JupyterApp):
                     # _jupyter_server_extension-path.
                     log_msg = _(
                         "Error loading server extensions in "
-                        "{module_name} module. There is no `_jupyter_server_extension_path` "
+                        "{module_name} module. There is no `_jupyter_server_extension_paths` "
                         "defined at the root of the extension module. Check "
                         "with the author of the extension to ensure this function "
                         "is added.".format(module_name=module_name)

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1322,7 +1322,6 @@ class ServerApp(JupyterApp):
             self.ssl_options['ca_certs'] = self.client_ca
         if not self.ssl_options:
             # could be an empty dict or None
-            # None indicates no SSL config
             self.ssl_options = None
         else:
             # SSL may be missing, so only import it if it's to be used
@@ -1336,6 +1335,7 @@ class ServerApp(JupyterApp):
             )
             if self.ssl_options.get('ca_certs', False):
                 self.ssl_options.setdefault('cert_reqs', ssl.CERT_REQUIRED)
+            ssl_options = self.ssl_options
 
         self.login_handler_class.validate_security(self, ssl_options=self.ssl_options)
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1501,7 +1501,7 @@ class ServerApp(JupyterApp):
             app_obj = metadata[0].get('app', None)
             if app_obj:
                 if not issubclass(app_obj, JupyterApp):
-                    raise TypeError(abb_obj.__name__ + "must be a subclass of JupyterApp")
+                    raise TypeError(abb_obj.__name__ + " must be a subclass of JupyterApp.")
                 # Initialize extension app
                 app = app_obj(parent=self)
                 # Update the app's config, setting

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,8 @@ for more information.
     ],
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'pytest==5.3.2', 'pytest-cov', 'pytest-tornasync', 'pytest-console-scripts'],
+                 'pytest==5.3.2', 'pytest-cov', 'pytest-tornasync',
+                 'pytest-console-scripts', 'pytest-lazy-fixture'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
     python_requires = '>=3.5',

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ for more information.
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
                  'pytest', 'pytest-cov', 'pytest-tornasync',
-                 'pytest-console-scripts', 'pytest-lazy-fixture'],
+                 'pytest-console-scripts'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
     python_requires = '>=3.5',

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ for more information.
     ],
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'pytest==5.3.2', 'pytest-cov', 'pytest-tornasync',
+                 'pytest', 'pytest-cov', 'pytest-tornasync',
                  'pytest-console-scripts', 'pytest-lazy-fixture'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -1,56 +1,6 @@
-import sys
 import pytest
-from traitlets import Unicode
 
-
-from jupyter_core import paths
-from jupyter_server.base.handlers import JupyterHandler
-from jupyter_server.extension import serverextension
-from jupyter_server.extension.serverextension import _get_config_dir
-from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
-from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHandlerJinjaMixin
-
-# ----------------- Mock Extension App ----------------------
-
-class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
-
-    def get(self):
-        self.finish(self.config.mock_trait)
-
-
-class MockExtensionTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler):
-
-    def get(self):
-        self.write(self.render_template("index.html"))
-
-
-class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
-    extension_name = 'mockextension'
-    mock_trait = Unicode('mock trait', config=True)
-
-    loaded = False
-
-    def initialize_handlers(self):
-        self.handlers.append(('/mock', MockExtensionHandler))
-        self.handlers.append(('/mock_template', MockExtensionTemplateHandler))
-        self.loaded = True
-
-    @classmethod
-    def _jupyter_server_extension_paths(cls):
-        return [{
-            'module': '_mockdestination/index',
-            'app': cls
-        }]
-
-@pytest.fixture
-def make_mock_extension_app(template_dir, config_dir):
-    def _make_mock_extension_app(**kwargs):
-        kwargs.setdefault('template_paths', [str(template_dir)])
-        return MockExtensionApp(config_dir=str(config_dir), **kwargs)
-
-    # TODO Should the index template creation be only be done only once?
-    index = template_dir.joinpath("index.html")
-    index.write_text("""
+mock_html = """
 <!DOCTYPE HTML>
 <html>
 <head>
@@ -69,34 +19,16 @@ def make_mock_extension_app(template_dir, config_dir):
   {% block after_site %}
   {% endblock after_site %}
 </body>
-</html>""")
-    return _make_mock_extension_app
+</html>
+"""
 
 
 @pytest.fixture
-def config_file(config_dir):
-    """"""
-    f = config_dir.joinpath("jupyter_mockextension_config.py")
-    f.write_text("c.MockExtensionApp.mock_trait ='config from file'")
-    return f
+def mock_template(template_dir):
+    index = template_dir.joinpath('index.html')
+    index.write_text(mock_html)
 
 
 @pytest.fixture
-def extended_serverapp(serverapp, make_mock_extension_app):
-    """"""
-    m = make_mock_extension_app()
-    m.initialize(serverapp)
-    return m
-
-
-@pytest.fixture
-def inject_mock_extension(environ, extension_environ, make_mock_extension_app):
-    """Fixture that can be used to inject a mock Jupyter Server extension into the tests namespace.
-
-        Usage: inject_mock_extension({'extension_name': ExtensionClass})
-    """
-    def ext(modulename="mockextension"):
-        sys.modules[modulename] = e = make_mock_extension_app()
-        return e
-
-    return ext
+def enabled_extensions(serverapp):
+    return serverapp._enabled_extensions

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -35,10 +35,11 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         self.handlers.append(('/mock_template', MockExtensionTemplateHandler))
         self.loaded = True
 
-    @staticmethod
-    def _jupyter_server_extension_paths():
+    @classmethod
+    def _jupyter_server_extension_paths(cls):
         return [{
-            'module': '_mockdestination/index'
+            'module': '_mockdestination/index',
+            'app': cls
         }]
 
 @pytest.fixture

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -42,13 +42,13 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
         }]
 
 @pytest.fixture
-def make_mock_extension_app(template_dir):
+def make_mock_extension_app(template_dir, config_dir):
     def _make_mock_extension_app(**kwargs):
         kwargs.setdefault('template_paths', [str(template_dir)])
-        return MockExtensionApp(**kwargs)
+        return MockExtensionApp(config_dir=str(config_dir), **kwargs)
 
     # TODO Should the index template creation be only be done only once?
-    index = template_dir.joinpath("index.html")    
+    index = template_dir.joinpath("index.html")
     index.write_text("""
 <!DOCTYPE HTML>
 <html>

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -32,3 +32,11 @@ def mock_template(template_dir):
 @pytest.fixture
 def enabled_extensions(serverapp):
     return serverapp._enabled_extensions
+
+
+@pytest.fixture
+def config_file(config_dir):
+    """"""
+    f = config_dir.joinpath("jupyter_mockextension_config.py")
+    f.write_text("c.MockExtensionApp.mock_trait ='config from file'")
+    return f

--- a/tests/extension/mockextensions/__init__.py
+++ b/tests/extension/mockextensions/__init__.py
@@ -1,0 +1,24 @@
+"""A mock extension module with a list of extensions
+to load in various tests.
+"""
+from .app import MockExtensionApp
+
+
+# Function that makes these extensions discoverable
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'mockextension',
+            'app': MockExtensionApp
+        },
+        {
+            'module': 'mock1'
+        },
+        {
+            'module': 'mock2'
+        },
+        {
+            'module': 'mock3'
+        }
+    ]

--- a/tests/extension/mockextensions/__init__.py
+++ b/tests/extension/mockextensions/__init__.py
@@ -9,16 +9,16 @@ from .app import MockExtensionApp
 def _jupyter_server_extension_paths():
     return [
         {
-            'module': 'mockextension',
+            'module': 'tests.extension.mockextensions.app',
             'app': MockExtensionApp
         },
         {
-            'module': 'mock1'
+            'module': 'tests.extension.mockextensions.mock1'
         },
         {
-            'module': 'mock2'
+            'module': 'tests.extension.mockextensions.mock2'
         },
         {
-            'module': 'mock3'
+            'module': 'tests.extension.mockextensions.mock3'
         }
     ]

--- a/tests/extension/mockextensions/app.py
+++ b/tests/extension/mockextensions/app.py
@@ -1,8 +1,14 @@
 from traitlets import Unicode, List
 
 from jupyter_server.base.handlers import JupyterHandler
-from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
-from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHandlerJinjaMixin
+from jupyter_server.extension.application import (
+    ExtensionApp,
+    ExtensionAppJinjaMixin
+)
+from jupyter_server.extension.handler import (
+    ExtensionHandlerMixin,
+    ExtensionHandlerJinjaMixin
+)
 
 
 class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
@@ -11,7 +17,11 @@ class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
         self.finish(self.config.mock_trait)
 
 
-class MockExtensionTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler):
+class MockExtensionTemplateHandler(
+        ExtensionHandlerJinjaMixin,
+        ExtensionHandlerMixin,
+        JupyterHandler
+    ):
 
     def get(self):
         self.write(self.render_template("index.html"))

--- a/tests/extension/mockextensions/app.py
+++ b/tests/extension/mockextensions/app.py
@@ -1,0 +1,31 @@
+from traitlets import Unicode, List
+
+from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
+from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHandlerJinjaMixin
+
+
+class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
+
+    def get(self):
+        self.finish(self.config.mock_trait)
+
+
+class MockExtensionTemplateHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandler):
+
+    def get(self):
+        self.write(self.render_template("index.html"))
+
+
+class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
+
+    extension_name = 'mockextension'
+    template_paths = List().tag(config=True)
+    mock_trait = Unicode('mock trait', config=True)
+    loaded = False
+
+    def initialize_handlers(self):
+        self.handlers.append(('/mock', MockExtensionHandler))
+        self.handlers.append(('/mock_template', MockExtensionTemplateHandler))
+        self.loaded = True
+

--- a/tests/extension/mockextensions/mock1.py
+++ b/tests/extension/mockextensions/mock1.py
@@ -1,0 +1,16 @@
+"""A mock extension named `mock1` for testing purposes.
+"""
+
+
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'tests.extension.mockextensions.mock1'
+        }
+    ]
+
+
+def _load_jupyter_server_extension(serverapp):
+    serverapp.mockI = True
+    serverapp.mock_shared = 'I'

--- a/tests/extension/mockextensions/mock2.py
+++ b/tests/extension/mockextensions/mock2.py
@@ -1,0 +1,16 @@
+"""A mock extension named `mock2` for testing purposes.
+"""
+
+
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'tests.extension.mockextensions.mock2'
+        }
+    ]
+
+
+def _load_jupyter_server_extension(serverapp):
+    serverapp.mockII = True
+    serverapp.mock_shared = 'II'

--- a/tests/extension/mockextensions/mock3.py
+++ b/tests/extension/mockextensions/mock3.py
@@ -1,5 +1,6 @@
 """A mock extension named `mock3` for testing purposes.
 """
 
-def _load_jupyter_server_extension():
+
+def _load_jupyter_server_extension(serverapp):
     pass

--- a/tests/extension/mockextensions/mock3.py
+++ b/tests/extension/mockextensions/mock3.py
@@ -1,0 +1,5 @@
+"""A mock extension named `mock3` for testing purposes.
+"""
+
+def _load_jupyter_server_extension():
+    pass

--- a/tests/extension/mockextensions/mockext_both.py
+++ b/tests/extension/mockextensions/mockext_both.py
@@ -1,0 +1,17 @@
+"""A mock extension named `mockext_both` for testing purposes.
+"""
+
+# Function that makes these extensions discoverable
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'tests.extension.mockextensions.mockext_both'
+        }
+    ]
+
+
+
+
+def _load_jupyter_server_extension():
+    pass

--- a/tests/extension/mockextensions/mockext_both.py
+++ b/tests/extension/mockextensions/mockext_both.py
@@ -1,6 +1,7 @@
 """A mock extension named `mockext_both` for testing purposes.
 """
 
+
 # Function that makes these extensions discoverable
 # by the test functions.
 def _jupyter_server_extension_paths():
@@ -11,7 +12,5 @@ def _jupyter_server_extension_paths():
     ]
 
 
-
-
-def _load_jupyter_server_extension():
+def _load_jupyter_server_extension(serverapp):
     pass

--- a/tests/extension/mockextensions/mockext_py.py
+++ b/tests/extension/mockextensions/mockext_py.py
@@ -1,6 +1,7 @@
 """A mock extension named `mockext_py` for testing purposes.
 """
 
+
 # Function that makes these extensions discoverable
 # by the test functions.
 def _jupyter_server_extension_paths():
@@ -11,5 +12,5 @@ def _jupyter_server_extension_paths():
     ]
 
 
-def _load_jupyter_server_extension():
+def _load_jupyter_server_extension(serverapp):
     pass

--- a/tests/extension/mockextensions/mockext_py.py
+++ b/tests/extension/mockextensions/mockext_py.py
@@ -1,0 +1,15 @@
+"""A mock extension named `mockext_py` for testing purposes.
+"""
+
+# Function that makes these extensions discoverable
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'tests.extension.mockextensions.mockext_py'
+        }
+    ]
+
+
+def _load_jupyter_server_extension():
+    pass

--- a/tests/extension/mockextensions/mockext_sys.py
+++ b/tests/extension/mockextensions/mockext_sys.py
@@ -1,5 +1,7 @@
 """A mock extension named `mockext_py` for testing purposes.
 """
+
+
 # Function that makes these extensions discoverable
 # by the test functions.
 def _jupyter_server_extension_paths():
@@ -10,5 +12,5 @@ def _jupyter_server_extension_paths():
     ]
 
 
-def _load_jupyter_server_extension():
+def _load_jupyter_server_extension(serverapp):
     pass

--- a/tests/extension/mockextensions/mockext_sys.py
+++ b/tests/extension/mockextensions/mockext_sys.py
@@ -1,0 +1,14 @@
+"""A mock extension named `mockext_py` for testing purposes.
+"""
+# Function that makes these extensions discoverable
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'tests.extension.mockextensions.mockext_sys'
+        }
+    ]
+
+
+def _load_jupyter_server_extension():
+    pass

--- a/tests/extension/mockextensions/mockext_user.py
+++ b/tests/extension/mockextensions/mockext_user.py
@@ -1,0 +1,14 @@
+"""A mock extension named `mockext_user` for testing purposes.
+"""
+# Function that makes these extensions discoverable
+# by the test functions.
+def _jupyter_server_extension_paths():
+    return [
+        {
+            'module': 'tests.extension.mockextensions.mockext_user'
+        }
+    ]
+
+
+def _load_jupyter_server_extension():
+    pass

--- a/tests/extension/mockextensions/mockext_user.py
+++ b/tests/extension/mockextensions/mockext_user.py
@@ -1,5 +1,7 @@
 """A mock extension named `mockext_user` for testing purposes.
 """
+
+
 # Function that makes these extensions discoverable
 # by the test functions.
 def _jupyter_server_extension_paths():
@@ -10,5 +12,5 @@ def _jupyter_server_extension_paths():
     ]
 
 
-def _load_jupyter_server_extension():
+def _load_jupyter_server_extension(serverapp):
     pass

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -4,61 +4,74 @@ from jupyter_server.serverapp import ServerApp
 from jupyter_server.extension.application import ExtensionApp
 
 
-def test_instance_creation(make_mock_extension_app, template_dir):
-    mock_extension = make_mock_extension_app()
-    assert mock_extension.static_paths == []
-    assert mock_extension.template_paths == [str(template_dir)]
-    assert mock_extension.settings == {}
-    assert mock_extension.handlers == []
+@pytest.fixture
+def server_config(template_dir):
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "tests.extension.mockextensions": True
+            }
+        },
+        "MockExtensionApp": {
+            "template_paths": [
+                str(template_dir)
+            ]
+        }
+    }
+
+@pytest.fixture
+def mock_extension(enabled_extensions):
+    return enabled_extensions["mockextension"]
 
 
-def test_initialize(serverapp, make_mock_extension_app):
-    mock_extension = make_mock_extension_app()
-    mock_extension.initialize(serverapp)
+def test_initialize(mock_extension, template_dir):
     # Check that settings and handlers were added to the mock extension.
     assert isinstance(mock_extension.serverapp, ServerApp)
-    assert len(mock_extension.settings) > 0
     assert len(mock_extension.handlers) > 0
+    assert mock_extension.template_paths == [str(template_dir)]
 
 
-traits = [
-    ('static_paths', ['test']),
-    ('template_paths', ['test']),
-    ('custom_display_url', '/test_custom_url'),
-    ('default_url', '/test_url')
-]
 
 
-@pytest.mark.parametrize(
-    'trait_name,trait_value',
-    traits
-)
-def test_instance_creation_with_instance_args(trait_name, trait_value, make_mock_extension_app):
-    kwarg = {}
-    kwarg.setdefault(trait_name, trait_value)
-    mock_extension = make_mock_extension_app(**kwarg)
-    assert getattr(mock_extension, trait_name) == trait_value
+
+# traits = [
+#     ('static_paths', ['test']),
+#     ('template_paths', ['test']),
+#     ('custom_display_url', '/test_custom_url'),
+#     ('default_url', '/test_url')
+# ]
 
 
-@pytest.mark.parametrize(
-    'trait_name,trait_value',
-    traits
-)
-def test_instance_creation_with_argv(serverapp, trait_name, trait_value, make_mock_extension_app):
-    kwarg = {}
-    kwarg.setdefault(trait_name, trait_value)
-    argv = [
-        '--MockExtensionApp.{name}={value}'.format(name=trait_name, value=trait_value)
-    ]
-    mock_extension = make_mock_extension_app()
-    mock_extension.initialize(serverapp, argv=argv)
-    assert getattr(mock_extension, trait_name) == trait_value
+# @pytest.mark.parametrize(
+#     'trait_name,trait_value',
+#     traits
+# )
+# def test_instance_creation_with_instance_args(trait_name, trait_value, mock_extension):
+#     kwarg = {}
+#     kwarg.setdefault(trait_name, trait_value)
+#     mock_extension = make_mock_extension_app(**kwarg)
+#     assert getattr(mock_extension, trait_name) == trait_value
 
 
-def test_extensionapp_load_config_file(config_file, serverapp, extended_serverapp):
-    # Assert default config_file_paths is the same in the app and extension.
-    assert extended_serverapp.config_file_paths == serverapp.config_file_paths
-    assert extended_serverapp.config_file_name == 'jupyter_mockextension_config'
-    assert extended_serverapp.config_dir == serverapp.config_dir
-    # Assert that the trait is updated by config file
-    assert extended_serverapp.mock_trait == 'config from file'
+# @pytest.mark.parametrize(
+#     'trait_name,trait_value',
+#     traits
+# )
+# def test_instance_creation_with_argv(serverapp, trait_name, trait_value, make_mock_extension_app):
+#     kwarg = {}
+#     kwarg.setdefault(trait_name, trait_value)
+#     argv = [
+#         '--MockExtensionApp.{name}={value}'.format(name=trait_name, value=trait_value)
+#     ]
+#     mock_extension = make_mock_extension_app()
+#     mock_extension.initialize(serverapp, argv=argv)
+#     assert getattr(mock_extension, trait_name) == trait_value
+
+
+# def test_extensionapp_load_config_file(config_file, serverapp, extended_serverapp):
+#     # Assert default config_file_paths is the same in the app and extension.
+#     assert extended_serverapp.config_file_paths == serverapp.config_file_paths
+#     assert extended_serverapp.config_file_name == 'jupyter_mockextension_config'
+#     assert extended_serverapp.config_dir == serverapp.config_dir
+#     # Assert that the trait is updated by config file
+#     assert extended_serverapp.mock_trait == 'config from file'

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -1,23 +1,24 @@
 import pytest
-
 from jupyter_server.serverapp import ServerApp
-from jupyter_server.extension.application import ExtensionApp
 
 
 @pytest.fixture
-def server_config(template_dir):
-    return {
+def server_config(request, template_dir):
+    config = {
         "ServerApp": {
             "jpserver_extensions": {
                 "tests.extension.mockextensions": True
-            }
+            },
         },
         "MockExtensionApp": {
             "template_paths": [
                 str(template_dir)
-            ]
+            ],
+            "log_level": 'DEBUG'
         }
     }
+    return config
+
 
 @pytest.fixture
 def mock_extension(enabled_extensions):
@@ -31,47 +32,36 @@ def test_initialize(mock_extension, template_dir):
     assert mock_extension.template_paths == [str(template_dir)]
 
 
+@pytest.mark.parametrize(
+    'trait_name, trait_value, argv',
+    (
+        [
+            'mock_trait',
+            'test mock trait',
+            ['--MockExtensionApp.mock_trait="test mock trait"']
+        ],
+    )
+)
+def test_instance_creation_with_argv(
+    serverapp,
+    trait_name,
+    trait_value,
+    enabled_extensions
+):
+    extension = enabled_extensions['mockextension']
+    assert getattr(extension, trait_name) == trait_value
 
 
-
-# traits = [
-#     ('static_paths', ['test']),
-#     ('template_paths', ['test']),
-#     ('custom_display_url', '/test_custom_url'),
-#     ('default_url', '/test_url')
-# ]
-
-
-# @pytest.mark.parametrize(
-#     'trait_name,trait_value',
-#     traits
-# )
-# def test_instance_creation_with_instance_args(trait_name, trait_value, mock_extension):
-#     kwarg = {}
-#     kwarg.setdefault(trait_name, trait_value)
-#     mock_extension = make_mock_extension_app(**kwarg)
-#     assert getattr(mock_extension, trait_name) == trait_value
-
-
-# @pytest.mark.parametrize(
-#     'trait_name,trait_value',
-#     traits
-# )
-# def test_instance_creation_with_argv(serverapp, trait_name, trait_value, make_mock_extension_app):
-#     kwarg = {}
-#     kwarg.setdefault(trait_name, trait_value)
-#     argv = [
-#         '--MockExtensionApp.{name}={value}'.format(name=trait_name, value=trait_value)
-#     ]
-#     mock_extension = make_mock_extension_app()
-#     mock_extension.initialize(serverapp, argv=argv)
-#     assert getattr(mock_extension, trait_name) == trait_value
-
-
-# def test_extensionapp_load_config_file(config_file, serverapp, extended_serverapp):
-#     # Assert default config_file_paths is the same in the app and extension.
-#     assert extended_serverapp.config_file_paths == serverapp.config_file_paths
-#     assert extended_serverapp.config_file_name == 'jupyter_mockextension_config'
-#     assert extended_serverapp.config_dir == serverapp.config_dir
-#     # Assert that the trait is updated by config file
-#     assert extended_serverapp.mock_trait == 'config from file'
+def test_extensionapp_load_config_file(
+    extension_environ,
+    config_file,
+    enabled_extensions,
+    serverapp,
+):
+    extension = enabled_extensions["mockextension"]
+    # Assert default config_file_paths is the same in the app and extension.
+    assert extension.config_file_paths == serverapp.config_file_paths
+    assert extension.config_dir == serverapp.config_dir
+    assert extension.config_file_name == 'jupyter_mockextension_config'
+    # Assert that the trait is updated by config file
+    assert extension.mock_trait == 'config from file'

--- a/tests/extension/test_entrypoint.py
+++ b/tests/extension/test_entrypoint.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 
@@ -6,7 +7,13 @@ pytestmark = pytest.mark.script_launch_mode('subprocess')
 
 
 def test_server_extension_list(environ, script_runner):
-    ret = script_runner.run('jupyter', 'server', 'extension', 'list')
+    ret = script_runner.run(
+        'jupyter',
+        'server',
+        'extension',
+        'list',
+        env=os.environ
+    )
     assert ret.success
 
 
@@ -19,7 +26,8 @@ def test_server_extension_enable(environ, script_runner):
         "server",
         "extension",
         "enable",
-        extension_name
+        extension_name,
+        env=os.environ
     )
     assert ret.success
     assert 'Enabling: {}'.format(extension_name) in ret.stderr
@@ -34,7 +42,8 @@ def test_server_extension_disable(environ, script_runner):
         'server',
         'extension',
         'disable',
-        extension_name
+        extension_name,
+        env=os.environ
     )
     assert ret.success
     assert 'Disabling: {}'.format(extension_name) in ret.stderr

--- a/tests/extension/test_entrypoint.py
+++ b/tests/extension/test_entrypoint.py
@@ -1,7 +1,5 @@
 import pytest
 
-from jupyter_core import paths
-from jupyter_server.extension import serverextension
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.script_launch_mode('subprocess')

--- a/tests/extension/test_entrypoint.py
+++ b/tests/extension/test_entrypoint.py
@@ -12,13 +12,17 @@ def test_server_extension_list(environ, script_runner):
     assert ret.success
 
 
-def test_server_extension_enable(environ, inject_mock_extension, script_runner):
+def test_server_extension_enable(environ, script_runner):
     # 'mock' is not a valid extension The entry point should complete
     # but print to sterr.
     extension_name = "mockextension"
-    inject_mock_extension()
-
-    ret = script_runner.run("jupyter", "server", "extension", "enable", extension_name)
+    ret = script_runner.run(
+        "jupyter",
+        "server",
+        "extension",
+        "enable",
+        extension_name
+    )
     assert ret.success
     assert 'Enabling: {}'.format(extension_name) in ret.stderr
 
@@ -27,6 +31,12 @@ def test_server_extension_disable(environ, script_runner):
     # 'mock' is not a valid extension The entry point should complete
     # but print to sterr.
     extension_name = 'mockextension'
-    ret = script_runner.run('jupyter', 'server', 'extension', 'disable', extension_name)
+    ret = script_runner.run(
+        'jupyter',
+        'server',
+        'extension',
+        'disable',
+        extension_name
+    )
     assert ret.success
     assert 'Disabling: {}'.format(extension_name) in ret.stderr

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -1,10 +1,23 @@
 import pytest
 
-from jupyter_server.serverapp import ServerApp
 
-# ------------------ Start tests -------------------
+@pytest.fixture
+def server_config(template_dir):
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "tests.extension.mockextensions": True
+            }
+        },
+        "MockExtensionApp": {
+            "template_paths": [
+                str(template_dir)
+            ]
+        }
+    }
 
-async def test_handler(fetch, extended_serverapp):
+
+async def test_handler(fetch):
     r = await fetch(
         'mock',
         method='GET'
@@ -13,7 +26,7 @@ async def test_handler(fetch, extended_serverapp):
     assert r.body.decode() == 'mock trait'
 
 
-async def test_handler_template(fetch, extended_serverapp):
+async def test_handler_template(fetch):
     r = await fetch(
         'mock_template',
         method='GET'
@@ -21,7 +34,7 @@ async def test_handler_template(fetch, extended_serverapp):
     assert r.code == 200
 
 
-async def test_handler_setting(fetch, serverapp, make_mock_extension_app):
+async def test_handler_setting(fetch, serverapp):
     # Configure trait in Mock Extension.
     m = make_mock_extension_app(mock_trait='test mock trait')
     m.initialize(serverapp)

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -1,5 +1,4 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture
 
 
 @pytest.fixture
@@ -45,9 +44,6 @@ async def test_handler_template(fetch, mock_template):
                 }
             },
             "MockExtensionApp": {
-                "template_paths": [
-                    lazy_fixture('template_dir')
-                ],
                 # Change a trait in the MockExtensionApp using
                 # the following config value.
                 "mock_trait": "test mock trait"

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 
 @pytest.fixture
@@ -45,8 +46,10 @@ async def test_handler_template(fetch, mock_template):
             },
             "MockExtensionApp": {
                 "template_paths": [
-                    pytest.lazy_fixture('template_dir')
+                    lazy_fixture('template_dir')
                 ],
+                # Change a trait in the MockExtensionApp using
+                # the following config value.
                 "mock_trait": "test mock trait"
             }
         }

--- a/tests/extension/test_serverextension.py
+++ b/tests/extension/test_serverextension.py
@@ -91,34 +91,36 @@ def test_merge_config(
     assert not extensions['mockext_both']
 
 
-@pytest.fixture
-def ordered_server_extensions():
-    mockextension1 = SimpleNamespace()
-    mockextension2 = SimpleNamespace()
+# ### NEED TO REFACTOR
 
-    def load_jupyter_server_extension(obj):
-        obj.mockI = True
-        obj.mock_shared = 'I'
+# @pytest.fixture
+# def ordered_server_extensions():
+#     mockextension1 = SimpleNamespace()
+#     mockextension2 = SimpleNamespace()
 
-    mockextension1.load_jupyter_server_extension = load_jupyter_server_extension
+#     def load_jupyter_server_extension(obj):
+#         obj.mockI = True
+#         obj.mock_shared = 'I'
 
-    def load_jupyter_server_extension(obj):
-        obj.mockII = True
-        obj.mock_shared = 'II'
+#     mockextension1.load_jupyter_server_extension = load_jupyter_server_extension
 
-    mockextension2.load_jupyter_server_extension = load_jupyter_server_extension
+#     def load_jupyter_server_extension(obj):
+#         obj.mockII = True
+#         obj.mock_shared = 'II'
 
-    sys.modules['mockextension2'] = mockextension2
-    sys.modules['mockextension1'] = mockextension1
+#     mockextension2.load_jupyter_server_extension = load_jupyter_server_extension
+
+#     sys.modules['mockextension2'] = mockextension2
+#     sys.modules['mockextension1'] = mockextension1
 
 
-def test_load_ordered(ordered_server_extensions):
-    app = ServerApp()
-    app.jpserver_extensions = OrderedDict([('mockextension2',True),('mockextension1',True)])
+# def test_load_ordered(ordered_server_extensions):
+#     app = ServerApp()
+#     app.jpserver_extensions = OrderedDict([('mockextension2',True),('mockextension1',True)])
 
-    app.init_server_extensions()
+#     app.init_server_extensions()
 
-    assert app.mockII is True, "Mock II should have been loaded"
-    assert app.mockI is True, "Mock I should have been loaded"
-    assert app.mock_shared == 'II', "Mock II should be loaded after Mock I"
+#     assert app.mockII is True, "Mock II should have been loaded"
+#     assert app.mockI is True, "Mock I should have been loaded"
+#     assert app.mock_shared == 'II', "Mock II should be loaded after Mock I"
 

--- a/tests/extension/test_serverextension.py
+++ b/tests/extension/test_serverextension.py
@@ -1,15 +1,7 @@
-import sys
 import pytest
 from collections import OrderedDict
-
-from types import SimpleNamespace
-
 from traitlets.tests.utils import check_help_all_output
 
-from ..utils import mkdir
-
-from jupyter_server.serverapp import ServerApp
-from jupyter_server.extension import serverextension
 from jupyter_server.extension.serverextension import (
     validate_server_extension,
     toggle_server_extension_python,
@@ -47,9 +39,10 @@ def test_disable():
 
 
 def test_merge_config(
-    env_config_path,
-    configurable_serverapp
-    ):
+        env_config_path,
+        configurable_serverapp,
+        extension_environ
+):
     # enabled at sys level
     validate_server_extension('tests.extension.mockextensions.mockext_sys')
     # enabled at sys, disabled at user
@@ -104,14 +97,20 @@ def test_merge_config(
     assert not extensions['tests.extension.mockextensions.mockext_both']
 
 
-def test_load_ordered(configurable_serverapp):
-    app = configurable_serverapp(
-        jpserver_extensions=OrderedDict([
-            ('tests.extension.mockextensions.mock2', True),
-            ('tests.extension.mockextensions.mock1', True)
-        ])
-    )
-    assert app.mockII is True, "Mock II should have been loaded"
-    assert app.mockI is True, "Mock I should have been loaded"
-    assert app.mock_shared == 'II', "Mock II should be loaded after Mock I"
-
+@pytest.mark.parametrize(
+    'server_config',
+    [
+        {
+            "ServerApp": {
+                "jpserver_extensions": OrderedDict([
+                    ('tests.extension.mockextensions.mock2', True),
+                    ('tests.extension.mockextensions.mock1', True)
+                ])
+            }
+        }
+    ]
+)
+def test_load_ordered(serverapp):
+    assert serverapp.mockII is True, "Mock II should have been loaded"
+    assert serverapp.mockI is True, "Mock I should have been loaded"
+    assert serverapp.mock_shared == 'II', "Mock II should be loaded after Mock I"

--- a/tests/extension/test_serverextension.py
+++ b/tests/extension/test_serverextension.py
@@ -32,95 +32,86 @@ def get_config(sys_prefix=True):
     return data.get("ServerApp", {}).get("jpserver_extensions", {})
 
 
-def test_enable(inject_mock_extension):
-    inject_mock_extension()
-    toggle_server_extension_python('mockextension', True)
+def test_enable():
+    toggle_server_extension_python('mock1', True)
     config = get_config()
-    assert config['mockextension']
+    assert config['mock1']
 
 
-def test_disable(inject_mock_extension):
-    inject_mock_extension()
-    toggle_server_extension_python('mockextension', True)
-    toggle_server_extension_python('mockextension', False)
+def test_disable():
+    toggle_server_extension_python('mock1', True)
+    toggle_server_extension_python('mock1', False)
 
     config = get_config()
-    assert not config['mockextension']
+    assert not config['mock1']
 
 
 def test_merge_config(
     env_config_path,
-    inject_mock_extension,
     configurable_serverapp
     ):
     # enabled at sys level
-    inject_mock_extension('mockext_sys')
-    validate_server_extension('mockext_sys')
+    validate_server_extension('tests.extension.mockextensions.mockext_sys')
     # enabled at sys, disabled at user
-    inject_mock_extension('mockext_both')
-    validate_server_extension('mockext_both')
+    validate_server_extension('tests.extension.mockextensions.mockext_both')
     # enabled at user
-    inject_mock_extension('mockext_user')
-    validate_server_extension('mockext_user')
+    validate_server_extension('tests.extension.mockextensions.mockext_user')
     # enabled at Python
-    inject_mock_extension('mockext_py')
-    validate_server_extension('mockext_py')
+    validate_server_extension('tests.extension.mockextensions.mockext_py')
 
     # Toggle each extension module with a JSON config file
     # at the sys-prefix config dir.
-    toggle_server_extension_python('mockext_sys', enabled=True, sys_prefix=True)
-    toggle_server_extension_python('mockext_user', enabled=True, user=True)
+    toggle_server_extension_python(
+        'tests.extension.mockextensions.mockext_sys',
+        enabled=True,
+        sys_prefix=True
+    )
+    toggle_server_extension_python(
+        'tests.extension.mockextensions.mockext_user',
+        enabled=True,
+        user=True
+    )
 
     # Write this configuration in two places, sys-prefix and user.
     # sys-prefix supercedes users, so the extension should be disabled
     # when these two configs merge.
-    toggle_server_extension_python('mockext_both', enabled=True, user=True)
-    toggle_server_extension_python('mockext_both', enabled=False, sys_prefix=True)
+    toggle_server_extension_python(
+        'tests.extension.mockextensions.mockext_both',
+        enabled=True,
+        user=True
+    )
+    toggle_server_extension_python(
+        'tests.extension.mockextensions.mockext_both',
+        enabled=False,
+        sys_prefix=True
+    )
+
+    arg = "--ServerApp.jpserver_extensions={{'{mockext_py}': True}}".format(
+        mockext_py='tests.extension.mockextensions.mockext_py'
+    )
 
     # Enable the last extension, mockext_py, using the CLI interface.
     app = configurable_serverapp(
         config_dir=str(env_config_path),
-        argv=['--ServerApp.jpserver_extensions={"mockext_py":True}']
+        argv=[arg]
     )
     # Verify that extensions are enabled and merged properly.
     extensions = app.jpserver_extensions
-    assert extensions['mockext_user']
-    assert extensions['mockext_sys']
-    assert extensions['mockext_py']
+    assert extensions['tests.extension.mockextensions.mockext_user']
+    assert extensions['tests.extension.mockextensions.mockext_sys']
+    assert extensions['tests.extension.mockextensions.mockext_py']
     # Merging should causes this extension to be disabled.
-    assert not extensions['mockext_both']
+    assert not extensions['tests.extension.mockextensions.mockext_both']
 
 
-# ### NEED TO REFACTOR
-
-# @pytest.fixture
-# def ordered_server_extensions():
-#     mockextension1 = SimpleNamespace()
-#     mockextension2 = SimpleNamespace()
-
-#     def load_jupyter_server_extension(obj):
-#         obj.mockI = True
-#         obj.mock_shared = 'I'
-
-#     mockextension1.load_jupyter_server_extension = load_jupyter_server_extension
-
-#     def load_jupyter_server_extension(obj):
-#         obj.mockII = True
-#         obj.mock_shared = 'II'
-
-#     mockextension2.load_jupyter_server_extension = load_jupyter_server_extension
-
-#     sys.modules['mockextension2'] = mockextension2
-#     sys.modules['mockextension1'] = mockextension1
-
-
-# def test_load_ordered(ordered_server_extensions):
-#     app = ServerApp()
-#     app.jpserver_extensions = OrderedDict([('mockextension2',True),('mockextension1',True)])
-
-#     app.init_server_extensions()
-
-#     assert app.mockII is True, "Mock II should have been loaded"
-#     assert app.mockI is True, "Mock I should have been loaded"
-#     assert app.mock_shared == 'II', "Mock II should be loaded after Mock I"
+def test_load_ordered(configurable_serverapp):
+    app = configurable_serverapp(
+        jpserver_extensions=OrderedDict([
+            ('tests.extension.mockextensions.mock2', True),
+            ('tests.extension.mockextensions.mock1', True)
+        ])
+    )
+    assert app.mockII is True, "Mock II should have been loaded"
+    assert app.mockI is True, "Mock I should have been loaded"
+    assert app.mock_shared == 'II', "Mock II should be loaded after Mock I"
 

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -5,7 +5,7 @@ from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoi
 
 
 @pytest.fixture
-def config():
+def server_config():
     return {'FileContentsManager': {'checkpoints_class': GenericFileCheckpoints}}
 
 

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -3,7 +3,7 @@ from traitlets.config import Config
 
 
 @pytest.fixture
-def config():
+def server_config():
     return Config({
         'ServerApp': {
             'MappingKernelManager': {


### PR DESCRIPTION
## Summary 

This PR enables the ServerApp to discover ExtensionApp's before the server's Tornado Web Application is configured. 

Other smaller changes:
1. Extensions' `default_url` changed to `extension_url`.
2. The order of paths for searching enabled extensions was reversed from user > env > sys-prefix to sys-prefix > env > user. This was a lingering fix in accordance with [JEP #29](https://github.com/jupyter/enhancement-proposals/blob/master/jupyter-server/jupyter-server.md) 
3. Extensions' loading function, `load_jupyter_server_extension`, changed to `_load_jupyter_server_extension` (a private function prefixed with `_`).
4.  ServerApp now uses extensions' `_jupyter_server_extension_paths` function to discover server extensions. Previously, this was only used to toggle extensions. 
5. Added an optional `"app"` key to the metadata returned by `_jupyter_server_extension_paths`.
6. ServerApp now initializes extensions first in it's `initialize` method. Then, constructs a WebApplication.

## tl;dr Why?
 
There's a challenge with the order in which the Server and Extensions are loaded. Previously, the order is:
1. Server is initialized
2. Server config is loaded
3. Tornado WebApplication is created
4. Extensions are initialized through `load_jupyter_server_extension`
5. Extension config is loaded

The issue is that, during a transition to jupyter server, extension apps that try configuring serverapp do not load their config early enough (step 5). The serverapp will already have created it's WebApplication and HTTPServer objects before the extension can change their attributes. E.g. if you want to change the `port` of the server through a CLI like `jupyter lab --LabApp.port=8890`, you cannot currently do this. The port value will be loaded too late. The server will run on 8888, and the trait will change after this server starts.

This PR adds a step after step 2, where the ServerApp can *discover* ExtensionApp subclasses listed in jpserver_extensions. The ServerApp can then call its `load_config_file()` method and discover server-specific config from the ExtensionApp.

1. Server is initialized
2. Server config is loaded
3. **Extension are found+stored in new attribute and ExtensionApp are initialized (thus, config loaded).**
4. Tornado WebApplication is created
5. Extensions are loaded through `_load_jupyter_server_extension` function.

The added benefit is that it allows me to intercept the ServerApp config and shim traits using the shim layer added in Zsailer/nbclassic#7. 

## How

This adds an optional key:value pair to the extension metadata dict, `app: <ExtensionApp subclass`. If an ExtensionApp is listed in `jpserver_extension`, this key will be found in the extension metadata and discoverable by ServerApp. Then, the ServerApp's initialize method can pick up these extensions and load their config before creating a webapp.

*My apologies for the auto-formatting diffs! 😦 If the diff is too difficult to look at, I can highlight the chunks that matter*
