### PR TITLE
Trigger github actions on all pushed branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,7 @@
 name: Jupyter Server Tests
 on:
   push:
-    branches:
-    - master
+    branches: '*'
   pull_request:
     branches: '*'
 jobs:


### PR DESCRIPTION
This allows users to ensure their changes can be tested via the CI tools prior to submitting the pull request.
(Unfortunately, it seems the one terminal test on macOS and python 3.7 is failing consistently right now.)
