### PR TITLE
Drop support for python 3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.5', '3.6', '3.7', '3.8' ]
+        python-version: [ '3.6', '3.7', '3.8' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1244,14 +1244,6 @@ class ServerApp(JupyterApp):
             connection_dir=self.runtime_dir,
             kernel_spec_manager=self.kernel_spec_manager,
         )
-        # Async randomly hangs on Python 3.5, prevent using it
-        if isinstance(self.kernel_manager, AsyncMappingKernelManager):
-            if sys.version_info < (3, 6):
-                raise ValueError("You are using `AsyncMappingKernelManager` in Python 3.5 (or lower),"
-                                 "which is not supported. Please upgrade Python to 3.6+.")
-            else:
-                self.log.info("Asynchronous kernel management has been configured to use '{}'.".
-                              format(self.kernel_manager.__class__.__name__))
         self.contents_manager = self.contents_manager_class(
             parent=self,
             log=self.log,
@@ -1325,7 +1317,6 @@ class ServerApp(JupyterApp):
             import ssl
             # PROTOCOL_TLS selects the highest ssl/tls protocol version that both the client and
             # server support. When PROTOCOL_TLS is not available use PROTOCOL_SSLv23.
-            # PROTOCOL_TLS is new in version 2.7.13, 3.5.3 and 3.6
             self.ssl_options.setdefault(
                 'ssl_version',
                 getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup_args = dict(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -56,6 +55,7 @@ setup_args = dict(
                  'pytest-console-scripts', 'ipykernel'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },
+    python_requires = '>=3.6',
     entry_points = {
         'console_scripts': [
             'jupyter-server = jupyter_server.serverapp:main',

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -19,20 +19,8 @@ def test_config(serverapp):
     assert serverapp.kernel_manager.allowed_message_types == ['kernel_info_request']
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 6),
-    reason="Kernel manager is AsyncMappingKernelManager, Python version < 3.6"
-)
 async def test_async_kernel_manager(configurable_serverapp):
     argv = ['--ServerApp.kernel_manager_class=jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager']
     app = configurable_serverapp(argv=argv)
     assert isinstance(app.kernel_manager, AsyncMappingKernelManager)
 
-
-@pytest.mark.parametrize(
-    "args",
-    [['--ServerApp.kernel_manager_class=jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager']]
-)
-async def test_async_kernel_manager_not_available_py35(configurable_serverapp, args):
-    with pytest.raises(ValueError):
-        app = configurable_serverapp(argv=args)

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -29,10 +29,6 @@ async def test_async_kernel_manager(configurable_serverapp):
     assert isinstance(app.kernel_manager, AsyncMappingKernelManager)
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 6),
-    reason="Testing AsyncMappingKernelManager on Python <=3.5"
-)
 @pytest.mark.parametrize(
     "args",
     [['--ServerApp.kernel_manager_class=jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager']]


### PR DESCRIPTION
JupyterLab is dropping support for Python 3.5 in 3.0, see also https://numpy.org/neps/nep-0029-deprecation_policy.html