### PR TITLE
Document tag to use on extension repositories

### DIFF
--- a/docs/source/frontends.rst
+++ b/docs/source/frontends.rst
@@ -137,3 +137,8 @@ Examples
 
 You can check some simple example on the `GitHub jupyter_server repository
 <https://github.com/jupyter/jupyter_server/tree/master/examples/simple>`_.
+
+Extension Repositories
+----------------------
+
+We invite developers to tag the extension repositories with ``jupyter-server-extension``.


### PR DESCRIPTION
This PR add a simple section in the documentation to invite developers to tag the extension repositories with `jupyter-server-extension`.