### PR TITLE
feat: add option to replace traceback on errors

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -131,6 +131,18 @@ class MappingKernelManager(MultiKernelManager):
         """
     )
 
+    allow_tracebacks = Bool(True, config=True, help=(
+        'Whether to send tracebacks to clients on exceptions.'
+    ))
+
+    traceback_replacement_message = Unicode(
+        'An exception occurred at runtime, which is not shown due to security reasons.',
+        config=True,
+        help=(
+            'Message to print when allow_tracebacks is False, and an exception occurs'
+        )
+    )
+
     #-------------------------------------------------------------------------
     # Methods for managing kernels and sessions
     #-------------------------------------------------------------------------


### PR DESCRIPTION
Showing a traceback can be a security risk in a context such as Voila.
(for instance showing paths, usernames or values in the exception message)

Similar to what we do at notebook execution time at:
https://github.com/voila-dashboards/voila/pull/758

here we also disable the transfer of tracebacks at runtime.

cc @SylvainCorlay @mariobuikhuizen 