### PR TITLE
add fixture to kill all terminals after each test

### DIFF
--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -14,9 +14,9 @@ if sys.platform.startswith('win'):
 # Kill all running terminals after each test to avoid cross-test issues
 # with still running terminals.
 @pytest.fixture(autouse=True)
-async def kill_all(serverapp):
+def kill_all(serverapp):
     yield
-    await serverapp.web_app.settings["terminal_manager"].kill_all()
+    serverapp.web_app.settings["terminal_manager"].kill_all()
 
 
 @pytest.fixture


### PR DESCRIPTION
The tests were failing in `test_terminals.py` on CI because terminals opened in one test persisted across other tests. Here, I've added a fixture to kill all terminals after each test. 

This is a work in progress—it doesn't fix the issue yet, but it's a step in the right direction. I can verify on my branch that terminals are staying open between tests.

I'll remove the "Draft" label once I've fixed the issue.