### PR TITLE
Remove open_browser attribute from extensionapp

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -203,9 +203,6 @@ class ExtensionApp(JupyterApp):
         help=_("""Handlers appended to the server.""")
     ).tag(config=True)
 
-    # Whether to open in a browser after starting.
-    open_browser = True
-
     def _config_file_name_default(self):
         """The default config file name."""
         if not self.name:


### PR DESCRIPTION
We should remove the `open_browser` attribute from extensionapp so that applications can override the exposed open_browser set in serverapp_config.