### PR TITLE
ExtensionApp: change extension_name to name.

### DIFF
--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -109,9 +109,9 @@ An ExtensionApp:
 
     - has traits.
     - is configurable (from file or CLI)
-    - has a name (see the ``extension_name`` trait).
-    - has an entrypoint, ``jupyter <extension_name>``.
-    - can serve static content from the ``/static/<extension_name>/`` endpoint.
+    - has a name (see the ``name`` trait).
+    - has an entrypoint, ``jupyter <name>``.
+    - can serve static content from the ``/static/<name>/`` endpoint.
     - can add new endpoints to the Jupyter Server.
 
 The basic structure of an ExtensionApp is shown below:
@@ -124,7 +124,7 @@ The basic structure of an ExtensionApp is shown below:
     class MyExtensionApp(ExtensionApp):
 
         # -------------- Required traits --------------
-        extension_name = "myextension"
+        name = "myextension"
         extension_url = "/myextension"
         load_other_extensions = True
 
@@ -163,7 +163,7 @@ Methods
 
 Properties
 
-* ``extension_name``: the name of the extension
+* ``name``: the name of the extension
 * ``extension_url``: the default url for this extension—i.e. the landing page for this extension when launched from the CLI.
 * ``load_other_extensions``: a boolean enabling/disabling other extensions when launching this extension directly.
 
@@ -174,8 +174,8 @@ Properties
 
 * ``config``: the ExtensionApp's config object.
 * ``server_config``: the ServerApp's config object.
-* ``extension_name``: the name of the extension to which this handler is linked.
-* ``static_url()``: a method that returns the url to static files (prefixed with ``/static/<extension_name>``).
+* ``name``: the name of the extension to which this handler is linked.
+* ``static_url()``: a method that returns the url to static files (prefixed with ``/static/<name>``).
 
 Jupyter Server provides a convenient mixin class for adding these properties to any ``JupyterHandler``. For example, the basic server extension handler in the section above becomes:
 
@@ -202,7 +202,7 @@ Jinja templating from frontend extensions
 
 Many Jupyter frontend applications use Jinja for basic HTML templating. Since this is common enough, Jupyter Server provides some extra mixin that integrate Jinja with Jupyter server extensions.
 
-Use ``ExtensionAppJinjaMixin`` to automatically add a Jinja templating environment to an ``ExtensionApp``. This adds a ``<extension_name>_jinja2_env`` setting to Tornado Web Server's settings that will be used by request handlers.
+Use ``ExtensionAppJinjaMixin`` to automatically add a Jinja templating environment to an ``ExtensionApp``. This adds a ``<name>_jinja2_env`` setting to Tornado Web Server's settings that will be used by request handlers.
 
 .. code-block:: python
 

--- a/docs/source/operators/configuring-extensions.rst
+++ b/docs/source/operators/configuring-extensions.rst
@@ -26,7 +26,7 @@ Jupyter Server looks for an extension's config file in a set of specific paths. 
 Extension config from file
 --------------------------
 
-Jupyter Server expects the file to be named after the extension's name like so: ``jupyter_{extension_name}_config``. For example, the Jupyter Notebook's config file is ``jupyter_notebook_config``.
+Jupyter Server expects the file to be named after the extension's name like so: ``jupyter_{name}_config``. For example, the Jupyter Notebook's config file is ``jupyter_notebook_config``.
 
 Configuration files can be Python or JSON files.
 

