### PR TITLE
Switch fixtures to use those in pytest-jupyter to avoid collisions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup_args = dict(
     ],
     extras_require = {
         'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'pytest', 'pytest-cov', 'pytest-tornasync',
+                 'pytest', 'pytest-cov', 'pytest-jupyter', 'pytest-tornasync',
                  'pytest-console-scripts', 'ipykernel'],
         'test:sys_platform == "win32"': ['nose-exclude'],
     },

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,9 @@ setup_args = dict(
         "pywin32>=1.0 ; sys_platform == 'win32'"
     ],
     extras_require = {
-        'test': ['nose', 'coverage', 'requests', 'nose_warnings_filters',
-                 'pytest', 'pytest-cov', 'pytest-jupyter', 'pytest-tornasync',
+        'test': ['coverage', 'requests',
+                 'pytest', 'pytest-cov', 'pytest-jupyter',
                  'pytest-console-scripts', 'ipykernel'],
-        'test:sys_platform == "win32"': ['nose-exclude'],
     },
     python_requires = '>=3.6',
     entry_points = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,0 @@
-pytest_plugins = ['pytest_jupyter_server']

--- a/tests/extension/conftest.py
+++ b/tests/extension/conftest.py
@@ -26,19 +26,19 @@ mock_html = """
 
 
 @pytest.fixture
-def mock_template(template_dir):
-    index = template_dir.joinpath('index.html')
+def mock_template(jp_template_dir):
+    index = jp_template_dir.joinpath('index.html')
     index.write_text(mock_html)
 
 
 @pytest.fixture
-def extension_manager(serverapp):
-    return serverapp.extension_manager
+def extension_manager(jp_serverapp):
+    return jp_serverapp.extension_manager
 
 
 @pytest.fixture
-def config_file(config_dir):
+def config_file(jp_config_dir):
     """"""
-    f = config_dir.joinpath("jupyter_mockextension_config.py")
+    f = jp_config_dir.joinpath("jupyter_mockextension_config.py")
     f.write_text("c.MockExtensionApp.mock_trait ='config from file'")
     return f

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -3,7 +3,7 @@ from jupyter_server.serverapp import ServerApp
 
 
 @pytest.fixture
-def server_config(template_dir):
+def jp_server_config(jp_template_dir):
     config = {
         "ServerApp": {
             "jpserver_extensions": {
@@ -12,7 +12,7 @@ def server_config(template_dir):
         },
         "MockExtensionApp": {
             "template_paths": [
-                str(template_dir)
+                str(jp_template_dir)
             ],
             "log_level": 'DEBUG'
         }
@@ -29,27 +29,28 @@ def mock_extension(extension_manager):
     return app
 
 
-def test_initialize(serverapp, template_dir, mock_extension):
+def test_initialize(jp_serverapp, jp_template_dir, mock_extension):
     # Check that settings and handlers were added to the mock extension.
     assert isinstance(mock_extension.serverapp, ServerApp)
     assert len(mock_extension.handlers) > 0
     assert mock_extension.loaded
-    assert mock_extension.template_paths == [str(template_dir)]
+    assert mock_extension.template_paths == [str(jp_template_dir)]
 
 
 @pytest.mark.parametrize(
-    'trait_name, trait_value, argv',
+    'trait_name, trait_value, jp_argv',
     (
         [
             'mock_trait',
             'test mock trait',
-            ['--MockExtensionApp.mock_trait="test mock trait"']
+            ['--MockExtensionApp.mock_trait=test mock trait']
         ],
     )
 )
 def test_instance_creation_with_argv(
     trait_name,
     trait_value,
+    jp_argv,
     mock_extension,
 ):
     assert getattr(mock_extension, trait_name) == trait_value
@@ -57,12 +58,12 @@ def test_instance_creation_with_argv(
 
 def test_extensionapp_load_config_file(
     config_file,
-    serverapp,
+    jp_serverapp,
     mock_extension,
 ):
     # Assert default config_file_paths is the same in the app and extension.
-    assert mock_extension.config_file_paths == serverapp.config_file_paths
-    assert mock_extension.config_dir == serverapp.config_dir
+    assert mock_extension.config_file_paths == jp_serverapp.config_file_paths
+    assert mock_extension.config_dir == jp_serverapp.config_dir
     assert mock_extension.config_file_name == 'jupyter_mockextension_config'
     # Assert that the trait is updated by config file
     assert mock_extension.mock_trait == 'config from file'

--- a/tests/extension/test_config.py
+++ b/tests/extension/test_config.py
@@ -8,13 +8,13 @@ from jupyter_server.extension.config import (
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
 # that's not cross contaminating the user config directory.
-pytestmark = pytest.mark.usefixtures("environ")
+pytestmark = pytest.mark.usefixtures("jp_environ")
 
 
 @pytest.fixture
-def configd(env_config_path):
+def configd(jp_env_config_path):
     """A pathlib.Path object that acts like a jupyter_server_config.d folder."""
-    configd = env_config_path.joinpath('jupyter_server_config.d')
+    configd = jp_env_config_path.joinpath('jupyter_server_config.d')
     configd.mkdir()
     return configd
 

--- a/tests/extension/test_entrypoint.py
+++ b/tests/extension/test_entrypoint.py
@@ -6,7 +6,7 @@ import pytest
 pytestmark = pytest.mark.script_launch_mode('subprocess')
 
 
-def test_server_extension_list(environ, script_runner):
+def test_server_extension_list(jp_environ, script_runner):
     ret = script_runner.run(
         'jupyter',
         'server',

--- a/tests/extension/test_handler.py
+++ b/tests/extension/test_handler.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def server_config(template_dir):
+def jp_server_config(jp_template_dir):
     return {
             "ServerApp": {
                 "jpserver_extensions": {
@@ -11,14 +11,14 @@ def server_config(template_dir):
             },
             "MockExtensionApp": {
                 "template_paths": [
-                    str(template_dir)
+                    str(jp_template_dir)
                 ]
             }
         }
 
 
-async def test_handler(fetch):
-    r = await fetch(
+async def test_handler(jp_fetch):
+    r = await jp_fetch(
         'mock',
         method='GET'
     )
@@ -26,8 +26,8 @@ async def test_handler(fetch):
     assert r.body.decode() == 'mock trait'
 
 
-async def test_handler_template(fetch, mock_template):
-    r = await fetch(
+async def test_handler_template(jp_fetch, mock_template):
+    r = await jp_fetch(
         'mock_template',
         method='GET'
     )
@@ -35,7 +35,7 @@ async def test_handler_template(fetch, mock_template):
 
 
 @pytest.mark.parametrize(
-    'server_config',
+    'jp_server_config',
     [
         {
             "ServerApp": {
@@ -51,9 +51,9 @@ async def test_handler_template(fetch, mock_template):
         }
     ]
 )
-async def test_handler_setting(fetch):
+async def test_handler_setting(jp_fetch):
     # Test that the extension trait was picked up by the webapp.
-    r = await fetch(
+    r = await jp_fetch(
         'mock',
         method='GET'
     )
@@ -62,11 +62,11 @@ async def test_handler_setting(fetch):
 
 
 @pytest.mark.parametrize(
-    'argv', (['--MockExtensionApp.mock_trait="test mock trait"'],)
+    'jp_argv', (['--MockExtensionApp.mock_trait=test mock trait'],)
 )
-async def test_handler_argv(fetch):
+async def test_handler_argv(jp_fetch):
     # Test that the extension trait was picked up by the webapp.
-    r = await fetch(
+    r = await jp_fetch(
         'mock',
         method='GET'
     )
@@ -75,7 +75,7 @@ async def test_handler_argv(fetch):
 
 
 @pytest.mark.parametrize(
-    'server_config',
+    'jp_server_config',
     [
         {
             "ServerApp": {
@@ -93,9 +93,9 @@ async def test_handler_argv(fetch):
         }
     ]
 )
-async def test_base_url(fetch):
+async def test_base_url(jp_fetch):
     # Test that the extension's handlers were properly prefixed
-    r = await fetch(
+    r = await jp_fetch(
         'test_prefix', 'mock',
         method='GET'
     )
@@ -103,7 +103,7 @@ async def test_base_url(fetch):
     assert r.body.decode() == 'test mock trait'
 
     # Test that the static namespace was prefixed by base_url
-    r = await fetch(
+    r = await jp_fetch(
         'test_prefix',
         'static', 'mockextension', 'mock.txt',
         method='GET'

--- a/tests/extension/test_manager.py
+++ b/tests/extension/test_manager.py
@@ -10,7 +10,7 @@ from jupyter_server.extension.manager import (
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
 # that's not cross contaminating the user config directory.
-pytestmark = pytest.mark.usefixtures("environ")
+pytestmark = pytest.mark.usefixtures("jp_environ")
 
 
 def test_extension_point_api():
@@ -76,9 +76,9 @@ def test_extension_manager_api():
     assert "tests.extension.mockextensions" in manager.extensions
 
 
-def test_extension_manager_linked_extensions(serverapp):
+def test_extension_manager_linked_extensions(jp_serverapp):
     name = "tests.extension.mockextensions"
     manager = ExtensionManager()
     manager.add_extension(name, enabled=True)
-    manager.link_extension(name, serverapp)
+    manager.link_extension(name, jp_serverapp)
     assert name in manager.linked_extensions

--- a/tests/extension/test_serverextension.py
+++ b/tests/extension/test_serverextension.py
@@ -12,7 +12,7 @@ from jupyter_server.config_manager import BaseJSONConfigManager
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
 # that's not cross contaminating the user config directory.
-pytestmark = pytest.mark.usefixtures("environ")
+pytestmark = pytest.mark.usefixtures("jp_environ")
 
 
 def test_help_output():
@@ -29,13 +29,13 @@ def get_config(sys_prefix=True):
     return data.get("ServerApp", {}).get("jpserver_extensions", {})
 
 
-def test_enable(env_config_path, extension_environ):
+def test_enable(jp_env_config_path, jp_extension_environ):
     toggle_server_extension_python('mock1', True)
     config = get_config()
     assert config['mock1']
 
 
-def test_disable(env_config_path, extension_environ):
+def test_disable(jp_env_config_path, jp_extension_environ):
     toggle_server_extension_python('mock1', True)
     toggle_server_extension_python('mock1', False)
 
@@ -44,9 +44,9 @@ def test_disable(env_config_path, extension_environ):
 
 
 def test_merge_config(
-        env_config_path,
-        configurable_serverapp,
-        extension_environ
+        jp_env_config_path,
+        jp_configurable_serverapp,
+        jp_extension_environ
 ):
     # Toggle each extension module with a JSON config file
     # at the sys-prefix config dir.
@@ -80,8 +80,8 @@ def test_merge_config(
     )
 
     # Enable the last extension, mockext_py, using the CLI interface.
-    app = configurable_serverapp(
-        config_dir=str(env_config_path),
+    app = jp_configurable_serverapp(
+        config_dir=str(jp_env_config_path),
         argv=[arg]
     )
     # Verify that extensions are enabled and merged in proper order.
@@ -94,7 +94,7 @@ def test_merge_config(
 
 
 @pytest.mark.parametrize(
-    'server_config',
+    'jp_server_config',
     [
         {
             "ServerApp": {
@@ -106,7 +106,7 @@ def test_merge_config(
         }
     ]
 )
-def test_load_ordered(serverapp):
-    assert serverapp.mockII is True, "Mock II should have been loaded"
-    assert serverapp.mockI is True, "Mock I should have been loaded"
-    assert serverapp.mock_shared == 'II', "Mock II should be loaded after Mock I"
+def test_load_ordered(jp_serverapp):
+    assert jp_serverapp.mockII is True, "Mock II should have been loaded"
+    assert jp_serverapp.mockI is True, "Mock I should have been loaded"
+    assert jp_serverapp.mock_shared == 'II', "Mock II should be loaded after Mock I"

--- a/tests/extension/test_utils.py
+++ b/tests/extension/test_utils.py
@@ -5,7 +5,7 @@ from jupyter_server.extension.utils import validate_extension
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
 # that's not cross contaminating the user config directory.
-pytestmark = pytest.mark.usefixtures("environ")
+pytestmark = pytest.mark.usefixtures("jp_environ")
 
 
 def test_validate_extension():

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -28,10 +28,10 @@ b'\x08\xd7c\x90\xfb\xcf\x00\x00\x02\\\x01\x1e.~d\x87\x00\x00\x00\x00IEND\xaeB`\x
 
 
 @pytest.fixture
-def notebook(root_dir):
+def notebook(jp_root_dir):
     # Build sub directory.
-    if not root_dir.joinpath('foo').is_dir():
-        subdir = root_dir / 'foo'
+    if not jp_root_dir.joinpath('foo').is_dir():
+        subdir = jp_root_dir / 'foo'
         subdir.mkdir()
 
     # Build a notebook programmatically.
@@ -51,8 +51,8 @@ def notebook(root_dir):
 
 
 @onlyif_cmds_exist('pandoc')
-async def test_from_file(fetch, notebook):
-    r = await fetch(
+async def test_from_file(jp_fetch, notebook):
+    r = await jp_fetch(
         'nbconvert', 'html', 'foo', 'testnb.ipynb',
         method='GET',
         params={'download': False}
@@ -63,7 +63,7 @@ async def test_from_file(fetch, notebook):
     assert 'Created by test' in r.body.decode()
     assert 'print' in r.body.decode()
 
-    r = await fetch(
+    r = await jp_fetch(
         'nbconvert', 'python', 'foo', 'testnb.ipynb',
         method='GET',
         params={'download': False}
@@ -75,9 +75,9 @@ async def test_from_file(fetch, notebook):
 
 
 @onlyif_cmds_exist('pandoc')
-async def test_from_file_404(fetch, notebook):
+async def test_from_file_404(jp_fetch, notebook):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await fetch(
+        await jp_fetch(
             'nbconvert', 'html', 'foo', 'thisdoesntexist.ipynb',
             method='GET',
             params={'download': False}
@@ -86,8 +86,8 @@ async def test_from_file_404(fetch, notebook):
 
 
 @onlyif_cmds_exist('pandoc')
-async def test_from_file_download(fetch, notebook):
-    r = await fetch(
+async def test_from_file_download(jp_fetch, notebook):
+    r = await jp_fetch(
         'nbconvert', 'python', 'foo', 'testnb.ipynb',
         method='GET',
         params={'download': True}
@@ -98,8 +98,8 @@ async def test_from_file_download(fetch, notebook):
 
 
 @onlyif_cmds_exist('pandoc')
-async def test_from_file_zip(fetch, notebook):
-    r = await fetch(
+async def test_from_file_zip(jp_fetch, notebook):
+    r = await jp_fetch(
         'nbconvert', 'latex', 'foo', 'testnb.ipynb',
         method='GET',
         params={'download': True}
@@ -109,14 +109,14 @@ async def test_from_file_zip(fetch, notebook):
 
 
 @onlyif_cmds_exist('pandoc')
-async def test_from_post(fetch, notebook):
-    r = await fetch(
+async def test_from_post(jp_fetch, notebook):
+    r = await jp_fetch(
         'api/contents/foo/testnb.ipynb',
         method='GET',
     )
     nbmodel = json.loads(r.body.decode())
 
-    r = await fetch(
+    r = await jp_fetch(
         'nbconvert', 'html',
         method='POST',
         body=json.dumps(nbmodel)
@@ -126,7 +126,7 @@ async def test_from_post(fetch, notebook):
     assert 'Created by test' in r.body.decode()
     assert 'print' in r.body.decode()
 
-    r = await fetch(
+    r = await jp_fetch(
         'nbconvert', 'python',
         method='POST',
         body=json.dumps(nbmodel)
@@ -137,14 +137,14 @@ async def test_from_post(fetch, notebook):
 
 
 @onlyif_cmds_exist('pandoc')
-async def test_from_post_zip(fetch, notebook):
-    r = await fetch(
+async def test_from_post_zip(jp_fetch, notebook):
+    r = await jp_fetch(
         'api/contents/foo/testnb.ipynb',
         method='GET',
     )
     nbmodel = json.loads(r.body.decode())
 
-    r = await fetch(
+    r = await jp_fetch(
         'nbconvert', 'latex',
         method='POST',
         body=json.dumps(nbmodel)

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -1,9 +1,5 @@
 # coding: utf-8
-import io
 import json
-import os
-from os.path import join as pjoin
-import shutil
 
 import tornado
 
@@ -12,7 +8,8 @@ from nbformat.v4 import (
     new_notebook, new_markdown_cell, new_code_cell, new_output,
 )
 
-from ipython_genutils.testing.decorators import onlyif_cmds_exist
+from ipython_genutils.py3compat import which
+
 
 from base64 import encodebytes
 
@@ -50,7 +47,9 @@ def notebook(jp_root_dir):
     nbfile.write_text(writes(nb, version=4), encoding='utf-8')
 
 
-@onlyif_cmds_exist('pandoc')
+pytestmark = pytest.mark.skipif(not which('pandoc'), reason="Command 'pandoc' is not available")
+
+
 async def test_from_file(jp_fetch, notebook):
     r = await jp_fetch(
         'nbconvert', 'html', 'foo', 'testnb.ipynb',
@@ -74,7 +73,6 @@ async def test_from_file(jp_fetch, notebook):
     assert 'print(2*6)' in r.body.decode()
 
 
-@onlyif_cmds_exist('pandoc')
 async def test_from_file_404(jp_fetch, notebook):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
@@ -85,7 +83,6 @@ async def test_from_file_404(jp_fetch, notebook):
     assert expected_http_error(e, 404)
 
 
-@onlyif_cmds_exist('pandoc')
 async def test_from_file_download(jp_fetch, notebook):
     r = await jp_fetch(
         'nbconvert', 'python', 'foo', 'testnb.ipynb',
@@ -97,7 +94,6 @@ async def test_from_file_download(jp_fetch, notebook):
     assert 'testnb.py' in content_disposition
 
 
-@onlyif_cmds_exist('pandoc')
 async def test_from_file_zip(jp_fetch, notebook):
     r = await jp_fetch(
         'nbconvert', 'latex', 'foo', 'testnb.ipynb',
@@ -108,7 +104,6 @@ async def test_from_file_zip(jp_fetch, notebook):
     assert '.zip' in r.headers['Content-Disposition']
 
 
-@onlyif_cmds_exist('pandoc')
 async def test_from_post(jp_fetch, notebook):
     r = await jp_fetch(
         'api/contents/foo/testnb.ipynb',
@@ -136,7 +131,6 @@ async def test_from_post(jp_fetch, notebook):
     assert 'print(2*6)'in r.body.decode()
 
 
-@onlyif_cmds_exist('pandoc')
 async def test_from_post_zip(jp_fetch, notebook):
     r = await jp_fetch(
         'api/contents/foo/testnb.ipynb',

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -27,8 +27,8 @@ b'\x08\xd7c\x90\xfb\xcf\x00\x00\x02\\\x01\x1e.~d\x87\x00\x00\x00\x00IEND\xaeB`\x
 @pytest.fixture
 def notebook(jp_root_dir):
     # Build sub directory.
+    subdir = jp_root_dir / 'foo'
     if not jp_root_dir.joinpath('foo').is_dir():
-        subdir = jp_root_dir / 'foo'
         subdir.mkdir()
 
     # Build a notebook programmatically.

--- a/tests/services/api/test_api.py
+++ b/tests/services/api/test_api.py
@@ -1,13 +1,13 @@
 import json
 
 
-async def test_get_spec(fetch):
-    response = await fetch("api", "spec.yaml", method="GET")
+async def test_get_spec(jp_fetch):
+    response = await jp_fetch("api", "spec.yaml", method="GET")
     assert response.code == 200
 
 
-async def test_get_status(fetch):
-    response = await fetch("api", "status", method="GET")
+async def test_get_status(jp_fetch):
+    response = await jp_fetch("api", "status", method="GET")
     assert response.code == 200
     assert response.headers.get("Content-Type") == "application/json"
     status = json.loads(response.body.decode("utf8"))

--- a/tests/services/config/test_api.py
+++ b/tests/services/config/test_api.py
@@ -4,16 +4,16 @@ import pytest
 from jupyter_server.utils import url_path_join
 
 
-async def test_create_retrieve_config(fetch):
+async def test_create_retrieve_config(jp_fetch):
     sample = {'foo': 'bar', 'baz': 73}
-    response = await fetch(
+    response = await jp_fetch(
         'api', 'config', 'example',
         method='PUT',
         body=json.dumps(sample)
     )
     assert response.code == 204
 
-    response2 = await fetch(
+    response2 = await jp_fetch(
         'api', 'config', 'example',
         method='GET',
     )
@@ -21,7 +21,7 @@ async def test_create_retrieve_config(fetch):
     assert json.loads(response2.body.decode()) == sample
 
 
-async def test_modify(fetch):
+async def test_modify(jp_fetch):
     sample = {
         'foo': 'bar', 
         'baz': 73,
@@ -43,13 +43,13 @@ async def test_modify(fetch):
         'sub': {'a': 8, 'd': 9}
     }
 
-    await fetch(
+    await jp_fetch(
         'api', 'config', 'example',
         method='PUT',
         body=json.dumps(sample)
     )
 
-    response2 = await fetch(
+    response2 = await jp_fetch(
         'api', 'config', 'example',
         method='PATCH',
         body=json.dumps(modified_sample)
@@ -59,8 +59,8 @@ async def test_modify(fetch):
     assert json.loads(response2.body.decode()) == diff
     
 
-async def test_get_unknown(fetch):
-    response = await fetch(
+async def test_get_unknown(jp_fetch):
+    response = await jp_fetch(
         'api', 'config', 'nonexistant',
         method='GET',
     )

--- a/tests/services/config/test_api.py
+++ b/tests/services/config/test_api.py
@@ -1,7 +1,4 @@
 import json
-import pytest
-
-from jupyter_server.utils import url_path_join
 
 
 async def test_create_retrieve_config(jp_fetch):

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -100,7 +100,7 @@ async def test_get_dir_no_contents(jp_fetch, contents, path, name):
     assert model['path'] == path
     assert model['type'] == 'directory'
     assert 'content' in model
-    assert model['content'] == None
+    assert model['content'] is None
 
 
 async def test_list_nonexistant_dir(jp_fetch, contents):
@@ -144,7 +144,7 @@ async def test_get_nb_no_contents(jp_fetch, contents, path, name):
     assert model['path'] == nbpath
     assert model['type'] == 'notebook'
     assert 'content' in model
-    assert model['content'] == None
+    assert model['content'] is None
 
 
 async def test_get_nb_invalid(contents_dir, jp_fetch, contents):
@@ -623,7 +623,7 @@ async def test_checkpoints_follow_file(jp_fetch, contents):
     hcell = new_markdown_cell('Created by test')
     nb.cells.append(hcell)
     nbmodel = {'content': nb, 'type': 'notebook'}
-    r = await jp_fetch(
+    await jp_fetch(
         'api', 'contents', path, name,
         method='PUT',
         body=json.dumps(nbmodel)
@@ -653,7 +653,7 @@ async def test_rename_existing(jp_fetch, contents):
         name = 'a.ipynb'
         new_name = 'b.ipynb'
         # Rename the file
-        r = await jp_fetch(
+        await jp_fetch(
             'api', 'contents', path, name,
             method='PATCH',
             body=json.dumps({'path': path+'/'+new_name})
@@ -671,7 +671,7 @@ async def test_save(jp_fetch, contents):
     nb = from_dict(nbmodel)
     nb.cells.append(new_markdown_cell('Created by test ³'))
     nbmodel = {'content': nb, 'type': 'notebook'}
-    r = await jp_fetch(
+    await jp_fetch(
         'api', 'contents', 'foo/a.ipynb',
         method='PUT',
         body=json.dumps(nbmodel)
@@ -711,7 +711,7 @@ async def test_checkpoints(jp_fetch, contents):
 
     # Save it.
     nbmodel = {'content': nb, 'type': 'notebook'}
-    resp = await jp_fetch(
+    await jp_fetch(
         'api', 'contents', path,
         method='PUT',
         body=json.dumps(nbmodel)
@@ -790,7 +790,7 @@ async def test_file_checkpoints(jp_fetch, contents):
     }
 
     # Save it.
-    resp = await jp_fetch(
+    await jp_fetch(
         'api', 'contents', path,
         method='PUT',
         body=json.dumps(model)

--- a/tests/services/contents/test_config.py
+++ b/tests/services/contents/test_config.py
@@ -5,9 +5,9 @@ from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoi
 
 
 @pytest.fixture
-def server_config():
+def jp_server_config():
     return {'FileContentsManager': {'checkpoints_class': GenericFileCheckpoints}}
 
 
-def test_config_did_something(serverapp):
-    assert isinstance(serverapp.contents_manager.checkpoints, GenericFileCheckpoints)
+def test_config_did_something(jp_serverapp):
+    assert isinstance(jp_serverapp.contents_manager.checkpoints, GenericFileCheckpoints)

--- a/tests/services/contents/test_fileio.py
+++ b/tests/services/contents/test_fileio.py
@@ -2,12 +2,10 @@ import io
 import os
 import stat
 import functools
-import decorator 
-
+import decorator
 import pytest
-
+import sys
 from ipython_genutils.testing.decorators import skip_win32 as _skip_win32
-from ipython_genutils.testing.decorators import skip_if_not_win32 as _skip_if_not_win32
 
 from jupyter_server.services.contents.fileio import atomic_writing
 
@@ -81,7 +79,7 @@ def handle_umask():
     os.umask(umask)
 
 
-@skip_win32
+@pytest.mark.skipif(sys.platform.startswith('win'), reason="Windows")
 def test_atomic_writing_umask(handle_umask, tmp_path):
 
     os.umask(0o022)

--- a/tests/services/contents/test_largefilemanager.py
+++ b/tests/services/contents/test_largefilemanager.py
@@ -1,14 +1,11 @@
 import pytest
 import tornado
 
-from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from ...utils import expected_http_error
 
-contents_manager = pytest.fixture(lambda tmp_path: LargeFileManager(root_dir=str(tmp_path)))
 
-
-def test_save(contents_manager):
-    cm = contents_manager
+def test_save(jp_large_contents_manager):
+    cm = jp_large_contents_manager
     model = cm.new_untitled(type='notebook')
     name = model['name']
     path = model['path']
@@ -46,14 +43,14 @@ def test_save(contents_manager):
         )
     ]
 )
-def test_bad_save(contents_manager, model, err_message):
+def test_bad_save(jp_large_contents_manager, model, err_message):
     with pytest.raises(tornado.web.HTTPError) as e:
-        contents_manager.save(model, model['path'])
+        jp_large_contents_manager.save(model, model['path'])
     assert expected_http_error(e, 400, expected_message=err_message)
 
 
-def test_saving_different_chunks(contents_manager):
-    cm = contents_manager
+def test_saving_different_chunks(jp_large_contents_manager):
+    cm = jp_large_contents_manager
     model = {'name': 'test', 'path': 'test', 'type': 'file',
                 'content': u'test==', 'format': 'text'}
     name = model['name']
@@ -74,8 +71,8 @@ def test_saving_different_chunks(contents_manager):
             assert model_res['path'] == path
 
 
-def test_save_in_subdirectory(contents_manager, tmp_path):
-    cm = contents_manager
+def test_save_in_subdirectory(jp_large_contents_manager, tmp_path):
+    cm = jp_large_contents_manager
     sub_dir = tmp_path / 'foo'
     sub_dir.mkdir()
     model = cm.new_untitled(path='/foo/', type='notebook')

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -15,24 +15,24 @@ from ...utils import expected_http_error
 
 # -------------- Functions ----------------------------
 
-def _make_dir(contents_manager, api_path):
+def _make_dir(jp_contents_manager, api_path):
     """
     Make a directory.
     """
-    os_path = contents_manager._get_os_path(api_path)
+    os_path = jp_contents_manager._get_os_path(api_path)
     try:
         os.makedirs(os_path)
     except OSError:
         print("Directory already exists: %r" % os_path)
 
 
-def symlink(contents_manager, src, dst):
+def symlink(jp_contents_manager, src, dst):
     """Make a symlink to src from dst
 
     src and dst are api_paths
     """
-    src_os_path = contents_manager._get_os_path(src)
-    dst_os_path = contents_manager._get_os_path(dst)
+    src_os_path = jp_contents_manager._get_os_path(src)
+    dst_os_path = jp_contents_manager._get_os_path(dst)
     print(src_os_path, dst_os_path, os.path.isfile(src_os_path))
     os.symlink(src_os_path, dst_os_path)
 
@@ -43,8 +43,8 @@ def add_code_cell(notebook):
     notebook.cells.append(cell)
 
 
-def new_notebook(contents_manager):
-    cm = contents_manager
+def new_notebook(jp_contents_manager):
+    cm = jp_contents_manager
     model = cm.new_untitled(type='notebook')
     name = model['name']
     path = model['path']
@@ -58,15 +58,15 @@ def new_notebook(contents_manager):
     return nb, name, path
 
 
-def make_populated_dir(contents_manager, api_path):
-    cm = contents_manager
+def make_populated_dir(jp_contents_manager, api_path):
+    cm = jp_contents_manager
     _make_dir(cm, api_path)
     cm.new(path="/".join([api_path, "nb.ipynb"]))
     cm.new(path="/".join([api_path, "file.txt"]))
 
 
-def check_populated_dir_files(contents_manager, api_path):
-    dir_model = contents_manager.get(api_path)
+def check_populated_dir_files(jp_contents_manager, api_path):
+    dir_model = jp_contents_manager.get(api_path)
 
     assert dir_model['path'] == api_path
     assert dir_model['type'] == "directory"
@@ -231,8 +231,8 @@ def test_escape_root(tmp_path):
     expected_http_error(e, 404)
 
 
-def test_new_untitled(contents_manager):
-    cm = contents_manager
+def test_new_untitled(jp_contents_manager):
+    cm = jp_contents_manager
     # Test in root directory
     model = cm.new_untitled(type='notebook')
     assert isinstance(model, dict)
@@ -270,8 +270,8 @@ def test_new_untitled(contents_manager):
     assert model['name'] == 'untitled1.foo.bar'
 
 
-def test_modified_date(contents_manager):
-    cm = contents_manager
+def test_modified_date(jp_contents_manager):
+    cm = jp_contents_manager
     # Create a new notebook.
     nb, name, path = new_notebook(cm)
     model = cm.get(path)
@@ -293,8 +293,8 @@ def test_modified_date(contents_manager):
     assert renamed['last_modified'] >= saved['last_modified']
 
 
-def test_get(contents_manager):
-    cm = contents_manager
+def test_get(jp_contents_manager):
+    cm = jp_contents_manager
     # Create a notebook
     model = cm.new_untitled(type='notebook')
     name = model['name']
@@ -382,8 +382,8 @@ def test_get(contents_manager):
         cm.get('foo', type='file')
 
 
-def test_update(contents_manager):
-    cm = contents_manager
+def test_update(jp_contents_manager):
+    cm = jp_contents_manager
     # Create a notebook.
     model = cm.new_untitled(type='notebook')
     name = model['name']
@@ -423,8 +423,8 @@ def test_update(contents_manager):
         cm.get(path)
 
 
-def test_save(contents_manager):
-    cm = contents_manager
+def test_save(jp_contents_manager):
+    cm = jp_contents_manager
     # Create a notebook
     model = cm.new_untitled(type='notebook')
     name = model['name']
@@ -459,8 +459,8 @@ def test_save(contents_manager):
     assert model['path'] == 'foo/Untitled.ipynb'
 
 
-def test_delete(contents_manager):
-    cm = contents_manager
+def test_delete(jp_contents_manager):
+    cm = jp_contents_manager
     # Create a notebook
     nb, name, path = new_notebook(cm)
 
@@ -476,8 +476,8 @@ def test_delete(contents_manager):
         cm.get(path)
 
 
-def test_rename(contents_manager):
-    cm = contents_manager
+def test_rename(jp_contents_manager):
+    cm = jp_contents_manager
     # Create a new notebook
     nb, name, path = new_notebook(cm)
 
@@ -528,15 +528,15 @@ def test_rename(contents_manager):
     cm.new_untitled("foo/bar_diff", ext=".ipynb")
 
 
-def test_delete_root(contents_manager):
-    cm = contents_manager
+def test_delete_root(jp_contents_manager):
+    cm = jp_contents_manager
     with pytest.raises(HTTPError) as e:
         cm.delete('')
     assert expected_http_error(e, 400)
 
 
-def test_copy(contents_manager):
-    cm = contents_manager
+def test_copy(jp_contents_manager):
+    cm = jp_contents_manager
     parent = u'å b'
     name = u'nb √.ipynb'
     path = u'{0}/{1}'.format(parent, name)
@@ -557,8 +557,8 @@ def test_copy(contents_manager):
     assert copy2['path'] == name
 
 
-def test_mark_trusted_cells(contents_manager):
-    cm = contents_manager
+def test_mark_trusted_cells(jp_contents_manager):
+    cm = jp_contents_manager
     nb, name, path = new_notebook(cm)
 
     cm.mark_trusted_cells(nb, path)
@@ -573,8 +573,8 @@ def test_mark_trusted_cells(contents_manager):
             assert cell.metadata.trusted
 
 
-def test_check_and_sign(contents_manager):
-    cm = contents_manager
+def test_check_and_sign(jp_contents_manager):
+    cm = jp_contents_manager
     nb, name, path = new_notebook(cm)
 
     cm.mark_trusted_cells(nb, path)

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -183,7 +183,7 @@ async def test_kernel_handler(jp_fetch):
     # Request to delete a non-existent kernel id
     bad_id = '111-111-111-111-111'
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        r = await jp_fetch(
+        await jp_fetch(
             'api', 'kernels', bad_id,
             method='DELETE'
         )

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -159,7 +159,7 @@ async def test_kernel_handler(jp_fetch):
     # Requests a bad kernel id.
     bad_id = '111-111-111-111-111'
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        r = await jp_fetch(
+        await jp_fetch(
             'api', 'kernels', bad_id,
             method='GET'
         )

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -22,8 +22,8 @@ def argv(request):
     return ["--ServerApp.kernel_manager_class=jupyter_server.services.kernels.kernelmanager." + request.param]
 
 
-async def test_no_kernels(fetch):
-    r = await fetch(
+async def test_no_kernels(jp_fetch):
+    r = await jp_fetch(
         'api', 'kernels',
         method='GET'
     )
@@ -31,8 +31,8 @@ async def test_no_kernels(fetch):
     assert kernels == []
 
 
-async def test_default_kernels(fetch):
-    r = await fetch(
+async def test_default_kernels(jp_fetch):
+    r = await jp_fetch(
         'api', 'kernels',
         method='POST',
         allow_nonstandard_methods=True
@@ -51,9 +51,9 @@ async def test_default_kernels(fetch):
     assert r.headers['Content-Security-Policy'] == expected_csp
 
 
-async def test_main_kernel_handler(fetch):
+async def test_main_kernel_handler(jp_fetch):
     # Start the first kernel
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='POST',
         body=json.dumps({
@@ -74,7 +74,7 @@ async def test_main_kernel_handler(fetch):
     assert r.headers['Content-Security-Policy'] == expected_csp
 
     # Check that the kernel is found in the kernel list
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='GET'
     )
@@ -85,7 +85,7 @@ async def test_main_kernel_handler(fetch):
     assert kernel_list[0]['name'] == kernel1['name']
 
     # Start a second kernel
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='POST',
         body=json.dumps({
@@ -96,7 +96,7 @@ async def test_main_kernel_handler(fetch):
     assert isinstance(kernel2, dict)
 
     # Get kernel list again
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='GET'
     )
@@ -106,7 +106,7 @@ async def test_main_kernel_handler(fetch):
     assert len(kernel_list) == 2
 
     # Interrupt a kernel
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kernel2['id'], 'interrupt',
         method='POST',
         allow_nonstandard_methods=True
@@ -114,7 +114,7 @@ async def test_main_kernel_handler(fetch):
     assert r.code == 204
 
     # Restart a kernel
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kernel2['id'], 'restart',
         method='POST',
         allow_nonstandard_methods=True
@@ -124,7 +124,7 @@ async def test_main_kernel_handler(fetch):
     assert restarted_kernel['name'] == kernel2['name']
 
     # Start a kernel with a path
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='POST',
                 body=json.dumps({
@@ -136,9 +136,9 @@ async def test_main_kernel_handler(fetch):
     assert isinstance(kernel3, dict)
 
 
-async def test_kernel_handler(fetch):
+async def test_kernel_handler(jp_fetch):
     # Create a kernel
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='POST',
         body=json.dumps({
@@ -146,7 +146,7 @@ async def test_kernel_handler(fetch):
         })
     )
     kernel_id = json.loads(r.body.decode())['id']
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kernel_id,
         method='GET'
     )
@@ -159,21 +159,21 @@ async def test_kernel_handler(fetch):
     # Requests a bad kernel id.
     bad_id = '111-111-111-111-111'
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels', bad_id,
             method='GET'
         )
     assert expected_http_error(e, 404)
 
     # Delete kernel with id.
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kernel_id,
         method='DELETE',
     )
     assert r.code == 204
 
     # Get list of kernels
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='GET'
     )
@@ -183,17 +183,17 @@ async def test_kernel_handler(fetch):
     # Request to delete a non-existent kernel id
     bad_id = '111-111-111-111-111'
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels', bad_id,
             method='DELETE'
         )
     assert expected_http_error(e, 404, 'Kernel does not exist: ' + bad_id)
 
 
-async def test_connection(fetch, ws_fetch, http_port, auth_header):
+async def test_connection(jp_fetch, jp_ws_fetch, jp_http_port, jp_auth_header):
     print('hello')
     # Create kernel
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels',
         method='POST',
         body=json.dumps({
@@ -203,7 +203,7 @@ async def test_connection(fetch, ws_fetch, http_port, auth_header):
     kid = json.loads(r.body.decode())['id']
 
     # Get kernel info
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kid,
         method='GET'
     )
@@ -212,12 +212,12 @@ async def test_connection(fetch, ws_fetch, http_port, auth_header):
 
     time.sleep(1)
     # Open a websocket connection.
-    ws = await ws_fetch(
+    ws = await jp_ws_fetch(
         'api', 'kernels', kid, 'channels'
     )
 
     # Test that it was opened.
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kid,
         method='GET'
     )
@@ -228,7 +228,7 @@ async def test_connection(fetch, ws_fetch, http_port, auth_header):
     ws.close()
     # give it some time to close on the other side:
     for i in range(10):
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels', kid,
             method='GET'
         )
@@ -238,7 +238,7 @@ async def test_connection(fetch, ws_fetch, http_port, auth_header):
         else:
             break
 
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernels', kid,
         method='GET'
     )

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -5,7 +5,7 @@ from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelMana
 
 
 @pytest.fixture
-def server_config():
+def jp_server_config():
     return Config({
         'ServerApp': {
             'MappingKernelManager': {
@@ -15,12 +15,12 @@ def server_config():
     })
 
 
-def test_config(serverapp):
-    assert serverapp.kernel_manager.allowed_message_types == ['kernel_info_request']
+def test_config(jp_serverapp):
+    assert jp_serverapp.kernel_manager.allowed_message_types == ['kernel_info_request']
 
 
-async def test_async_kernel_manager(configurable_serverapp):
+async def test_async_kernel_manager(jp_configurable_serverapp):
     argv = ['--ServerApp.kernel_manager_class=jupyter_server.services.kernels.kernelmanager.AsyncMappingKernelManager']
-    app = configurable_serverapp(argv=argv)
+    app = jp_configurable_serverapp(argv=argv)
     assert isinstance(app.kernel_manager, AsyncMappingKernelManager)
 

--- a/tests/services/kernelspecs/test_api.py
+++ b/tests/services/kernelspecs/test_api.py
@@ -3,20 +3,20 @@ import json
 
 import tornado
 
-from jupyter_server.pytest_plugin import some_resource
+from pytest_jupyter.jupyter_server import some_resource
 
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
 
 from ...utils import expected_http_error
 
 
-async def test_list_kernelspecs_bad(fetch, kernelspecs, data_dir):
-    bad_kernel_dir = data_dir.joinpath(data_dir, 'kernels', 'bad')
+async def test_list_kernelspecs_bad(jp_fetch, jp_kernelspecs, jp_data_dir):
+    bad_kernel_dir = jp_data_dir.joinpath(jp_data_dir, 'kernels', 'bad')
     bad_kernel_dir.mkdir(parents=True)
     bad_kernel_json = bad_kernel_dir.joinpath('kernel.json')
     bad_kernel_json.write_text('garbage')
 
-    r = await fetch(
+    r = await jp_fetch(
         'api', 'kernelspecs',
         method='GET'
     )
@@ -28,8 +28,8 @@ async def test_list_kernelspecs_bad(fetch, kernelspecs, data_dir):
     assert len(specs) > 2
 
 
-async def test_list_kernelspecs(fetch, kernelspecs):
-    r = await fetch(
+async def test_list_kernelspecs(jp_fetch, jp_kernelspecs):
+    r = await jp_fetch(
         'api', 'kernelspecs',
         method='GET'
     )
@@ -50,8 +50,8 @@ async def test_list_kernelspecs(fetch, kernelspecs):
     assert any(is_default_kernelspec(s) for s in specs.values()), specs
 
 
-async def test_get_kernelspecs(fetch, kernelspecs):
-    r = await fetch(
+async def test_get_kernelspecs(jp_fetch, jp_kernelspecs):
+    r = await jp_fetch(
         'api', 'kernelspecs', 'Sample',
         method='GET'
     )
@@ -62,8 +62,8 @@ async def test_get_kernelspecs(fetch, kernelspecs):
     assert isinstance(model['resources'], dict)
 
 
-async def test_get_kernelspec_spaces(fetch, kernelspecs):
-    r = await fetch(
+async def test_get_kernelspec_spaces(jp_fetch, jp_kernelspecs):
+    r = await jp_fetch(
         'api', 'kernelspecs', 'sample%202',
         method='GET'
     )
@@ -71,17 +71,17 @@ async def test_get_kernelspec_spaces(fetch, kernelspecs):
     assert model['name'].lower() == 'sample 2'
 
 
-async def test_get_nonexistant_kernelspec(fetch, kernelspecs):
+async def test_get_nonexistant_kernelspec(jp_fetch, jp_kernelspecs):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await fetch(
+        await jp_fetch(
             'api', 'kernelspecs', 'nonexistant',
             method='GET'
         )
     assert expected_http_error(e, 404)
 
 
-async def test_get_kernel_resource_file(fetch, kernelspecs):
-    r = await fetch(
+async def test_get_kernel_resource_file(jp_fetch, jp_kernelspecs):
+    r = await jp_fetch(
         'kernelspecs', 'sAmple', 'resource.txt',
         method='GET'
     )
@@ -89,16 +89,16 @@ async def test_get_kernel_resource_file(fetch, kernelspecs):
     assert res == some_resource
 
 
-async def test_get_nonexistant_resource(fetch, kernelspecs):
+async def test_get_nonexistant_resource(jp_fetch, jp_kernelspecs):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await fetch(
+        await jp_fetch(
             'kernelspecs', 'nonexistant', 'resource.txt',
             method='GET'
         )
     assert expected_http_error(e, 404)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await fetch(
+        await jp_fetch(
             'kernelspecs', 'sample', 'nonexistant.txt',
             method='GET'
         )

--- a/tests/services/nbconvert/test_api.py
+++ b/tests/services/nbconvert/test_api.py
@@ -1,5 +1,4 @@
 import json
-import pytest
 
 async def test_list_formats(jp_fetch):
     r = await jp_fetch(

--- a/tests/services/nbconvert/test_api.py
+++ b/tests/services/nbconvert/test_api.py
@@ -1,5 +1,6 @@
 import json
 
+
 async def test_list_formats(jp_fetch):
     r = await jp_fetch(
         'api', 'nbconvert',

--- a/tests/services/nbconvert/test_api.py
+++ b/tests/services/nbconvert/test_api.py
@@ -1,8 +1,8 @@
 import json
 import pytest
 
-async def test_list_formats(fetch):
-    r = await fetch(
+async def test_list_formats(jp_fetch):
+    r = await jp_fetch(
         'api', 'nbconvert',
         method='GET'
     )

--- a/tests/services/sessions/test_api.py
+++ b/tests/services/sessions/test_api.py
@@ -24,13 +24,13 @@ def argv(request):
 class SessionClient:
 
     def __init__(self, fetch_callable):
-        self.fetch = fetch_callable
+        self.jp_fetch = fetch_callable
 
     async def _req(self, *args, method, body=None):
         if body is not None:
             body = json.dumps(body)
 
-        r = await self.fetch(
+        r = await self.jp_fetch(
             'api', 'sessions', *args,
             method=method,
             body=body,
@@ -106,8 +106,8 @@ class SessionClient:
 
 
 @pytest.fixture
-def session_client(root_dir, fetch):
-    subdir = root_dir.joinpath('foo')
+def session_client(jp_root_dir, jp_fetch):
+    subdir = jp_root_dir.joinpath('foo')
     subdir.mkdir()
 
     # Write a notebook to subdir.
@@ -117,7 +117,7 @@ def session_client(root_dir, fetch):
     nbpath.write_text(nb_str, encoding='utf-8')
 
     # Yield a session client
-    client = SessionClient(fetch)
+    client = SessionClient(jp_fetch)
     yield client
 
     # Remove subdir
@@ -209,9 +209,9 @@ async def test_create_deprecated(session_client):
     await session_client.cleanup()
 
 
-async def test_create_with_kernel_id(session_client, fetch):
+async def test_create_with_kernel_id(session_client, jp_fetch):
     # create a new kernel
-    resp = await fetch('api/kernels', method='POST', allow_nonstandard_methods=True)
+    resp = await jp_fetch('api/kernels', method='POST', allow_nonstandard_methods=True)
     kernel = j(resp)
 
     resp = await session_client.create('foo/nb1.ipynb', kernel_id=kernel['id'])
@@ -289,7 +289,7 @@ async def test_modify_type(session_client):
     # Need to find a better solution to this.
     await session_client.cleanup()
 
-async def test_modify_kernel_name(session_client, fetch):
+async def test_modify_kernel_name(session_client, jp_fetch):
     resp = await session_client.create('foo/nb1.ipynb')
     before = j(resp)
     sid = before['id']
@@ -302,7 +302,7 @@ async def test_modify_kernel_name(session_client, fetch):
     assert after['kernel']['id'] != before['kernel']['id']
 
     # check kernel list, to be sure previous kernel was cleaned up
-    resp = await fetch('api/kernels', method='GET')
+    resp = await jp_fetch('api/kernels', method='GET')
     kernel_list = j(resp)
     after['kernel'].pop('last_activity')
     [ k.pop('last_activity') for k in kernel_list ]
@@ -311,13 +311,13 @@ async def test_modify_kernel_name(session_client, fetch):
     await session_client.cleanup()
 
 
-async def test_modify_kernel_id(session_client, fetch):
+async def test_modify_kernel_id(session_client, jp_fetch):
     resp = await session_client.create('foo/nb1.ipynb')
     before = j(resp)
     sid = before['id']
 
     # create a new kernel
-    resp = await fetch('api/kernels', method='POST', allow_nonstandard_methods=True)
+    resp = await jp_fetch('api/kernels', method='POST', allow_nonstandard_methods=True)
     kernel = j(resp)
 
     # Attach our session to the existing kernel
@@ -330,7 +330,7 @@ async def test_modify_kernel_id(session_client, fetch):
     assert after['kernel']['id'] == kernel['id']
 
     # check kernel list, to be sure previous kernel was cleaned up
-    resp = await fetch('api/kernels', method='GET')
+    resp = await jp_fetch('api/kernels', method='GET')
     kernel_list = j(resp)
 
     kernel.pop('last_activity')

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -22,15 +22,12 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
     dirs = not_hidden + hidden
 
     for d in dirs:
-        path  = jp_root_dir / d.replace('/', os.sep)
+        path = jp_root_dir / d.replace('/', os.sep)
         path.mkdir(parents=True, exist_ok=True)
         path.joinpath('foo').write_text('foo')
         path.joinpath('.foo').write_text('.foo')
 
-
     for d in not_hidden:
-        path = jp_root_dir / d.replace('/', os.sep)
-
         r = await jp_fetch(
             'files', d, 'foo',
             method='GET'
@@ -44,9 +41,7 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
             )
         assert expected_http_error(e, 404)
 
-
     for d in hidden:
-        path = jp_root_dir / d.replace('/', os.sep)
         for foo in ('foo', '.foo'):
             with pytest.raises(tornado.httpclient.HTTPClientError) as e:
                 r = await jp_fetch(
@@ -58,8 +53,6 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
     jp_serverapp.contents_manager.allow_hidden = True
 
     for d in not_hidden:
-        path = jp_root_dir / d.replace('/', os.sep)
-
         r = await jp_fetch(
             'files', d, 'foo',
             method='GET'
@@ -72,15 +65,13 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
         )
         assert r.body.decode() == '.foo'
 
-        for d in hidden:
-            path = jp_root_dir / d.replace('/', os.sep)
-
-            for foo in ('foo', '.foo'):
-                r = await jp_fetch(
-                    'files', d, foo,
-                    method='GET'
-                )
-                assert r.body.decode() == foo
+    for d in hidden:
+        for foo in ('foo', '.foo'):
+            r = await jp_fetch(
+                'files', d, foo,
+                method='GET'
+            )
+            assert r.body.decode() == foo
 
 
 async def test_contents_manager(jp_fetch, jp_serverapp, jp_root_dir):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -35,7 +35,7 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
         assert r.body.decode() == 'foo'
 
         with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-            r = await jp_fetch(
+            await jp_fetch(
                 'files', d, '.foo',
                 method='GET'
             )
@@ -44,7 +44,7 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
     for d in hidden:
         for foo in ('foo', '.foo'):
             with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-                r = await jp_fetch(
+                await jp_fetch(
                     'files', d, foo,
                     method='GET'
                 )
@@ -75,7 +75,7 @@ async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
 
 
 async def test_contents_manager(jp_fetch, jp_serverapp, jp_root_dir):
-    "make sure ContentsManager returns right files (ipynb, bin, txt)."
+    """make sure ContentsManager returns right files (ipynb, bin, txt)."""
     nb = new_notebook(
         cells=[
             new_markdown_cell(u'Created by test ³'),
@@ -138,7 +138,6 @@ async def test_old_files_redirect(jp_fetch, jp_serverapp, jp_root_dir):
     """pre-2.0 'files/' prefixed links are properly redirected"""
     jp_root_dir.joinpath('files').mkdir(parents=True, exist_ok=True)
     jp_root_dir.joinpath('sub', 'files').mkdir(parents=True, exist_ok=True)
-
 
     for prefix in ('', 'sub'):
         jp_root_dir.joinpath(prefix, 'files', 'f1.txt').write_text(prefix + '/files/f1')

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -10,7 +10,7 @@ from nbformat.v4 import (new_notebook,
                          new_output)
 
 
-async def test_hidden_files(fetch, serverapp, root_dir):
+async def test_hidden_files(jp_fetch, jp_serverapp, jp_root_dir):
     not_hidden = [
         u'å b',
         u'å b/ç. d',
@@ -22,23 +22,23 @@ async def test_hidden_files(fetch, serverapp, root_dir):
     dirs = not_hidden + hidden
 
     for d in dirs:
-        path  = root_dir / d.replace('/', os.sep)
+        path  = jp_root_dir / d.replace('/', os.sep)
         path.mkdir(parents=True, exist_ok=True)
         path.joinpath('foo').write_text('foo')
         path.joinpath('.foo').write_text('.foo')
 
 
     for d in not_hidden:
-        path = root_dir / d.replace('/', os.sep)
+        path = jp_root_dir / d.replace('/', os.sep)
 
-        r = await fetch(
+        r = await jp_fetch(
             'files', d, 'foo',
             method='GET'
         )
         assert r.body.decode() == 'foo'
 
         with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-            r = await fetch(
+            r = await jp_fetch(
                 'files', d, '.foo',
                 method='GET'
             )
@@ -46,44 +46,44 @@ async def test_hidden_files(fetch, serverapp, root_dir):
 
 
     for d in hidden:
-        path = root_dir / d.replace('/', os.sep)
+        path = jp_root_dir / d.replace('/', os.sep)
         for foo in ('foo', '.foo'):
             with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-                r = await fetch(
+                r = await jp_fetch(
                     'files', d, foo,
                     method='GET'
                 )
             assert expected_http_error(e, 404)
 
-    serverapp.contents_manager.allow_hidden = True
+    jp_serverapp.contents_manager.allow_hidden = True
 
     for d in not_hidden:
-        path = root_dir / d.replace('/', os.sep)
+        path = jp_root_dir / d.replace('/', os.sep)
 
-        r = await fetch(
+        r = await jp_fetch(
             'files', d, 'foo',
             method='GET'
         )
         assert r.body.decode() == 'foo'
 
-        r = await fetch(
+        r = await jp_fetch(
             'files', d, '.foo',
             method='GET'
         )
         assert r.body.decode() == '.foo'
 
         for d in hidden:
-            path = root_dir / d.replace('/', os.sep)
+            path = jp_root_dir / d.replace('/', os.sep)
 
             for foo in ('foo', '.foo'):
-                r = await fetch(
+                r = await jp_fetch(
                     'files', d, foo,
                     method='GET'
                 )
                 assert r.body.decode() == foo
 
 
-async def test_contents_manager(fetch, serverapp, root_dir):
+async def test_contents_manager(jp_fetch, jp_serverapp, jp_root_dir):
     "make sure ContentsManager returns right files (ipynb, bin, txt)."
     nb = new_notebook(
         cells=[
@@ -93,18 +93,18 @@ async def test_contents_manager(fetch, serverapp, root_dir):
             ])
         ]
     )
-    root_dir.joinpath('testnb.ipynb').write_text(writes(nb, version=4), encoding='utf-8')
-    root_dir.joinpath('test.bin').write_bytes(b'\xff' + os.urandom(5))
-    root_dir.joinpath('test.txt').write_text('foobar')
+    jp_root_dir.joinpath('testnb.ipynb').write_text(writes(nb, version=4), encoding='utf-8')
+    jp_root_dir.joinpath('test.bin').write_bytes(b'\xff' + os.urandom(5))
+    jp_root_dir.joinpath('test.txt').write_text('foobar')
 
-    r = await fetch(
+    r = await jp_fetch(
         'files/testnb.ipynb',
         method='GET'
     )
     assert r.code == 200
     assert 'print(2*6)' in r.body.decode('utf-8')
 
-    r = await fetch(
+    r = await jp_fetch(
         'files/test.bin',
         method='GET'
     )
@@ -113,7 +113,7 @@ async def test_contents_manager(fetch, serverapp, root_dir):
     assert r.body[:1] == b'\xff'
     assert len(r.body) == 6
 
-    r = await fetch(
+    r = await jp_fetch(
         'files/test.txt',
         method='GET'
     )
@@ -122,18 +122,18 @@ async def test_contents_manager(fetch, serverapp, root_dir):
     assert r.body.decode() == 'foobar'
 
 
-async def test_download(fetch, serverapp, root_dir):
+async def test_download(jp_fetch, jp_serverapp, jp_root_dir):
     text = 'hello'
-    root_dir.joinpath('test.txt').write_text(text)
+    jp_root_dir.joinpath('test.txt').write_text(text)
 
-    r = await fetch(
+    r = await jp_fetch(
         'files', 'test.txt',
         method='GET'
     )
     disposition = r.headers.get('Content-Disposition', '')
     assert 'attachment' not in disposition
 
-    r = await fetch(
+    r = await jp_fetch(
         'files', 'test.txt',
         method='GET',
         params={'download': True}
@@ -143,17 +143,17 @@ async def test_download(fetch, serverapp, root_dir):
     assert "filename*=utf-8''test.txt" in disposition
 
 
-async def test_old_files_redirect(fetch, serverapp, root_dir):
+async def test_old_files_redirect(jp_fetch, jp_serverapp, jp_root_dir):
     """pre-2.0 'files/' prefixed links are properly redirected"""
-    root_dir.joinpath('files').mkdir(parents=True, exist_ok=True)
-    root_dir.joinpath('sub', 'files').mkdir(parents=True, exist_ok=True)
+    jp_root_dir.joinpath('files').mkdir(parents=True, exist_ok=True)
+    jp_root_dir.joinpath('sub', 'files').mkdir(parents=True, exist_ok=True)
 
 
     for prefix in ('', 'sub'):
-        root_dir.joinpath(prefix, 'files', 'f1.txt').write_text(prefix + '/files/f1')
-        root_dir.joinpath(prefix, 'files', 'f2.txt').write_text(prefix + '/files/f2')
-        root_dir.joinpath(prefix, 'f2.txt').write_text(prefix + '/f2')
-        root_dir.joinpath(prefix, 'f3.txt').write_text(prefix + '/f3')
+        jp_root_dir.joinpath(prefix, 'files', 'f1.txt').write_text(prefix + '/files/f1')
+        jp_root_dir.joinpath(prefix, 'files', 'f2.txt').write_text(prefix + '/files/f2')
+        jp_root_dir.joinpath(prefix, 'f2.txt').write_text(prefix + '/f2')
+        jp_root_dir.joinpath(prefix, 'f3.txt').write_text(prefix + '/f3')
 
     # These depend on the tree handlers
     #

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -145,25 +145,25 @@ def init_gateway(monkeypatch):
     GatewayClient.clear_instance()
 
 
-async def test_gateway_env_options(init_gateway, serverapp):
-    assert serverapp.gateway_config.gateway_enabled is True
-    assert serverapp.gateway_config.url == mock_gateway_url
-    assert serverapp.gateway_config.http_user == mock_http_user
-    assert serverapp.gateway_config.connect_timeout == serverapp.gateway_config.request_timeout
-    assert serverapp.gateway_config.connect_timeout == 44.4
+async def test_gateway_env_options(init_gateway, jp_serverapp):
+    assert jp_serverapp.gateway_config.gateway_enabled is True
+    assert jp_serverapp.gateway_config.url == mock_gateway_url
+    assert jp_serverapp.gateway_config.http_user == mock_http_user
+    assert jp_serverapp.gateway_config.connect_timeout == jp_serverapp.gateway_config.request_timeout
+    assert jp_serverapp.gateway_config.connect_timeout == 44.4
 
 
-async def test_gateway_cli_options(configurable_serverapp):
+async def test_gateway_cli_options(jp_configurable_serverapp):
     argv = [
-        "--gateway-url='" + mock_gateway_url + "'",
-        "--GatewayClient.http_user='" + mock_http_user + "'",
+        '--gateway-url=' + mock_gateway_url,
+        '--GatewayClient.http_user=' + mock_http_user,
         '--GatewayClient.connect_timeout=44.4',
         '--GatewayClient.request_timeout=44.4'
     ]
 
 
     GatewayClient.clear_instance()
-    app = configurable_serverapp(argv=argv)
+    app = jp_configurable_serverapp(argv=argv)
 
     assert app.gateway_config.gateway_enabled is True
     assert app.gateway_config.url == mock_gateway_url
@@ -173,17 +173,17 @@ async def test_gateway_cli_options(configurable_serverapp):
     GatewayClient.clear_instance()
 
 
-async def test_gateway_class_mappings(init_gateway, serverapp):
+async def test_gateway_class_mappings(init_gateway, jp_serverapp):
     # Ensure appropriate class mappings are in place.
-    assert serverapp.kernel_manager_class.__name__ == 'GatewayKernelManager'
-    assert serverapp.session_manager_class.__name__ == 'GatewaySessionManager'
-    assert serverapp.kernel_spec_manager_class.__name__ == 'GatewayKernelSpecManager'
+    assert jp_serverapp.kernel_manager_class.__name__ == 'GatewayKernelManager'
+    assert jp_serverapp.session_manager_class.__name__ == 'GatewaySessionManager'
+    assert jp_serverapp.kernel_spec_manager_class.__name__ == 'GatewayKernelSpecManager'
 
 
-async def test_gateway_get_kernelspecs(init_gateway, fetch):
+async def test_gateway_get_kernelspecs(init_gateway, jp_fetch):
     # Validate that kernelspecs come from gateway.
     with mocked_gateway:
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernelspecs',
             method='GET'
         )
@@ -194,10 +194,10 @@ async def test_gateway_get_kernelspecs(init_gateway, fetch):
         assert kspecs.get('kspec_bar').get('name') == 'kspec_bar'
 
 
-async def test_gateway_get_named_kernelspec(init_gateway, fetch):
+async def test_gateway_get_named_kernelspec(init_gateway, jp_fetch):
     # Validate that a specific kernelspec can be retrieved from gateway (and an invalid spec can't)
     with mocked_gateway:
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernelspecs', 'kspec_foo',
             method='GET'
         )
@@ -206,69 +206,69 @@ async def test_gateway_get_named_kernelspec(init_gateway, fetch):
         assert kspec_foo.get('name') == 'kspec_foo'
 
         with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-            await fetch(
+            await jp_fetch(
                 'api', 'kernelspecs', 'no_such_spec',
                 method='GET'
             )
         assert expected_http_error(e, 404)
 
 
-async def test_gateway_session_lifecycle(init_gateway, root_dir, fetch):
+async def test_gateway_session_lifecycle(init_gateway, jp_root_dir, jp_fetch):
     # Validate session lifecycle functions; create and delete.
 
     # create
-    session_id, kernel_id = await create_session(root_dir, fetch, 'kspec_foo')
+    session_id, kernel_id = await create_session(jp_root_dir, jp_fetch, 'kspec_foo')
 
     # ensure kernel still considered running
-    assert await is_kernel_running(fetch, kernel_id) is True
+    assert await is_kernel_running(jp_fetch, kernel_id) is True
 
     # interrupt
-    await interrupt_kernel(fetch, kernel_id)
+    await interrupt_kernel(jp_fetch, kernel_id)
 
     # ensure kernel still considered running
-    assert await is_kernel_running(fetch, kernel_id) is True
+    assert await is_kernel_running(jp_fetch, kernel_id) is True
 
     # restart
-    await restart_kernel(fetch, kernel_id)
+    await restart_kernel(jp_fetch, kernel_id)
 
     # ensure kernel still considered running
-    assert await is_kernel_running(fetch, kernel_id) is True
+    assert await is_kernel_running(jp_fetch, kernel_id) is True
 
     # delete
-    await delete_session(fetch, session_id)
-    assert await is_kernel_running(fetch, kernel_id) is False
+    await delete_session(jp_fetch, session_id)
+    assert await is_kernel_running(jp_fetch, kernel_id) is False
 
 
-async def test_gateway_kernel_lifecycle(init_gateway, fetch):
+async def test_gateway_kernel_lifecycle(init_gateway, jp_fetch):
     # Validate kernel lifecycle functions; create, interrupt, restart and delete.
 
     # create
-    kernel_id = await create_kernel(fetch, 'kspec_bar')
+    kernel_id = await create_kernel(jp_fetch, 'kspec_bar')
 
     # ensure kernel still considered running
-    assert await is_kernel_running(fetch, kernel_id) is True
+    assert await is_kernel_running(jp_fetch, kernel_id) is True
 
     # interrupt
-    await interrupt_kernel(fetch, kernel_id)
+    await interrupt_kernel(jp_fetch, kernel_id)
 
     # ensure kernel still considered running
-    assert await is_kernel_running(fetch, kernel_id) is True
+    assert await is_kernel_running(jp_fetch, kernel_id) is True
 
     # restart
-    await restart_kernel(fetch, kernel_id)
+    await restart_kernel(jp_fetch, kernel_id)
 
     # ensure kernel still considered running
-    assert await is_kernel_running(fetch, kernel_id) is True
+    assert await is_kernel_running(jp_fetch, kernel_id) is True
 
     # delete
-    await delete_kernel(fetch, kernel_id)
-    assert await is_kernel_running(fetch, kernel_id) is False
+    await delete_kernel(jp_fetch, kernel_id)
+    assert await is_kernel_running(jp_fetch, kernel_id) is False
 
 
 #
 # Test methods below...
 #
-async def create_session(root_dir, fetch, kernel_name):
+async def create_session(root_dir, jp_fetch, kernel_name):
     """Creates a session for a kernel.  The session is created against the server
        which then uses the gateway for kernel management.
     """
@@ -282,7 +282,7 @@ async def create_session(root_dir, fetch, kernel_name):
         os.environ['KERNEL_KSPEC_NAME'] = kernel_name
 
         # Create the kernel... (also tests get_kernel)
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'sessions',
             method='POST',
             body=body
@@ -302,12 +302,12 @@ async def create_session(root_dir, fetch, kernel_name):
         return session_id, kernel_id
 
 
-async def delete_session(fetch, session_id):
+async def delete_session(jp_fetch, session_id):
     """Deletes a session corresponding to the given session id.
     """
     with mocked_gateway:
         # Delete the session (and kernel)
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'sessions', session_id,
             method='DELETE'
         )
@@ -315,12 +315,12 @@ async def delete_session(fetch, session_id):
         assert r.reason == 'No Content'
 
 
-async def is_kernel_running(fetch, kernel_id):
+async def is_kernel_running(jp_fetch, kernel_id):
     """Issues request to get the set of running kernels
     """
     with mocked_gateway:
         # Get list of running kernels
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels',
             method='GET'
         )
@@ -333,7 +333,7 @@ async def is_kernel_running(fetch, kernel_id):
         return False
 
 
-async def create_kernel(fetch, kernel_name):
+async def create_kernel(jp_fetch, kernel_name):
     """Issues request to retart the given kernel
     """
     with mocked_gateway:
@@ -342,7 +342,7 @@ async def create_kernel(fetch, kernel_name):
         # add a KERNEL_ value to the current env and we'll ensure that that value exists in the mocked method
         os.environ['KERNEL_KSPEC_NAME'] = kernel_name
 
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels',
             method='POST',
             body=body
@@ -360,11 +360,11 @@ async def create_kernel(fetch, kernel_name):
         return kernel_id
 
 
-async def interrupt_kernel(fetch, kernel_id):
+async def interrupt_kernel(jp_fetch, kernel_id):
     """Issues request to interrupt the given kernel
     """
     with mocked_gateway:
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels', kernel_id, 'interrupt',
             method='POST',
             allow_nonstandard_methods=True
@@ -373,11 +373,11 @@ async def interrupt_kernel(fetch, kernel_id):
         assert r.reason == 'No Content'
 
 
-async def restart_kernel(fetch, kernel_id):
+async def restart_kernel(jp_fetch, kernel_id):
     """Issues request to retart the given kernel
     """
     with mocked_gateway:
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels', kernel_id, 'restart',
             method='POST',
             allow_nonstandard_methods=True
@@ -391,12 +391,12 @@ async def restart_kernel(fetch, kernel_id):
         assert model.get('name') == running_kernel.get('name')
 
 
-async def delete_kernel(fetch, kernel_id):
+async def delete_kernel(jp_fetch, kernel_id):
     """Deletes kernel corresponding to the given kernel id.
     """
     with mocked_gateway:
         # Delete the session (and kernel)
-        r = await fetch(
+        r = await jp_fetch(
             'api', 'kernels', kernel_id,
             method='DELETE'
         )

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -22,8 +22,8 @@ def test_help_output():
     check_help_all_output('jupyter_server')
 
 
-def test_server_info_file(tmp_path, configurable_serverapp):
-    app = configurable_serverapp(log=logging.getLogger())
+def test_server_info_file(tmp_path, jp_configurable_serverapp):
+    app = jp_configurable_serverapp(log=logging.getLogger())
 
     app.write_server_info_file()
     servers = list(list_running_servers(app.runtime_dir))
@@ -41,8 +41,8 @@ def test_server_info_file(tmp_path, configurable_serverapp):
     app.remove_server_info_file
 
 
-def test_root_dir(tmp_path, configurable_serverapp):
-    app = configurable_serverapp(root_dir=str(tmp_path))
+def test_root_dir(tmp_path, jp_configurable_serverapp):
+    app = jp_configurable_serverapp(root_dir=str(tmp_path))
     assert app.root_dir == str(tmp_path)
 
 
@@ -62,8 +62,8 @@ def invalid_root_dir(tmp_path, request):
     return str(path)
 
 
-def test_invalid_root_dir(invalid_root_dir, configurable_serverapp):
-    app = configurable_serverapp()
+def test_invalid_root_dir(invalid_root_dir, jp_configurable_serverapp):
+    app = jp_configurable_serverapp()
     with pytest.raises(TraitError):
         app.root_dir = invalid_root_dir
 
@@ -81,8 +81,8 @@ def valid_root_dir(tmp_path, request):
         path.mkdir(parents=True)
     return str(path)
 
-def test_valid_root_dir(valid_root_dir, configurable_serverapp):
-    app = configurable_serverapp(root_dir=valid_root_dir)
+def test_valid_root_dir(valid_root_dir, jp_configurable_serverapp):
+    app = jp_configurable_serverapp(root_dir=valid_root_dir)
     root_dir = valid_root_dir
     # If nested path, the last slash should
     # be stripped by the root_dir trait.
@@ -91,15 +91,15 @@ def test_valid_root_dir(valid_root_dir, configurable_serverapp):
     assert app.root_dir == root_dir
 
 
-def test_generate_config(tmp_path, configurable_serverapp):
-    app = configurable_serverapp(config_dir=str(tmp_path))
+def test_generate_config(tmp_path, jp_configurable_serverapp):
+    app = jp_configurable_serverapp(config_dir=str(tmp_path))
     app.initialize(['--generate-config', '--allow-root'])
     with pytest.raises(NoStart):
         app.start()
     assert tmp_path.joinpath('jupyter_server_config.py').exists()
 
 
-def test_server_password(tmp_path, configurable_serverapp):
+def test_server_password(tmp_path, jp_configurable_serverapp):
     password = 'secret'
     with patch.dict(
         'os.environ', {'JUPYTER_CONFIG_DIR': str(tmp_path)}
@@ -107,13 +107,13 @@ def test_server_password(tmp_path, configurable_serverapp):
         app = JupyterPasswordApp(log_level=logging.ERROR)
         app.initialize([])
         app.start()
-        sv = configurable_serverapp()
+        sv = jp_configurable_serverapp()
         sv.load_config_file()
         assert sv.password != ''
         passwd_check(sv.password, password)
 
 
-def test_list_running_servers(serverapp, app):
-    servers = list(list_running_servers(serverapp.runtime_dir))
+def test_list_running_servers(jp_serverapp, jp_web_app):
+    servers = list(list_running_servers(jp_serverapp.runtime_dir))
     assert len(servers) >= 1
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -14,9 +14,9 @@ if sys.platform.startswith('win'):
 # Kill all running terminals after each test to avoid cross-test issues
 # with still running terminals.
 @pytest.fixture
-def kill_all(serverapp):
+def kill_all(jp_serverapp):
     async def _():
-        await serverapp.web_app.settings["terminal_manager"].kill_all()
+        await jp_serverapp.web_app.settings["terminal_manager"].kill_all()
     return _
 
 
@@ -30,14 +30,14 @@ def terminal_path(tmp_path):
     shutil.rmtree(str(subdir), ignore_errors=True)
 
 
-async def test_terminal_create(fetch, kill_all):
-    await fetch(
+async def test_terminal_create(jp_fetch, kill_all):
+    await jp_fetch(
         'api', 'terminals',
         method='POST',
         allow_nonstandard_methods=True,
     )
 
-    resp_list = await fetch(
+    resp_list = await jp_fetch(
         'api', 'terminals',
         method='GET',
         allow_nonstandard_methods=True,
@@ -49,8 +49,8 @@ async def test_terminal_create(fetch, kill_all):
     await kill_all()
 
 
-async def test_terminal_create_with_kwargs(fetch, ws_fetch, terminal_path, kill_all):
-    resp_create = await fetch(
+async def test_terminal_create_with_kwargs(jp_fetch, jp_ws_fetch, terminal_path, kill_all):
+    resp_create = await jp_fetch(
         'api', 'terminals',
         method='POST',
         body=json.dumps({'cwd': str(terminal_path)}),
@@ -60,7 +60,7 @@ async def test_terminal_create_with_kwargs(fetch, ws_fetch, terminal_path, kill_
     data = json.loads(resp_create.body.decode())
     term_name = data['name']
 
-    resp_get = await fetch(
+    resp_get = await jp_fetch(
         'api', 'terminals', term_name,
         method='GET',
         allow_nonstandard_methods=True,
@@ -72,8 +72,8 @@ async def test_terminal_create_with_kwargs(fetch, ws_fetch, terminal_path, kill_
     await kill_all()
 
 
-async def test_terminal_create_with_cwd(fetch, ws_fetch, terminal_path):
-    resp = await fetch(
+async def test_terminal_create_with_cwd(jp_fetch, jp_ws_fetch, terminal_path):
+    resp = await jp_fetch(
         'api', 'terminals',
         method='POST',
         body=json.dumps({'cwd': str(terminal_path)}),
@@ -83,7 +83,7 @@ async def test_terminal_create_with_cwd(fetch, ws_fetch, terminal_path):
     data = json.loads(resp.body.decode())
     term_name = data['name']
 
-    ws = await ws_fetch(
+    ws = await jp_ws_fetch(
         'terminals', 'websocket', term_name
     )
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,7 +4,7 @@ import pytest
 from jupyter_server import __version__
 
 
-pep440re = re.compile('^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')
+pep440re = re.compile(r'^(\d+)\.(\d+)\.(\d+((a|b|rc)\d+)?)(\.post\d+)?(\.dev\d*)?$')
 
 def raise_on_bad_version(version):
     if not pep440re.match(version):


### PR DESCRIPTION
Now that `pytest-jupyter` is released, this updates the custom fixtures to use their `jp_` versions made available via `pytest-jupyter`.  This will avoid collisions with similarly named fixtures introduced in other packages (provided of course, they too are not prefixed with `jp_` :smile:  ).

Note that because other packages still depend on [`jupyter_server/pytest_plugin.py`](https://github.com/jupyter/jupyter_server/blob/master/jupyter_server/pytest_plugin.py) for the non-prefixed features, both it as well as the [`pytest_jupyter_server`](https://github.com/jupyter/jupyter_server/blob/master/setup.py#L65) entrypoint remain in existence. 

Prior to removing `jupyter_server/pytest_plugin.py` and the `pytest_jupyter_server` entrypoint, we may want to cut a release to provide dependents a "pin point" until they've prefixed the jupyter server fixtures.

Resolves #322