### PR TITLE
add check_origin handler to gateway WebSocketChannelsHandler

### DIFF
--- a/jupyter_server/gateway/handlers.py
+++ b/jupyter_server/gateway/handlers.py
@@ -32,6 +32,9 @@ class WebSocketChannelsHandler(WebSocketHandler, JupyterHandler):
     kernel_id = None
     ping_callback = None
 
+    def check_origin(self, origin=None):
+        return JupyterHandler.check_origin(self, origin)
+
     def set_default_headers(self):
         """Undo the set_default_headers in IPythonHandler which doesn't make sense for websockets"""
         pass


### PR DESCRIPTION
This was already merged on jupyter/notebook:

https://github.com/jupyter/notebook/blob/cd7a06ce88387b70c3dbe1bca6ab5ae222e28c60/notebook/gateway/handlers.py#L35

It makes sure the Websocket handler of the Gateway respects the user config of allow_origin.

Happy to change anything if this is not correct/desired for the jupyter_server repo!