### PR TITLE
Update log messages when testing for load_jupyter_server_extension method

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1616,8 +1616,14 @@ class ServerApp(JupyterApp):
                 # underscored loading functions.
                 func = getattr(extension, 'load_jupyter_server_extension')
                 func(self)
-                self.log.debug(log_msg)
-            except:
+                warn_msg = _(
+                    "{extkey} is enabled. "
+                    "`load_jupyter_server_extension` function "
+                    "was found but `_load_jupyter_server_extension`"
+                    "is preferred.".format(extkey=extkey)
+                )
+                self.log.warning(warn_msg)
+            except AttributeError:
                 warn_msg = _(
                     "{extkey} is enabled but no "
                     "`_load_jupyter_server_extension` function "


### PR DESCRIPTION
When checking in serverapp for `load_jupyter_server_extension` or `_load_jupyter_server_extension`, this PR reduces the scope of the except (only catch  AttributeError and not other exceptions as this may hide other issues).

It also logs a warning if `load_jupyter_server_extension` instead of the preferred `_load_jupyter_server_extension`.