### PR TITLE
Prefix all extension URLs with base_url (including static)

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -289,7 +289,6 @@ class ExtensionApp(JupyterApp):
         # Add static endpoint for this extension, if static paths are given.
         if len(self.static_paths) > 0:
             # Append the extension's static directory to server handlers.
-            print(self.static_url_prefix)
             static_url = url_path_join(self.static_url_prefix, "(.*)")
 
             # Construct handler.

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -1,6 +1,7 @@
 import sys
 import re
 import logging
+from urllib.parse import urljoin
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -8,9 +9,7 @@ from traitlets import (
     Unicode,
     List,
     Dict,
-    Bool,
-    default,
-    validate
+    default
 )
 from traitlets.config import Config
 from tornado.log import LogFormatter
@@ -191,8 +190,10 @@ class ExtensionApp(JupyterApp):
 
     @property
     def static_url_prefix(self):
-        return "/static/{name}/".format(
-            name=self.name)
+        static_url = "static/{name}".format(
+            name=self.name
+        )
+        return urljoin(self.serverapp.base_url, static_url)
 
     static_paths = List(Unicode(),
         help="""paths to search for serving static files.
@@ -288,6 +289,7 @@ class ExtensionApp(JupyterApp):
         # Add static endpoint for this extension, if static paths are given.
         if len(self.static_paths) > 0:
             # Append the extension's static directory to server handlers.
+            print(self.static_url_prefix)
             static_url = url_path_join(self.static_url_prefix, "(.*)")
 
             # Construct handler.

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,3 +1,4 @@
+from urllib.parse import urljoin
 from jupyter_server.base.handlers import FileFindHandler
 
 
@@ -55,10 +56,10 @@ class ExtensionHandlerMixin:
 
     @property
     def static_url_prefix(self):
-        return "{base_url}/static/{name}/".format(
-            name=self.name,
-            base_url=self.base_url
+        static_url = "static/{name}".format(
+            name=self.name
         )
+        return urljoin(self.serverapp.base_url, static_url)
 
     @property
     def static_path(self):

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -15,7 +15,7 @@ class ExtensionHandlerMixin:
     """Base class for Jupyter server extension handlers.
 
     Subclasses can serve static files behind a namespaced
-    endpoint: "/static/<name>/"
+    endpoint: "<base_url>/static/<name>/"
 
     This allows multiple extensions to serve static files under
     their own namespace and avoid intercepting requests for
@@ -50,8 +50,15 @@ class ExtensionHandlerMixin:
         return self.settings["config"]
 
     @property
+    def base_url(self):
+        return self.settings.get('base_url', '/')
+
+    @property
     def static_url_prefix(self):
-        return "/static/{name}/".format(name=self.name)
+        return "{base_url}/static/{name}/".format(
+            name=self.name,
+            base_url=self.base_url
+        )
 
     @property
     def static_path(self):

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -295,7 +295,6 @@ class ListServerExtensionsApp(BaseExtensionApp):
             {"user": False, "sys_prefix": True},
             {"user": False, "sys_prefix": False}
         )
-        self.log.info
 
         for option in configurations:
             config_dir, ext_manager = _get_extmanager_for_context(**option)

--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -45,7 +45,7 @@ def _get_config_dir(user=False, sys_prefix=False):
     return extdir
 
 
-def _get_extmanager_for_context(user=False, sys_prefix=False):
+def _get_extmanager_for_context(write_dir="jupyter_server_config.d", user=False, sys_prefix=False):
     """Get an extension manager pointing at the current context
 
     Returns the path to the current context and an ExtensionManager object.
@@ -295,6 +295,8 @@ class ListServerExtensionsApp(BaseExtensionApp):
             {"user": False, "sys_prefix": True},
             {"user": False, "sys_prefix": False}
         )
+        self.log.info
+
         for option in configurations:
             config_dir, ext_manager = _get_extmanager_for_context(**option)
             self.log.info("Config dir: {}".format(config_dir))

--- a/tests/extension/mockextensions/app.py
+++ b/tests/extension/mockextensions/app.py
@@ -1,3 +1,4 @@
+import os
 from traitlets import Unicode, List
 
 from jupyter_server.base.handlers import JupyterHandler
@@ -9,6 +10,8 @@ from jupyter_server.extension.handler import (
     ExtensionHandlerMixin,
     ExtensionHandlerJinjaMixin
 )
+
+STATIC_PATH = os.path.join(os.path.dirname(__file__), "static")
 
 
 class MockExtensionHandler(ExtensionHandlerMixin, JupyterHandler):
@@ -31,6 +34,7 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
 
     name = 'mockextension'
     template_paths = List().tag(config=True)
+    static_paths = [STATIC_PATH]
     mock_trait = Unicode('mock trait', config=True)
     loaded = False
 

--- a/tests/extension/mockextensions/static/mock.txt
+++ b/tests/extension/mockextensions/static/mock.txt
@@ -1,0 +1,1 @@
+mock static content

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -72,3 +72,42 @@ async def test_handler_argv(fetch):
     )
     assert r.code == 200
     assert r.body.decode() == 'test mock trait'
+
+
+@pytest.mark.parametrize(
+    'server_config',
+    [
+        {
+            "ServerApp": {
+                "jpserver_extensions": {
+                    "tests.extension.mockextensions": True
+                },
+                # Move extension handlers behind a url prefix
+                "base_url": "test_prefix"
+            },
+            "MockExtensionApp": {
+                # Change a trait in the MockExtensionApp using
+                # the following config value.
+                "mock_trait": "test mock trait"
+            }
+        }
+    ]
+)
+async def test_base_url(fetch):
+    # Test that the extension's handlers were properly prefixed
+    r = await fetch(
+        'test_prefix', 'mock',
+        method='GET'
+    )
+    assert r.code == 200
+    assert r.body.decode() == 'test mock trait'
+
+    # Test that the static namespace was prefixed by base_url
+    r = await fetch(
+        'test_prefix',
+        'static', 'mockextension', 'mock.txt',
+        method='GET'
+    )
+    assert r.code == 200
+    body = r.body.decode()
+    assert "mock static content" in body


### PR DESCRIPTION
Fixes #282.

Adds the base_url as a prefix to all extensions URLs, including the static namespaced URLs. 

I've also added a test to check that the static URL is properly prefixed. 