--- a/examples/simple/simple_ext1/application.py
+++ b/examples/simple/simple_ext1/application.py
@@ -10,7 +10,7 @@ DEFAULT_TEMPLATE_FILES_PATH = os.path.join(os.path.dirname(__file__), "templates
 class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
 
     # The name of the extension.
-    extension_name = "simple_ext1"
+    name = "simple_ext1"
 
     # The url that your extension will serve its homepage.
     extension_url = '/simple_ext1/default'
@@ -45,11 +45,11 @@ class SimpleApp1(ExtensionAppJinjaMixin, ExtensionApp):
 
     def initialize_handlers(self):
         self.handlers.extend([
-            (r'/{}/default'.format(self.extension_name), DefaultHandler),
-            (r'/{}/params/(.+)$'.format(self.extension_name), ParameterHandler),
-            (r'/{}/template1/(.*)$'.format(self.extension_name), TemplateHandler),
-            (r'/{}/redirect'.format(self.extension_name), RedirectHandler),
-            (r'/{}/typescript/?'.format(self.extension_name), TypescriptHandler),
+            (r'/{}/default'.format(self.name), DefaultHandler),
+            (r'/{}/params/(.+)$'.format(self.name), ParameterHandler),
+            (r'/{}/template1/(.*)$'.format(self.name), TemplateHandler),
+            (r'/{}/redirect'.format(self.name), RedirectHandler),
+            (r'/{}/typescript/?'.format(self.name), TypescriptHandler),
             (r'/{}/(.*)', ErrorHandler)
         ])
 

--- a/examples/simple/simple_ext1/handlers.py
+++ b/examples/simple/simple_ext1/handlers.py
@@ -4,17 +4,17 @@ from jupyter_server.extension.handler import ExtensionHandlerMixin, ExtensionHan
 class DefaultHandler(ExtensionHandlerMixin, JupyterHandler):
     def get(self):
         # The name of the extension to which this handler is linked.
-        self.log.info("Extension Name in {} Default Handler: {}".format(self.extension_name, self.extension_name))
-        # A method for getting the url to static files (prefixed with /static/<extension_name>).
+        self.log.info("Extension Name in {} Default Handler: {}".format(self.name, self.name))
+        # A method for getting the url to static files (prefixed with /static/<name>).
         self.log.info("Static URL for / in simple_ext1 Default Handler:".format(self.static_url(path='/')))
         self.write('<h1>Hello Simple 1 - I am the default...</h1>')
-        self.write('Config in {} Default Handler: {}'.format(self.extension_name, self.config))
+        self.write('Config in {} Default Handler: {}'.format(self.name, self.config))
 
 class RedirectHandler(ExtensionHandlerMixin, JupyterHandler):
     def get(self):
-        self.redirect("/static/{}/favicon.ico".format(self.extension_name))
+        self.redirect("/static/{}/favicon.ico".format(self.name))
 
-class ParameterHandler(ExtensionHandlerMixin, JupyterHandler):    
+class ParameterHandler(ExtensionHandlerMixin, JupyterHandler):
     def get(self, matched_part=None, *args, **kwargs):
         var1 = self.get_argument('var1', default=None)
         components = [x for x in self.request.path.split("/") if x]

--- a/examples/simple/simple_ext11/application.py
+++ b/examples/simple/simple_ext11/application.py
@@ -15,7 +15,7 @@ class SimpleApp11(SimpleApp1):
     })
 
     # The name of the extension.
-    extension_name = "simple_ext11"
+    name = "simple_ext11"
 
     # Te url that your extension will serve its homepage.
     extension_url = '/simple_ext11/default'

