### PR TITLE
Use extensionapp open_browser trait for serverapp config

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -206,7 +206,7 @@ class ExtensionApp(JupyterApp):
         help=_("""Handlers appended to the server.""")
     ).tag(config=True)
 
-    open_browser = Bool(False,
+    open_browser = Bool(True,
         help=_("""Whether to open in a browser after starting.
         The specific browser used is platform dependent and
         determined by the python standard library `webbrowser`

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -7,6 +7,7 @@ from traitlets import (
     Unicode,
     List,
     Dict,
+    Bool,
     default,
     validate
 )
@@ -204,6 +205,14 @@ class ExtensionApp(JupyterApp):
     handlers = List(
         help=_("""Handlers appended to the server.""")
     ).tag(config=True)
+
+    open_browser = Bool(False,
+        help=_("""Whether to open in a browser after starting.
+        The specific browser used is platform dependent and
+        determined by the python standard library `webbrowser`
+        module, unless it is overridden using the --browser
+        (ServerApp.browser) configuration option.
+        """)).tag(config=True)
 
     def _config_file_name_default(self):
         """The default config file name."""

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -311,7 +311,7 @@ class ExtensionApp(JupyterApp):
         config = Config({
             "ServerApp": {
                 "jpserver_extensions": {cls.extension_name: True},
-                "open_browser": True,
+                "open_browser": cls.open_browser,
                 "default_url": cls.extension_url
             }
         })


### PR DESCRIPTION
This is a fix for https://github.com/jupyter/jupyter_server/issues/215

It uses the ExtensionApp open_browser trait for ServerApp config.