### PR TITLE
Enable ExtensionApps to work with classic notebook server

### DIFF
--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -299,6 +299,23 @@ To make your extension executable from anywhere on your system, point an entry-p
         }
     )
 
+``ExtensionApp`` as a classic Notebook server extension
+-------------------------------------------------------
+
+An extension that extends ``ExtensionApp`` should still work with the old Tornado server from the classic Jupyter Notebook. The ``ExtensionApp`` class 
+provides a method, ``load_classic_server_extension``, that handles the extension initialization. Simply  define a ``load_jupyter_server_extension`` reference
+pointing at the ``load_classic_server_extension`` method: 
+
+.. code-block:: python
+
+    # This is typically defined in the root `__init__.py` 
+    # file of the extension package.
+    load_jupyter_server_extension = MyExtensionApp.load_classic_server_extension
+
+
+If the extension is enabled, the extension will be loaded when the server starts.
+
+
 Distributing a server extension
 ===============================
 

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -13,6 +13,7 @@ from traitlets import (
 )
 from traitlets.config import Config
 from tornado.log import LogFormatter
+from tornado.web import RedirectHandler
 
 from jupyter_core.application import JupyterApp
 
@@ -20,7 +21,6 @@ from jupyter_server.serverapp import ServerApp
 from jupyter_server.transutils import _
 from jupyter_server.utils import url_path_join
 from .handler import ExtensionHandlerMixin
-
 
 # -----------------------------------------------------------------------------
 # Util functions and classes.
@@ -421,6 +421,36 @@ class ExtensionApp(JupyterApp):
             extension._link_jupyter_server_extension(serverapp)
         extension.initialize()
         return extension
+
+    @classmethod
+    def load_classic_server_extension(cls, serverapp):
+        """Enables extension to be loaded as classic Notebook (jupyter/notebook) extension.
+        """
+        extension = cls()
+        extension.serverapp = serverapp
+        extension.load_config_file()
+        extension.update_config(serverapp.config)
+        extension.parse_command_line(serverapp.extra_args)
+        # Add redirects to get favicons from old locations in the classic notebook server
+        extension.handlers.extend([
+            (r"/static/favicons/favicon.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon.ico")}),
+            (r"/static/favicons/favicon-busy-1.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon-busy-1.ico")}),
+            (r"/static/favicons/favicon-busy-2.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon-busy-2.ico")}),
+            (r"/static/favicons/favicon-busy-3.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon-busy-3.ico")}),
+            (r"/static/favicons/favicon-file.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon-file.ico")}),
+            (r"/static/favicons/favicon-notebook.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon-notebook.ico")}),
+            (r"/static/favicons/favicon-terminal.ico", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/favicon-terminal.ico")}),
+            (r"/static/logo/logo.png", RedirectHandler,
+                {"url": url_path_join(serverapp.base_url, "static/base/images/logo.png")}),
+        ])
+        extension.initialize()
 
     @classmethod
     def launch_instance(cls, argv=None, **kwargs):


### PR DESCRIPTION
While working on JupyterLab + Jupyter Server integration, I found that we can make the (new) ExtensionApp work with the old Jupyter Notebook server with this slim chunk of boilerplate code. I suspect that this might be helpful for other applications looking to transition to Jupyter Server. This chunk handles redirects needed, since some static files have moved between Notebook Server and Jupyter Server.

I've also added a short section to the documentation to highlight this useful function.