### PR TITLE
Add option to load extensions listed on jupyter_config_path

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -316,7 +316,7 @@ class ExtensionApp(JupyterApp):
             }
         })
         serverapp = ServerApp.instance(**kwargs, argv=[], config=config)
-        serverapp.initialize(argv=argv, load_extensions=load_other_extensions)
+        serverapp.initialize(argv=argv, find_extensions=load_other_extensions)
         return serverapp
 
     def link_to_serverapp(self, serverapp):


### PR DESCRIPTION
Fixes #211. @davidbrochart 

This PR:

1. separates out the logic that looks at jupyter_config_path to find server extensions.
1. makes `find_server_extensions` a separate step in the server `initialize` method.
1. renames `load_extensions` argument to `find_extension`. 

As a result,
1. If `find_extension=False`, only extensions that are *directly* passed to the ServerApp through CLI, argv, or the `jpserver_extensions` trait will be initialized+loaded. Extensions listed in config files are ignored.
1. ExtensionApps with `load_other_extensions=False` will ignore all other extensions (unless the ExtensionApp explicitly whitelists some extensions through its initialize method).