### PR TITLE
remove call to deprecated pyzmq ioloop.install

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -41,11 +41,6 @@ from jinja2 import Environment, FileSystemLoader
 from jupyter_server.transutils import trans, _
 from jupyter_server.utils import secure_write, run_sync
 
-# Install the pyzmq ioloop. This has to be done before anything else from
-# tornado is imported.
-from zmq.eventloop import ioloop
-ioloop.install()
-
 # check for tornado 3.1.0
 try:
     import tornado
@@ -59,6 +54,7 @@ if version_info < (4,0):
     raise ImportError(_("The Jupyter Server requires tornado >= 4.0, but you have %s") % tornado.version)
 
 from tornado import httpserver
+from tornado import ioloop
 from tornado import web
 from tornado.httputil import url_concat
 from tornado.log import LogFormatter, app_log, access_log, gen_log

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,6 @@ for more information.
     install_requires = [
         'jinja2',
         'tornado>=5.0',
-        # pyzmq>=17 is not technically necessary,
-        # but hopefully avoids incompatibilities with Tornado 5. April 2018
         'pyzmq>=17',
         'ipython_genutils',
         'traitlets>=4.2.1',


### PR DESCRIPTION
this is deprecated as of pyzmq 17 (Feb 2018) which is already our minimum version.