### PR TITLE
add metric for kernel restarts

### DIFF
--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -8,7 +8,7 @@ conventions for metrics & labels.
 from prometheus_client import Counter
 
 try:
-    import notebook
+    import notebook  # type: ignore
 
     if notebook.__name__ != "notebook":
         # avoid double-importing myself if nbclassic is shimming jupyter_server into notebook,

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -5,6 +5,8 @@ Read https://prometheus.io/docs/practices/naming/ for naming
 conventions for metrics & labels.
 """
 
+from prometheus_client import Counter
+
 try:
     # Jupyter Notebook also defines these metrics.  Re-defining them results in a ValueError.
     # Try to de-duplicate by using the ones in Notebook if available.
@@ -34,3 +36,9 @@ except ImportError:
         "counter for how many kernels are running labeled by type",
         ["type"],
     )
+
+KERNEL_RESTARTS = Counter(
+    "kernel_restarts",
+    "counter for how many kernel restarts, labeled by type and source (user or restarter)",
+    ["type", "source"],
+)

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -8,6 +8,13 @@ conventions for metrics & labels.
 from prometheus_client import Counter
 
 try:
+    import notebook
+
+    if notebook.__name__ != "notebook":
+        # avoid double-importing myself if nbclassic is shimming jupyter_server into notebook,
+        # in which case notebook.__name__ will be 'jupyter_server'
+        _msg = "Not importing jupyter_server metrics under two names"
+        raise ImportError(_msg)
     # Jupyter Notebook also defines these metrics.  Re-defining them results in a ValueError.
     # Try to de-duplicate by using the ones in Notebook if available.
     # See https://github.com/jupyter/jupyter_server/issues/209

--- a/jupyter_server/prometheus/metrics.py
+++ b/jupyter_server/prometheus/metrics.py
@@ -45,7 +45,7 @@ except ImportError:
     )
 
 KERNEL_RESTARTS = Counter(
-    "kernel_restarts",
-    "counter for how many kernel restarts, labeled by type and source (user or restarter)",
-    ["type", "source"],
+    "jupyter_kernel_restarts",
+    "counter for how many kernel restarts, labeled by kernel_name and source (user or restarter)",
+    ["kernel_name", "source"],
 )

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -16,6 +16,7 @@ from jupyter_core.utils import ensure_async
 from tornado import web
 
 from jupyter_server.auth import authorized
+from jupyter_server.prometheus.metrics import KERNEL_RESTARTS
 from jupyter_server.utils import url_escape, url_path_join
 
 from ...base.handlers import APIHandler
@@ -104,6 +105,7 @@ class KernelActionHandler(KernelsAPIHandler):
                 self.set_status(500)
             else:
                 model = await ensure_async(km.kernel_model(kernel_id))
+                KERNEL_RESTARTS.labels(type=model["name"], source="user").inc()
                 self.write(json.dumps(model, default=json_default))
         self.finish()
 

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -105,7 +105,7 @@ class KernelActionHandler(KernelsAPIHandler):
                 self.set_status(500)
             else:
                 model = await ensure_async(km.kernel_model(kernel_id))
-                KERNEL_RESTARTS.labels(type=model["name"], source="user").inc()
+                KERNEL_RESTARTS.labels(kernel_name=model["name"], source="user").inc()
                 self.write(json.dumps(model, default=json_default))
         self.finish()
 

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -181,7 +181,7 @@ class MappingKernelManager(MultiKernelManager):
 
     def _handle_kernel_restart(self, kernel_id, kernel_name):
         """notice that a kernel restarted"""
-        KERNEL_RESTARTS.labels(type=kernel_name, source="restarter").inc()
+        KERNEL_RESTARTS.labels(kernel_name=kernel_name, source="restarter").inc()
 
     def _handle_kernel_died(self, kernel_id):
         """notice that a kernel died"""


### PR DESCRIPTION
labels: kernel_name = kernel name, source = "restarter" or "user"

I don't love `type` as a label, but it's already used in running kernels, so it's probably more important that it match other metrics than it be the more logical `name` or `kernel_name`, used elsewhere in the API. Same goes for `source` to distinguish API ('user') restarts from auto restarts by the KernelRestarter ('restarter'). I also considered `trigger=user|crash` (or 'exit' instead of crash, which is slightly more precise).

closes #1240 