### PR TITLE
pin traitlets temporarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_args = dict(
         'tornado>=5.0',
         'pyzmq>=17',
         'ipython_genutils',
-        'traitlets>=4.2.1',
+        'traitlets>=4.2.1,<5.0.0',
         'jupyter_core>=4.4.0',
         'jupyter_client>=6.1.1',
         'nbformat',


### PR DESCRIPTION
Traitlets 5.0.0 was released (awesome work, @Carreau and others!). 

We have some tests failing with this upgrade, so I'm temporarily pinning traitlets to `>=4.2.x,<5` until we fix these issues. I'll work on addressing these issues today.