### PR TITLE
[HOTFIX] open_browser should be a primitive, not a trait

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -206,13 +206,8 @@ class ExtensionApp(JupyterApp):
         help=_("""Handlers appended to the server.""")
     ).tag(config=True)
 
-    open_browser = Bool(True,
-        help=_("""Whether to open in a browser after starting.
-        The specific browser used is platform dependent and
-        determined by the python standard library `webbrowser`
-        module, unless it is overridden using the --browser
-        (ServerApp.browser) configuration option.
-        """)).tag(config=True)
+    # Whether to open in a browser after starting.
+    open_browser = True
 
     def _config_file_name_default(self):
         """The default config file name."""


### PR DESCRIPTION
This is a hotfix for a regression introduced in https://github.com/jupyter/jupyter_server/pull/217

As discussed during last jupyter server weekly meeting, open_browser defined on ExtensionApp should be a primitive boolean value, not a trait.

We will review anyway this when we will support serverapp traits overrides in a generic way (with whitelist).