### PR TITLE
Port gateway updates from notebook (PRs 5317 and 5484)

### DIFF
--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -102,7 +102,7 @@ class GatewayClient(SingletonConfigurable):
     def _kernelspecs_resource_endpoint_default(self):
         return os.environ.get(self.kernelspecs_resource_endpoint_env, self.kernelspecs_resource_endpoint_default_value)
 
-    connect_timeout_default_value = 60.0
+    connect_timeout_default_value = 40.0
     connect_timeout_env = 'JUPYTER_GATEWAY_CONNECT_TIMEOUT'
     connect_timeout = Float(default_value=connect_timeout_default_value, config=True,
         help="""The time allowed for HTTP connection establishment with the Gateway server.
@@ -112,7 +112,7 @@ class GatewayClient(SingletonConfigurable):
     def connect_timeout_default(self):
         return float(os.environ.get('JUPYTER_GATEWAY_CONNECT_TIMEOUT', self.connect_timeout_default_value))
 
-    request_timeout_default_value = 60.0
+    request_timeout_default_value = 40.0
     request_timeout_env = 'JUPYTER_GATEWAY_REQUEST_TIMEOUT'
     request_timeout = Float(default_value=request_timeout_default_value, config=True,
         help="""The time allowed for HTTP request completion. (JUPYTER_GATEWAY_REQUEST_TIMEOUT env var)""")
@@ -226,18 +226,20 @@ class GatewayClient(SingletonConfigurable):
 
     # Ensure KERNEL_LAUNCH_TIMEOUT has a default value.
     KERNEL_LAUNCH_TIMEOUT = int(os.environ.get('KERNEL_LAUNCH_TIMEOUT', 40))
-    os.environ['KERNEL_LAUNCH_TIMEOUT'] = str(KERNEL_LAUNCH_TIMEOUT)
-
-    LAUNCH_TIMEOUT_PAD = int(os.environ.get('LAUNCH_TIMEOUT_PAD', 2))
 
     def init_static_args(self):
         """Initialize arguments used on every request.  Since these are static values, we'll
         perform this operation once.
 
         """
-        # Ensure that request timeout is at least "pad" greater than launch timeout.
-        if self.request_timeout < float(GatewayClient.KERNEL_LAUNCH_TIMEOUT + GatewayClient.LAUNCH_TIMEOUT_PAD):
-            self.request_timeout = float(GatewayClient.KERNEL_LAUNCH_TIMEOUT + GatewayClient.LAUNCH_TIMEOUT_PAD)
+        # Ensure that request timeout and KERNEL_LAUNCH_TIMEOUT are the same, taking the
+        #  greater value of the two.
+        if self.request_timeout < float(GatewayClient.KERNEL_LAUNCH_TIMEOUT):
+            self.request_timeout = float(GatewayClient.KERNEL_LAUNCH_TIMEOUT)
+        elif self.request_timeout > float(GatewayClient.KERNEL_LAUNCH_TIMEOUT):
+            GatewayClient.KERNEL_LAUNCH_TIMEOUT = int(self.request_timeout)
+        # Ensure any adjustments are reflected in env.
+        os.environ['KERNEL_LAUNCH_TIMEOUT'] = str(GatewayClient.KERNEL_LAUNCH_TIMEOUT)
 
         self._static_args['headers'] = json.loads(self.headers)
         if 'Authorization' not in self._static_args['headers'].keys():

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -152,15 +152,17 @@ async def test_gateway_env_options(init_gateway, jp_serverapp):
     assert jp_serverapp.gateway_config.connect_timeout == jp_serverapp.gateway_config.request_timeout
     assert jp_serverapp.gateway_config.connect_timeout == 44.4
 
+    GatewayClient.instance().init_static_args()
+    assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == int(jp_serverapp.gateway_config.request_timeout)
+
 
 async def test_gateway_cli_options(jp_configurable_serverapp):
     argv = [
         '--gateway-url=' + mock_gateway_url,
         '--GatewayClient.http_user=' + mock_http_user,
         '--GatewayClient.connect_timeout=44.4',
-        '--GatewayClient.request_timeout=44.4'
+        '--GatewayClient.request_timeout=96.0'
     ]
-
 
     GatewayClient.clear_instance()
     app = jp_configurable_serverapp(argv=argv)
@@ -168,8 +170,10 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
     assert app.gateway_config.gateway_enabled is True
     assert app.gateway_config.url == mock_gateway_url
     assert app.gateway_config.http_user == mock_http_user
-    assert app.gateway_config.connect_timeout == app.gateway_config.request_timeout
     assert app.gateway_config.connect_timeout == 44.4
+    assert app.gateway_config.request_timeout == 96.0
+    GatewayClient.instance().init_static_args()
+    assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 96  # Ensure KLT gets set from request-timeout
     GatewayClient.clear_instance()
 
 


### PR DESCRIPTION
This pull request brings over the changes relative to the following Notebook PRs:
- https://github.com/jupyter/notebook/pull/5317: Gateway only: Ensure launch and request timeouts are in sync 
- https://github.com/jupyter/notebook/pull/5484: Added functionality to allow filter kernels by Jupyter Enterprise Gat…