### PR TITLE
Fix Jovyan Zoom URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Where: [calpoly/jupyter Zoom](https://zoom.us/my/jovyan)
 What: [Meeting notes](https://github.com/jupyter/jupyter_server/issues/126)
 
 * When: Thursdays [8:00am, Pacific time](https://www.thetimezoneconverter.com/?t=8%3A00%20am&tz=San%20Francisco&)
-* Where: [Jupyter Zoom](https://calpoly.zoom.us/my/jupyter)
+* Where: [Jovyan Zoom](https://zoom.us/my/jovyan)
 * What: [Meeting notes](https://github.com/jupyter/jupyter_server/issues/126)
 
 See our tentative [roadmap here](https://github.com/jupyter/jupyter_server/issues/127).


### PR DESCRIPTION
Fix Jovyan Zoom URL on the README

Was: https://calpoly.zoom.us/my/jupyter
Should be: https://zoom.us/my/jovyan