### PR TITLE
Add wasm mime override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ __pycache__
 .DS_Store
 \#*#
 .#*
-.coverage
+.coverage*
 .pytest_cache
 src
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1519,6 +1519,8 @@ class ServerApp(JupyterApp):
         # ensure css, js are correct, which are required for pages to function
         mimetypes.add_type('text/css', '.css')
         mimetypes.add_type('application/javascript', '.js')
+        # for python <3.8
+        mimetypes.add_type('application/wasm', '.wasm')
 
     def shutdown_no_activity(self):
         """Shutdown server on timeout when there are no kernels or terminals."""


### PR DESCRIPTION
Python <3.8 doesn't know how to guess the `.wasm` mimetype, and the browsers are _real particular_ about it. This PR just adds it to the existing patches, without any complicated version detecting. I started writing a test, and ran into some cross-device nonsense, but upon reflection, decided it's probably not worth it. :stuck_out_tongue_closed_eyes: 

As the community starts ramping up cool, complex things that use wasm for various nefarious purposes, this will avoid extensions having to do their own patches.