### PR TITLE
Fix missing await when call 'async_replace_file'

### DIFF
--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -373,8 +373,8 @@ class AsyncFileManagerMixin(FileManagerMixin):
 
             # Move the bad file aside, restore the intermediate, and try again.
             invalid_file = path_to_invalid(os_path)
-            async_replace_file(os_path, invalid_file)
-            async_replace_file(tmp_path, os_path)
+            await async_replace_file(os_path, invalid_file)
+            await async_replace_file(tmp_path, os_path)
             return await self._read_notebook(os_path, as_version)
 
     async def _save_notebook(self, os_path, nb):


### PR DESCRIPTION
https://github.com/jupyter-server/jupyter_server/issues/594

I am currently reading the source code for file operations noticed that it seems to be missing await when call 'async_replace_file'

It's better to fix it, isn't it?