### PR TITLE
Apply security advisory fix to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2020-11-18
+
+1.0.6 is a security release, fixing one vulnerability:
+
+### Changed
+
+- Fix open redirect vulnerability GHSA-grfj-wjv9-4f9v (CVE-2020-26232)
+
+
 ## [1.0] - 2020-9-18
 
 ### Added.

--- a/docs/source/other/changelog.rst
+++ b/docs/source/other/changelog.rst
@@ -21,6 +21,15 @@ We strongly recommend that you upgrade to version 9+ of pip before upgrading ``j
     Use ``pip install pip --upgrade`` to upgrade pip. Check pip version with
     ``pip --version``.
 
+.. _release-1.0.6:
+
+1.0.6
+-----
+
+1.0.6 is a security release, fixing one vulnerability:
+
+- Fix open redirect vulnerability GHSA-grfj-wjv9-4f9v (CVE-2020-26232)
+
 .. _release-1.0.0:
 
 1.0.0

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -9,5 +9,5 @@ store the current version info of the server.
 
 # Next beta/alpha/rc release: The version number for beta is X.Y.ZbN **without dots**.
 
-version_info = (1, 0, 5, '')
+version_info = (1, 0, 6, '')
 __version__ = '.'.join(map(str, version_info[:3])) + ''.join(version_info[3:])

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -55,4 +55,3 @@ async def test_trailing_slash(uri, expected, http_server_client, auth_header, ba
     assert response.code == 302
     assert "Location" in response.headers
     assert response.headers["Location"] == expected
-    assert False


### PR DESCRIPTION
This applies CVE-2020-26232 to the master branch - already released in jupyter_server 1.0.6.