### PR TITLE
Only fail on warnings from Jupyter packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ timeout = 300
 # Restore this setting to debug failures
 # timeout_method = "thread"
 filterwarnings = [
-  "error",
+  "error:::jupyter.*",
   "ignore:There is no current event loop:DeprecationWarning",
   "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
   "ignore:unclosed <socket.socket:ResourceWarning",


### PR DESCRIPTION
avoid failing tests on use of deprecations out of our control

Potentially adding a strict warnings test run makes sense, but this prevents us from needing updates from dependencies before tests can run when there are no actual problems (#876)