### PR TITLE
Add a link to the swagger viewer to the REST API page in the docs

### DIFF
--- a/docs/source/developers/rest-api.rst
+++ b/docs/source/developers/rest-api.rst
@@ -1,4 +1,7 @@
 The REST API
 ============
 
+An interactive version is available
+`here <https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter_server/master/jupyter_server/services/api/api.yaml>`_.
+
 .. openapi:: ../../../jupyter_server/services/api/api.yaml

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ Jupyter Server is the backendâ€”the core services, APIs, and `REST endpoints`_â€
 
 .. _Tornado: https://www.tornadoweb.org/en/stable/
 .. _Jupyter Notebook: https://github.com/jupyter/notebook
-.. _REST endpoints: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/notebook/master/notebook/services/api/api.yaml
+.. _REST endpoints: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter_server/master/jupyter_server/services/api/api.yaml
 
 Who's this for?
 ---------------

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
-  title: Jupyter Notebook API
-  description: Notebook API
+  title: Jupyter Server API
+  description: Server API
   version: "5"
   contact:
     name: Jupyter Project


### PR DESCRIPTION
A quick change to:

- Add a link to interactive version of the REST API rendered by swagger
- Update the title of the API spec to "Jupyter Server"