### PR TITLE
Add kernel independent logging

### DIFF
--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -8,6 +8,7 @@ Preliminary documentation at https://github.com/ipython/ipython/wiki/IPEP-16%3A-
 
 import json
 import logging
+import logging.config
 from textwrap import dedent
 
 from tornado import web
@@ -115,6 +116,13 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
     @property
     def rate_limit_window(self):
         return self.settings.get('rate_limit_window', 1.0)
+
+    @property
+    def kernel_logger(self):
+        logger_conf = self.settings.get('kernel_logger', None)
+        if logger_conf:
+            logging.config.fileConfig(logger_conf, disable_existing_loggers=False)
+            return logging.getLogger('kernel_logger')
 
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, getattr(self, 'kernel_id', 'uninitialized'))
@@ -307,6 +315,8 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         else:
             stream = self.channels[channel]
             self.session.send(stream, msg)
+            if self.kernel_logger and msg['content'].get('code', None):
+                self.kernel_logger.info(msg['content']['code'].replace('\n', '\\n'))
 
     def _on_zmq_reply(self, stream, msg_list):
         idents, fed_msg_list = self.session.feed_identities(msg_list)


### PR DESCRIPTION
This moves https://github.com/jupyter/notebook/pull/2252 to jupyter_server. I think it is useful to have the ability to log which code has been executed (for auditability reasons).

The method of specifying a python logger is clunky and I'm looking for suggestions on ways to improve that (specifying the logger in a traitlets config file?).

Pinging @Zsailer 