### PR TITLE
replace urljoin with url_path_join in extensionapp

### DIFF
--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -1,7 +1,6 @@
 import sys
 import re
 import logging
-from urllib.parse import urljoin
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -197,7 +196,7 @@ class ExtensionApp(JupyterApp):
         static_url = "static/{name}/".format(
             name=self.name
         )
-        return urljoin(self.serverapp.base_url, static_url)
+        return url_path_join(self.serverapp.base_url, static_url)
 
     static_paths = List(Unicode(),
         help="""paths to search for serving static files.

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,4 +1,3 @@
-from urllib.parse import urljoin
 from jupyter_server.base.handlers import FileFindHandler
 from jinja2.exceptions import TemplateNotFound
 


### PR DESCRIPTION
This fixes a bug when serving static content behind a base_url. `urljoin` drops the base_url because of its leading forward slash. Switching to using `url_path_join` from our utils module.