### PR TITLE
Add TermSocket back from nbclassic 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0] - 2020-9-18
 
-## Added.
+### Added.
 
 * Added a basic, styled `login.html` template. ([220](https://github.com/jupyter/jupyter_server/pull/220), [295](https://github.com/jupyter/jupyter_server/pull/295))
 * Added new extension manager API for handling server extensions. ([248](https://github.com/jupyter/jupyter_server/pull/248), [265](https://github.com/jupyter/jupyter_server/pull/265), [275](https://github.com/jupyter/jupyter_server/pull/275), [303](https://github.com/jupyter/jupyter_server/pull/303))
 * The favicon and Jupyter logo are now available under jupyter_server's static namespace. ([284](https://github.com/jupyter/jupyter_server/pull/284))
 
-## Changed.
+### Changed.
 
 * `load_jupyter_server_extension` should be renamed to `_load_jupyter_server_extension` in server extensions. Server now throws a warning when the old name is used. ([213](https://github.com/jupyter/jupyter_server/pull/213))
 * Docs for server extensions now recommend using `authenticated` decorator for handlers. ([219](https://github.com/jupyter/jupyter_server/pull/219))
@@ -25,11 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Dropped support for Python 3.5. ([296](https://github.com/jupyter/jupyter_server/pull/296))
 * Made the `config_dir_name` trait configurable in `ConfigManager`. ([297](https://github.com/jupyter/jupyter_server/pull/297))
 
-## Removed for now removed features.
+### Removed for now removed features.
 
 * Removed ipykernel as a dependency of jupyter_server. ([255](https://github.com/jupyter/jupyter_server/pull/255))
 
-## Fixed for any bug fixes.
+### Fixed for any bug fixes.
 * Prevent a re-definition of prometheus metrics if `notebook` package already imports them. ([#210](https://github.com/jupyter/jupyter_server/pull/210))
 * Fixed `terminals` REST API unit tests that weren't shutting down properly. ([221](https://github.com/jupyter/jupyter_server/pull/221))
 * Fixed jupyter_server on Windows for Python < 3.7. Added patch to handle subprocess cleanup. ([240](https://github.com/jupyter/jupyter_server/pull/240))

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -11,6 +11,7 @@ from terminado import NamedTermManager
 from tornado.log import app_log
 from jupyter_server.utils import url_path_join as ujoin
 from . import api_handlers
+from .handlers import TermSocket
 
 
 def initialize(webapp, root_dir, connection_url, settings):
@@ -33,6 +34,8 @@ def initialize(webapp, root_dir, connection_url, settings):
     terminal_manager.log = app_log
     base_url = webapp.settings['base_url']
     handlers = [
+        (ujoin(base_url, r"/terminals/websocket/(\w+)"), TermSocket,
+             {'term_manager': terminal_manager}),
         (ujoin(base_url, r"/api/terminals"), api_handlers.TerminalRootHandler),
         (ujoin(base_url, r"/api/terminals/(\w+)"), api_handlers.TerminalHandler),
     ]

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -1,0 +1,33 @@
+#encoding: utf-8
+"""Tornado handlers for the terminal emulator."""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from tornado import web
+import terminado
+from jupyter_server._tz import utcnow
+from ..base.handlers import JupyterHandler
+from ..base.zmqhandlers import WebSocketMixin
+
+
+class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
+
+    def origin_check(self):
+        """Terminado adds redundant origin_check
+        Tornado already calls check_origin, so don't do anything here.
+        """
+        return True
+
+    def get(self, *args, **kwargs):
+        if not self.get_current_user():
+            raise web.HTTPError(403)
+        return super(TermSocket, self).get(*args, **kwargs)
+
+    def on_message(self, message):
+        super(TermSocket, self).on_message(message)
+        self.application.settings['terminal_last_activity'] = utcnow()
+
+    def write_message(self, message, binary=False):
+        super(TermSocket, self).write_message(message, binary=binary)
+        self.application.settings['terminal_last_activity'] = utcnow()


### PR DESCRIPTION
#313 removed too much to nbclassic. Reverting part of it allows JupyterLab to work with the standalone jupyter server (and JupyterLab examples to work without loading other extensions like nbclassic).