### PR TITLE
add ensure_async in status handler

### DIFF
--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -9,6 +9,7 @@ import os
 from tornado import web
 
 from ...base.handlers import JupyterHandler, APIHandler
+from jupyter_server.utils import ensure_async
 from jupyter_server._tz import utcfromtimestamp, isoformat
 
 
@@ -36,7 +37,7 @@ class APIStatusHandler(APIHandler):
         started = self.settings.get('started', utcfromtimestamp(0))
         started = isoformat(started)
 
-        kernels = await self.kernel_manager.list_kernels()
+        kernels = await ensure_async(self.kernel_manager.list_kernels())
         total_connections = sum(k['connections'] for k in kernels)
         last_activity = isoformat(self.application.last_activity())
         model = {

--- a/tests/services/api/test_api.py
+++ b/tests/services/api/test_api.py
@@ -1,14 +1,23 @@
-import pytest
-
-from jupyter_server.utils import url_path_join
+import json
 
 
 async def test_get_spec(fetch):
-    response = await fetch(
-        'api', 'spec.yaml',
-        method='GET'
-    )
+    response = await fetch("api", "spec.yaml", method="GET")
     assert response.code == 200
 
 
-
+async def test_get_status(fetch):
+    response = await fetch("api", "status", method="GET")
+    assert response.code == 200
+    assert response.headers.get("Content-Type") == "application/json"
+    status = json.loads(response.body.decode("utf8"))
+    assert sorted(status.keys()) == [
+        "connections",
+        "kernels",
+        "last_activity",
+        "started",
+    ]
+    assert status["connections"] == 0
+    assert status["kernels"] == 0
+    assert status["last_activity"].endswith("Z")
+    assert status["started"].endswith("Z")


### PR DESCRIPTION
and make sure status handler is tested

status handler is currently returning 500 because the default KernelManager has a synchronous list_kernels method

This is blocking jupyterhub support for juptyer_server: https://github.com/jupyterhub/jupyterhub/pull/3128