### PR TITLE
add basic login.html template

### DIFF
--- a/jupyter_server/templates/login.html
+++ b/jupyter_server/templates/login.html
@@ -1,0 +1,17 @@
+{% extends "page.html" %}
+
+{% block site %}
+{% if message %}
+{% for key in message %}
+<div>
+    {{message[key]}}
+</div>
+{% endfor %}
+{% endif %}
+<form action="{{base_url}}login?next={{next}}" method="post">
+    {{ xsrf_form_html() | safe }}
+    <label for="password_input"><strong>{% trans %}Password:{% endtrans %}</strong></label>
+    <input type="password" name="password" id="password_input">
+    <button type="submit" id="login_submit">{% trans %}Log in{% endtrans %}</button>
+</form>
+{% endblock site %}

--- a/jupyter_server/templates/logout.html
+++ b/jupyter_server/templates/logout.html
@@ -1,0 +1,13 @@
+{% extends "page.html" %}
+
+{% block site %}
+{% if message %}
+{% for key in message %}
+<div>
+  {{message[key]}}
+</div>
+{% endfor %}
+{% endif %}
+
+{% trans %}Proceed to the <a href="{{base_url}}login">login page{% endtrans %}</a>.
+{% endblock %}


### PR DESCRIPTION
If you try to run a jupyter-server with just basic password it will fail with `500` on the login handler with the error "login.html" not found. 

This PR fixes the error. The code is extracted from jupyter-notebook [login.html](https://github.com/jupyter/notebook/blob/master/notebook/templates/login.html)

