### PR TITLE
Fix broken base_url traitlets config

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1371,7 +1371,7 @@ class ServerApp(JupyterApp):
         if not ip:
             ip = self.ip if self.ip else 'localhost'
         if not path:
-            path = url_path_join(self.base_url, self.default_url)
+            path = self.default_url
         # Build query string.
         if token:
             token = urllib.parse.urlencode({'token': token})


### PR DESCRIPTION
Fixes #278. 

The value returned by the `get_path` method in ServerApp was creating a duplicate path by combining default_url and base_url. Default_url already includes the base url, so we shouldn't be joining these two paths. 