### PR TITLE
Enable JupyterHandlers to set the logger on log_request

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -1,5 +1,6 @@
 import sys
 import re
+import logging
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -12,6 +13,7 @@ from traitlets import (
     validate
 )
 from traitlets.config import Config
+from tornado.log import LogFormatter
 
 from jupyter_core.application import JupyterApp
 
@@ -176,6 +178,17 @@ class ExtensionApp(JupyterApp):
     # A ServerApp is not defined yet, but will be initialized below.
     serverapp = None
 
+    _log_formatter_cls = LogFormatter
+
+    @default('log_level')
+    def _default_log_level(self):
+        return logging.INFO
+
+    @default('log_format')
+    def _default_log_format(self):
+        """override default log format to include date & time"""
+        return u"%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s]%(end_color)s %(message)s"
+
     @property
     def static_url_prefix(self):
         return "/static/{name}/".format(
@@ -237,7 +250,7 @@ class ExtensionApp(JupyterApp):
         # Add static and template paths to settings.
         self.settings.update({
             "{}_static_paths".format(self.name): self.static_paths,
-            "{}".format(self.name): self
+            "{}".format(self.name): self,
         })
 
         # Get setting defined by subclass using initialize_settings method.

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,5 +1,4 @@
 from jupyter_server.base.handlers import FileFindHandler
-from traitlets import Unicode, default
 
 
 class ExtensionHandlerJinjaMixin:
@@ -33,6 +32,14 @@ class ExtensionHandlerMixin:
     def serverapp(self):
         key = "serverapp"
         return self.settings[key]
+
+    @property
+    def log(self):
+        # Attempt to pull the ExtensionApp's log, otherwise fall back to ServerApp.
+        try:
+            return self.extensionapp.log
+        except AttributeError:
+            return self.serverapp.log
 
     @property
     def config(self):

--- a/jupyter_server/log.py
+++ b/jupyter_server/log.py
@@ -12,7 +12,7 @@ from .prometheus.log_functions import prometheus_log_method
 
 def log_request(handler):
     """log a bit more information about each request than tornado's default
-    
+
     - move static file get success to debug-level (reduces noise)
     - get proxied IP instead of proxy IP
     - log referer for redirect and failed requests
@@ -20,16 +20,21 @@ def log_request(handler):
     """
     status = handler.get_status()
     request = handler.request
+    try:
+        logger = handler.log
+    except AttributeError:
+        logger = access_log
+
     if status < 300 or status == 304:
         # Successes (or 304 FOUND) are debug-level
-        log_method = access_log.debug
+        log_method = logger.debug
     elif status < 400:
-        log_method = access_log.info
+        log_method = logger.info
     elif status < 500:
-        log_method = access_log.warning
+        log_method = logger.warning
     else:
-        log_method = access_log.error
-    
+        log_method = logger.error
+
     request_time = 1000.0 * handler.request.request_time()
     ns = dict(
         status=status,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -273,7 +273,7 @@ class ServerWebApplication(web.Application):
             server_root_dir=root_dir,
             jinja2_env=env,
             terminals_available=False,  # Set later if terminals are available
-            serverapp=self
+            serverapp=jupyter_app
         )
 
         # allow custom overrides for the tornado web app.


### PR DESCRIPTION
This enables server extensions to log from their own logger, rather than always logging from the `ServerApp`'s logger. Previously, all log messages from extensions were routed through the ServerApp logger, leading to some confusion on where these messages were actually coming from.

Fixes #273.