### PR TITLE
Remove remains of jupyter bundlerextension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ for more information.
     entry_points = {
         'console_scripts': [
             'jupyter-server = jupyter_server.serverapp:main',
-            'jupyter-bundlerextension = jupyter_server.bundler.bundlerextensions:main',
         ],
         'pytest11': [
             'pytest_jupyter_server = jupyter_server.pytest_plugin'

--- a/setupbase.py
+++ b/setupbase.py
@@ -111,7 +111,6 @@ def find_package_data():
 
     package_data = {
         'jupyter_server' : ['templates/*'],
-        'jupyter_server.bundler.tests': ['resources/*', 'resources/*/*', 'resources/*/*/.*'],
         'jupyter_server.services.api': ['api.yaml'],
         'jupyter_server.i18n': ['*/LC_MESSAGES/*.*'],
     }


### PR DESCRIPTION
If you install or update `jupyter_server` after [notebook](https://github.com/jupyter/notebook) the executable `jupyter-bundlerextension` will be overwritten because of the entrypoint defined in [setup.py](https://github.com/jupyter/jupyter_server/blob/master/setup.py#L102) and the [conda-forge-recipe](https://github.com/conda-forge/jupyter_server-feedstock/blob/master/recipe/meta.yaml#L18). You will get the following error if you execute the following example command `jupyter bundlerextension list`

```python
Traceback (most recent call last):
  File "/Users/USER/opt/anaconda3/bin/jupyter-bundlerextension", line 7, in <module>
    from jupyter_server.bundlerextensions import main
ModuleNotFoundError: No module named 'jupyter_server.bundlerextensions'
```

This can be fixed by reinstalling `notebook` with `conda install notebook --force-reinstall`, however this PR removes the remaining parts (left of https://github.com/jupyter/jupyter_server/pull/47) of the bundler from the codebase.