### PR TITLE
Track linked extensions in extension manager

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -257,6 +257,12 @@ class ExtensionManager(LoggingConfigurable):
             for name, point in value.extension_points.items()
         }
 
+    @property
+    def linked_extensions(self):
+        """Dictionary with extension names as keys; values are
+        True if the extension is linked, False if not."""
+        return self._linked_extensions
+
     def from_config_manager(self, config_manager):
         """Add extensions found by an ExtensionConfigManager"""
         self._config_manager = config_manager
@@ -281,7 +287,9 @@ class ExtensionManager(LoggingConfigurable):
         extension = self.extensions[name]
         if not linked and extension.enabled:
             try:
+                # Link extension and store links
                 extension.link_all_points(serverapp)
+                self._linked_extensions[name] = True
                 self.log.info("{name} | extension was successfully linked.".format(name=name))
             except Exception as e:
                 self.log.warning(e)

--- a/tests/extension/test_manager.py
+++ b/tests/extension/test_manager.py
@@ -75,3 +75,10 @@ def test_extension_manager_api():
     assert len(manager.extensions) == 1
     assert "tests.extension.mockextensions" in manager.extensions
 
+
+def test_extension_manager_linked_extensions(serverapp):
+    name = "tests.extension.mockextensions"
+    manager = ExtensionManager()
+    manager.add_extension(name, enabled=True)
+    manager.link_extension(name, serverapp)
+    assert name in manager.linked_extensions


### PR DESCRIPTION
This logic is missing in #248, so I've added it here.

The `linked_extension` property tracks if an extension has already been initialized and linked to a ServerApp. It was originally added for [nbclassic](https://github.com/Zsailer/nbclassic) when handling the shimming of server extensions. (This missing logic hasn't caused any issues because nbclassic is appending extensions directly to the private property, `_linked_extensions`). 

This missing public-facing property became an issue when drafting [jpserver-extension-check](https://github.com/Zsailer/jpserver-extension-check). I want to use this property to verify that extensions are linked properly in those tests.