### PR TITLE
include eveything in the package directory in package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,10 +4,9 @@ include README.md
 include RELEASE.md
 include CHANGELOG.md
 include setupbase.py
-include jupyter_server/i18n/*
-include jupyter_server/static/*
-include jupyter_server/static/*/*
-include jupyter_server/templates/*
+
+# include everything in package_data
+include jupyter_server/**/*
 
 # Documentation
 graft docs


### PR DESCRIPTION
api.yaml is missing from 1.0.4, resulting in 404s on `/api/api.yaml`, but I don't think there are any files in here we want to exclude. This is causing test failures with jupyterhub + jupyter_server 1.0.4 which uses api.yaml as a test target

explicit excludes can be added if there are known things to exclude