### PR TITLE
make config_dir_name in ConfigManager configurable.

### DIFF
--- a/jupyter_server/extension/serverextension.py
+++ b/jupyter_server/extension/serverextension.py
@@ -52,7 +52,8 @@ def _get_extmanager_for_context(write_dir="jupyter_server_config.d", user=False,
 
     Parameters
     ----------
-
+    write_dir : str [default: 'jupyter_server_config.d']
+        Name of config directory to write extension config.
     user : bool [default: False]
         Get the user's .jupyter config directory
     sys_prefix : bool [default: False]
@@ -61,7 +62,7 @@ def _get_extmanager_for_context(write_dir="jupyter_server_config.d", user=False,
     config_dir = _get_config_dir(user=user, sys_prefix=sys_prefix)
     config_manager = ExtensionConfigManager(
         read_config_path=[config_dir],
-        write_config_dir=os.path.join(config_dir, "jupyter_server_config.d"),
+        write_config_dir=os.path.join(config_dir, write_dir),
     )
     extension_manager = ExtensionManager(
         config_manager=config_manager,

--- a/jupyter_server/services/config/manager.py
+++ b/jupyter_server/services/config/manager.py
@@ -14,6 +14,11 @@ from traitlets.config import LoggingConfigurable
 class ConfigManager(LoggingConfigurable):
     """Config Manager used for storing frontend config"""
 
+    config_dir_name = Unicode(
+        default="serverconfig",
+        help="""Name of the config directory."""
+    ).tag(config=True)
+
     # Public API
 
     def get(self, section_name):
@@ -39,13 +44,13 @@ class ConfigManager(LoggingConfigurable):
 
     @default('read_config_path')
     def _default_read_config_path(self):
-        return [os.path.join(p, 'serverconfig') for p in jupyter_config_path()]
+        return [os.path.join(p, self.config_dir_name) for p in jupyter_config_path()]
 
     write_config_dir = Unicode()
 
     @default('write_config_dir')
     def _default_write_config_dir(self):
-        return os.path.join(jupyter_config_dir(), 'serverconfig')
+        return os.path.join(jupyter_config_dir(), self.config_dir_name)
 
     write_config_manager = Instance(BaseJSONConfigManager)
 


### PR DESCRIPTION
This generalizes the `ConfigManager` a bit, so you can point the manager at other config directories (inspired by work happening in JupyterLab config).

Also addressed @vidartf's comment in [#285](https://github.com/jupyter/jupyter_server/pull/285#discussion_r481209490) by using the `write_dir` argument for setting a config write directory and added a docstring. 