### PR TITLE
fix default_url redirect when base_url is defined

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -332,7 +332,7 @@ class ServerWebApplication(web.Application):
         # register base handlers last
         handlers.extend(load_handlers('jupyter_server.base.handlers'))
 
-        if settings['default_url'] != '/':
+        if settings['default_url'] != settings['base_url']:
             # set the URL that will be redirected from `/`
             handlers.append(
                 (r'/?', RedirectWithParams, {


### PR DESCRIPTION
as it is, when base_url is set, default_url would redirect to itself, creating an infinite redirect loop.

The condition is meant to prevent this loop when the default_url is the base_url, but base_url's default value was hardcoded in the check, causing the behavior to only be correct when base_url has this default value.

discovered testing with jupyterhub: https://github.com/jupyterhub/jupyterhub/pull/3128