### PR TITLE
bugfix: dir_exists is never awaited

### DIFF
--- a/jupyter_server/tests/services/contents/test_manager.py
+++ b/jupyter_server/tests/services/contents/test_manager.py
@@ -551,7 +551,7 @@ async def test_delete_non_empty_folder(delete_to_trash, always_delete, error, jp
             await ensure_async(cm.delete_file(dir))
     else:
         await ensure_async(cm.delete_file(dir))
-        assert cm.dir_exists(dir) == False
+        assert await ensure_async(cm.dir_exists(dir)) == False
 
 
 async def test_rename(jp_contents_manager):


### PR DESCRIPTION
Accoding to https://github.com/jupyter-server/jupyter_server/blob/master/jupyter_server/services/contents/manager.py#L579 , AsyncContentsManager. dir_exists can be async function, but never awaited in test case. 

Background: I implemented subclass of AsyncContentsManager, but it not passed this testcase.