### PR TITLE
Include all package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,7 @@ setup_args = dict(
     long_description = README,
     version          = VERSION,
     packages         = find_packages('.'),
-    package_data     = {
-        'jupyter_server' : ['templates/*'],
-        'jupyter_server.i18n': ['*/LC_MESSAGES/*.*'],
-        'jupyter_server.services.api': ['api.yaml'],
-    },
+    include_package_data = True,
     author           = 'Jupyter Development Team',
     author_email     = 'jupyter@googlegroups.com',
     url              = 'http://jupyter.org',


### PR DESCRIPTION
Include all package data in the wheel.

```
$ python setup.py bdist_wheel
...
copying build/lib/jupyter_server/static/favicons/favicon-file.ico -> build/bdist.macosx-10.9-x86_64/wheel/jupyter_server/static/favicons
...
copying build/lib/jupyter_server/i18n/zh_CN/LC_MESSAGES/nbui.po -> build/bdist.macosx-10.9-x86_64/wheel/jupyter_server/i18n/zh_CN/LC_MESSAGES
```