--- a/examples/simple/simple_ext2/application.py
+++ b/examples/simple/simple_ext2/application.py
@@ -9,7 +9,7 @@ DEFAULT_TEMPLATE_FILES_PATH = os.path.join(os.path.dirname(__file__), "templates
 class SimpleApp2(ExtensionAppJinjaMixin, ExtensionApp):
 
     # The name of the extension.
-    extension_name = "simple_ext2"
+    name = "simple_ext2"
 
     # Te url that your extension will serve its homepage.
     extension_url = '/simple_ext2'

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -8,7 +8,7 @@ class ExtensionHandlerJinjaMixin:
     """
     def get_template(self, name):
         """Return the jinja template object for a given name"""
-        env = '{}_jinja2_env'.format(self.extension_name)
+        env = '{}_jinja2_env'.format(self.name)
         return self.settings[env].get_template(name)
 
 
@@ -16,18 +16,18 @@ class ExtensionHandlerMixin:
     """Base class for Jupyter server extension handlers.
 
     Subclasses can serve static files behind a namespaced
-    endpoint: "/static/<extension_name>/"
+    endpoint: "/static/<name>/"
 
     This allows multiple extensions to serve static files under
     their own namespace and avoid intercepting requests for
     other extensions.
     """
-    def initialize(self, extension_name):
-        self.extension_name = extension_name
+    def initialize(self, name):
+        self.name = name
 
     @property
     def extensionapp(self):
-        return self.settings[self.extension_name]
+        return self.settings[self.name]
 
     @property
     def serverapp(self):
@@ -36,7 +36,7 @@ class ExtensionHandlerMixin:
 
     @property
     def config(self):
-        return self.settings["{}_config".format(self.extension_name)]
+        return self.settings["{}_config".format(self.name)]
 
     @property
     def server_config(self):
@@ -44,16 +44,15 @@ class ExtensionHandlerMixin:
 
     @property
     def static_url_prefix(self):
-        return "/static/{extension_name}/".format(
-            extension_name=self.extension_name)
+        return "/static/{name}/".format(name=self.name)
 
     @property
     def static_path(self):
-        return self.settings['{}_static_paths'.format(self.extension_name)]
+        return self.settings['{}_static_paths'.format(self.name)]
 
     def static_url(self, path, include_host=None, **kwargs):
         """Returns a static URL for the given relative static file path.
-        This method requires you set the ``{extension_name}_static_path``
+        This method requires you set the ``{name}_static_path``
         setting in your extension (which specifies the root directory
         of your static files).
         This method returns a versioned url (by default appending
@@ -68,7 +67,7 @@ class ExtensionHandlerMixin:
         that value will be used as the default for all `static_url`
         calls that do not pass ``include_host`` as a keyword argument.
         """
-        key = "{}_static_paths".format(self.extension_name)
+        key = "{}_static_paths".format(self.name)
         try:
             self.require_setting(key, "static_url")
         except Exception as e:

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -154,7 +154,7 @@ def _get_load_jupyter_server_extension(obj):
     return func
 
 
-def validate_server_extension(extension_name):
+def validate_server_extension(name):
     """Validates that you can import the extension module,
     gather all extension metadata, and find `load_jupyter_server_extension`
     functions for each extension.
@@ -176,10 +176,10 @@ def validate_server_extension(extension_name):
     """
     # If the extension does not exist, raise an exception
     try:
-        mod, metadata = _get_server_extension_metadata(extension_name)
+        mod, metadata = _get_server_extension_metadata(name)
         version = getattr(mod, '__version__', '')
     except ImportError:
-        raise ExtensionValidationError('{} is not importable.'.format(extension_name))
+        raise ExtensionValidationError('{} is not importable.'.format(name))
 
     try:
         for item in metadata:
@@ -194,7 +194,7 @@ def validate_server_extension(extension_name):
                 raise AttributeError
     # If the extension does not have a `load_jupyter_server_extension` function, raise exception.
     except AttributeError:
-        raise ExtensionValidationError('Found "{}" module but cannot load it.'.format(extension_name))
+        raise ExtensionValidationError('Found "{}" module but cannot load it.'.format(name))
     return version
 
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1571,7 +1571,7 @@ class ServerApp(JupyterApp):
                         app = extapp()
                         app.link_to_serverapp(self)
                         # Build a new list where we
-                        self._enabled_extensions[app.extension_name] = app
+                        self._enabled_extensions[app.name] = app
                     elif extloc:
                         extmod = importlib.import_module(extloc)
                         func = _get_load_jupyter_server_extension(extmod)
@@ -1603,8 +1603,8 @@ class ServerApp(JupyterApp):
                 )
             else:
                 log_msg = (
-                    "Extension {extension_name} enabled and "
-                    "loaded".format(extension_name=extension.extension_name)
+                    "Extension {name} enabled and "
+                    "loaded".format(name=extension.name)
                 )
             # Find the extension loading function.
             func = None

--- a/tests/extension/mockextensions/app.py
+++ b/tests/extension/mockextensions/app.py
@@ -18,10 +18,10 @@ class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
 
 
 class MockExtensionTemplateHandler(
-        ExtensionHandlerJinjaMixin,
-        ExtensionHandlerMixin,
-        JupyterHandler
-    ):
+    ExtensionHandlerJinjaMixin,
+    ExtensionHandlerMixin,
+    JupyterHandler
+):
 
     def get(self):
         self.write(self.render_template("index.html"))
@@ -29,7 +29,7 @@ class MockExtensionTemplateHandler(
 
 class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
 
-    extension_name = 'mockextension'
+    name = 'mockextension'
     template_paths = List().tag(config=True)
     mock_trait = Unicode('mock trait', config=True)
     loaded = False


### PR DESCRIPTION
Changes the `extension_name` trait to `name` in ExtensionApp. 

This addresses issues in #222 and #224. @echarles 