### PR TITLE
Kernelspec Caching

### DIFF
--- a/docs/source/api/jupyter_server.services.kernelspecs.monitors.rst
+++ b/docs/source/api/jupyter_server.services.kernelspecs.monitors.rst
@@ -1,0 +1,25 @@
+jupyter\_server.services.kernelspecs.monitors package
+=====================================================
+
+Submodules
+----------
+
+
+.. automodule:: jupyter_server.services.kernelspecs.monitors.polling_monitor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: jupyter_server.services.kernelspecs.monitors.watchdog_monitor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: jupyter_server.services.kernelspecs.monitors
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/jupyter_server.services.kernelspecs.rst
+++ b/docs/source/api/jupyter_server.services.kernelspecs.rst
@@ -1,11 +1,25 @@
 jupyter\_server.services.kernelspecs package
 ============================================
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   jupyter_server.services.kernelspecs.monitors
+
 Submodules
 ----------
 
 
 .. automodule:: jupyter_server.services.kernelspecs.handlers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: jupyter_server.services.kernelspecs.kernelspec_cache
    :members:
    :undoc-members:
    :show-inheritance:

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -343,6 +343,10 @@ class JupyterHandler(AuthenticatedHandler):
         return self.settings["kernel_spec_manager"]
 
     @property
+    def kernel_spec_cache(self):
+        return self.settings["kernel_spec_cache"]
+
+    @property
     def config_manager(self):
         return self.settings["config_manager"]
 

--- a/jupyter_server/kernelspecs/handlers.py
+++ b/jupyter_server/kernelspecs/handlers.py
@@ -24,11 +24,11 @@ class KernelSpecResourceHandler(web.StaticFileHandler, JupyterHandler):
     @authorized
     async def get(self, kernel_name, path, include_body=True):
         """Get a kernelspec resource."""
-        ksm = self.kernel_spec_manager
+        ksc = self.kernel_spec_cache
         if path.lower().endswith(".png"):
             self.set_header("Cache-Control", f"max-age={60*60*24*30}")
         try:
-            kspec = await ensure_async(ksm.get_kernel_spec(kernel_name))
+            kspec = await ensure_async(ksc.get_kernel_spec(kernel_name))
             self.root = kspec.resource_dir
         except KeyError as e:
             raise web.HTTPError(404, "Kernel spec %s not found" % kernel_name) from e

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -107,6 +107,7 @@ from jupyter_server.services.kernels.kernelmanager import (
     AsyncMappingKernelManager,
     MappingKernelManager,
 )
+from jupyter_server.services.kernelspecs.kernelspec_cache import KernelSpecCache
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 from jupyter_server.utils import (
     check_pid,
@@ -234,6 +235,7 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
         kernel_websocket_connection_class=None,
+        kernel_spec_cache=None,
     ):
         """Initialize a server web application."""
         if identity_provider is None:
@@ -271,6 +273,7 @@ class ServerWebApplication(web.Application):
             authorizer=authorizer,
             identity_provider=identity_provider,
             kernel_websocket_connection_class=kernel_websocket_connection_class,
+            kernel_spec_cache=kernel_spec_cache,
         )
         handlers = self.init_handlers(default_services, settings)
 
@@ -295,6 +298,7 @@ class ServerWebApplication(web.Application):
         authorizer=None,
         identity_provider=None,
         kernel_websocket_connection_class=None,
+        kernel_spec_cache=None,
     ):
         """Initialize settings for the web application."""
         _template_path = settings_overrides.get(
@@ -372,6 +376,7 @@ class ServerWebApplication(web.Application):
             "contents_manager": contents_manager,
             "session_manager": session_manager,
             "kernel_spec_manager": kernel_spec_manager,
+            "kernel_spec_cache": kernel_spec_cache,
             "config_manager": config_manager,
             "authorizer": authorizer,
             "identity_provider": identity_provider,
@@ -1504,6 +1509,16 @@ class ServerApp(JupyterApp):
             return "jupyter_server.gateway.managers.GatewaySessionManager"
         return SessionManager
 
+    kernel_spec_cache_class = Type(
+        default_value=KernelSpecCache,
+        klass=KernelSpecCache,
+        config=True,
+        help="""
+        The kernel spec cache class to use. Must be a subclass
+        of `jupyter_server.services.kernelspecs.kernelspec_cache.KernelSpecCache`.
+        """,
+    )
+
     kernel_websocket_connection_class = Type(
         default_value=ZMQChannelsWebsocketConnection,
         klass=BaseKernelWebsocketConnection,
@@ -1886,6 +1901,11 @@ class ServerApp(JupyterApp):
             kernel_manager=self.kernel_manager,
             contents_manager=self.contents_manager,
         )
+        self.kernel_spec_cache = self.kernel_spec_cache_class(
+            parent=self,
+            log=self.log,
+            kernel_spec_manager=self.kernel_spec_manager,
+        )
         self.config_manager = self.config_manager_class(
             parent=self,
             log=self.log,
@@ -2044,6 +2064,7 @@ class ServerApp(JupyterApp):
             authorizer=self.authorizer,
             identity_provider=self.identity_provider,
             kernel_websocket_connection_class=self.kernel_websocket_connection_class,
+            kernel_spec_cache=self.kernel_spec_cache,
         )
         if self.certfile:
             self.ssl_options["certfile"] = self.certfile

--- a/jupyter_server/services/kernelspecs/handlers.py
+++ b/jupyter_server/services/kernelspecs/handlers.py
@@ -62,12 +62,12 @@ class MainKernelSpecHandler(KernelSpecsAPIHandler):
     @authorized
     async def get(self):
         """Get the list of kernel specs."""
-        ksm = self.kernel_spec_manager
+        ksc = self.kernel_spec_cache
         km = self.kernel_manager
         model = {}
         model["default"] = km.default_kernel_name
         model["kernelspecs"] = specs = {}
-        kspecs = await ensure_async(ksm.get_all_specs())
+        kspecs = await ensure_async(ksc.get_all_specs())
         for kernel_name, kernel_info in kspecs.items():
             try:
                 if is_kernelspec_model(kernel_info):
@@ -94,10 +94,10 @@ class KernelSpecHandler(KernelSpecsAPIHandler):
     @authorized
     async def get(self, kernel_name):
         """Get a kernel spec model."""
-        ksm = self.kernel_spec_manager
+        ksc = self.kernel_spec_cache
         kernel_name = url_unescape(kernel_name)
         try:
-            spec = await ensure_async(ksm.get_kernel_spec(kernel_name))
+            spec = await ensure_async(ksc.get_kernel_spec(kernel_name))
         except KeyError as e:
             raise web.HTTPError(404, "Kernel spec %s not found" % kernel_name) from e
         if is_kernelspec_model(spec):

--- a/jupyter_server/services/kernelspecs/kernelspec_cache.py
+++ b/jupyter_server/services/kernelspecs/kernelspec_cache.py
@@ -4,13 +4,13 @@
 
 
 import os
+from abc import ABC, abstractmethod
 from typing import Dict, Optional, Union
 
 from jupyter_client.kernelspec import KernelSpec
+from overrides import overrides
 from traitlets.config import SingletonConfigurable
-from traitlets.traitlets import CBool, default
-from watchdog.events import FileMovedEvent, FileSystemEventHandler
-from watchdog.observers import Observer
+from traitlets.traitlets import CBool, Instance, Type, default
 
 from jupyter_server.utils import ensure_async
 
@@ -43,11 +43,27 @@ class KernelSpecCache(SingletonConfigurable):
     def _cache_enabled_default(self):
         return os.getenv(self.cache_enabled_env, "true").lower() in ("true", "1")
 
+    kernel_spec_manager = Instance("jupyter_client.kernelspec.KernelSpecManager")
+
+    monitor_class = Type(
+        klass="jupyter_server.services.kernelspecs.kernelspec_cache.KernelSpecMonitorBase",
+        help="""The monitor class to use to capture kernelspecs.""",
+    ).tag(config=True)
+
+    @default("monitor_class")
+    def _monitor_class_default(self):
+        return "jupyter_server.services.kernelspecs.kernelspec_cache.KernelSpecWatchdogMonitor"
+
+    # The kernelspec cache consists of a dictionary mapping the kernel name to the actual
+    # kernelspec data (CacheItemType).
+    cache_items: Dict = {}
+    cache_misses: int = 0
+
     def __init__(self, kernel_spec_manager, **kwargs) -> None:
         """Initialize the cache."""
         super().__init__(**kwargs)
         self.kernel_spec_manager = kernel_spec_manager
-        self._initialize()
+        self.kernel_spec_monitor = KernelSpecMonitorBase.create_instance(self)
 
     async def get_kernel_spec(self, kernel_name: str) -> KernelSpec:
         """Get the named kernel specification.
@@ -133,27 +149,12 @@ class KernelSpecCache(SingletonConfigurable):
         This method can take either a KernelSpec (if called directly from the `get_kernel_spec()`
         method, or a CacheItemItem (if called from a cache-related method) as that is the type
         in which the cache items are stored.
-
-        If it determines the cache entry corresponds to a currently unwatched directory,
-        that directory will be added to list of observed directories and scheduled accordingly.
         """
         if self.cache_enabled:
             self.log.info(f"KernelSpecCache: adding/updating kernelspec: {kernel_name}")
             if type(cache_item) is KernelSpec:
                 cache_item = KernelSpecCache.kernel_spec_to_cache_item(cache_item)
-
-            resource_dir = cache_item["resource_dir"]
             self.cache_items[kernel_name.lower()] = cache_item
-            observed_dir = os.path.dirname(resource_dir)
-            if observed_dir not in self.observed_dirs:
-                # New directory to watch, schedule it...
-                self.log.debug(
-                    "KernelSpecCache: observing directory: {observed_dir}".format(
-                        observed_dir=observed_dir
-                    )
-                )
-                self.observed_dirs.add(observed_dir)
-                self.observer.schedule(KernelSpecChangeHandler(self), observed_dir, recursive=True)
 
     def put_all_items(self, kernelspecs: Dict[str, CacheItemType]) -> None:
         """Adds or updates a dictionary of kernel specification in the cache."""
@@ -168,40 +169,6 @@ class KernelSpecCache(SingletonConfigurable):
             self.log.info(f"KernelSpecCache: removed kernelspec: {kernel_name}")
         return cache_item
 
-    def _initialize(self):
-        """Initializes the cache and starts the observer."""
-
-        # The kernelspec cache consists of a dictionary mapping the kernel name to the actual
-        # kernelspec data (CacheItemType).
-        self.cache_items = {}  # Maps kernel name to kernelspec
-        self.observed_dirs = set()  # Tracks which directories are being watched
-        self.cache_misses = 0
-
-        # Seed the cache and start the observer
-        if self.cache_enabled:
-            self.observer = Observer()
-            kernelspecs = self.kernel_spec_manager.get_all_specs()
-            self.put_all_items(kernelspecs)
-            # Following adds, see if any of the manager's kernel dirs are not observed and add them
-            for kernel_dir in self.kernel_spec_manager.kernel_dirs:
-                if kernel_dir not in self.observed_dirs:
-                    if os.path.exists(kernel_dir):
-                        self.log.info(
-                            "KernelSpecCache: observing directory: {kernel_dir}".format(
-                                kernel_dir=kernel_dir
-                            )
-                        )
-                        self.observed_dirs.add(kernel_dir)
-                        self.observer.schedule(
-                            KernelSpecChangeHandler(self), kernel_dir, recursive=True
-                        )
-                    else:
-                        self.log.warning(
-                            "KernelSpecCache: kernel_dir '{kernel_dir}' does not exist"
-                            " and will not be observed.".format(kernel_dir=kernel_dir)
-                        )
-            self.observer.start()
-
     @staticmethod
     def kernel_spec_to_cache_item(kernelspec: KernelSpec) -> CacheItemType:
         """Converts a KernelSpec instance to a CacheItemType for storage into the cache."""
@@ -215,88 +182,159 @@ class KernelSpecCache(SingletonConfigurable):
         return kernel_spec
 
 
-class KernelSpecChangeHandler(FileSystemEventHandler):
+class KernelSpecMonitorBase(ABC):
+    @classmethod
+    def create_instance(
+        cls, kernel_spec_cache: KernelSpecCache, **kwargs
+    ) -> "KernelSpecMonitorBase":
+        """Creates an instance of the monitor class configured on the KernelSpecCache instance."""
+        monitor_instance = kernel_spec_cache.monitor_class(kernel_spec_cache, **kwargs)
+        monitor_instance.initialize()
+        return monitor_instance
+
+    @abstractmethod
+    def initialize(self) -> None:
+        """Initializes the monitor."""
+        pass
+
+    @abstractmethod
+    def destroy(self) -> None:
+        """Destroys the monitor."""
+        pass
+
+
+class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
     """Watchdog handler that filters on specific files deemed representative of a kernel specification."""
 
-    # Events related to these files trigger the management of the KernelSpec cache.  Should we find
-    # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
-    # files in the future) should be added to this list - at which time it should become configurable.
-    watched_files = ["kernel.json"]
+    from watchdog.events import FileSystemEventHandler
 
     def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
         """Initialize the handler."""
         super().__init__(**kwargs)
         self.kernel_spec_cache = kernel_spec_cache
+        self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
         self.log = kernel_spec_cache.log
+        self.observed_dirs = set()  # Tracks which directories are being watched
+        self.observer = None
 
-    def dispatch(self, event):
-        """Dispatches events pertaining to kernelspecs to the appropriate methods.
+    @overrides
+    def initialize(self):
+        """Initializes the cache and starts the observer."""
+        from watchdog.observers import Observer
+
+        # Seed the cache and start the observer
+        if self.kernel_spec_cache.cache_enabled:
+            self.observer = Observer()
+            kernelspecs = self.kernel_spec_manager.get_all_specs()
+            self.kernel_spec_cache.put_all_items(kernelspecs)
+            # Following adds, see if any of the manager's kernel dirs are not observed and add them
+            for kernel_dir in self.kernel_spec_manager.kernel_dirs:
+                if kernel_dir not in self.observed_dirs:
+                    if os.path.exists(kernel_dir):
+                        self.log.info(
+                            "KernelSpecCache: observing directory: {kernel_dir}".format(
+                                kernel_dir=kernel_dir
+                            )
+                        )
+                        self.observed_dirs.add(kernel_dir)
+                        self.observer.schedule(
+                            KernelSpecWatchdogMonitor.WatchDogHandler(self),
+                            kernel_dir,
+                            recursive=True,
+                        )
+                    else:
+                        self.log.warning(
+                            "KernelSpecCache: kernel_dir '{kernel_dir}' does not exist"
+                            " and will not be observed.".format(kernel_dir=kernel_dir)
+                        )
+            self.observer.start()
+
+    @overrides
+    def destroy(self) -> None:
+        self.observer = None
+
+    class WatchDogHandler(FileSystemEventHandler):
+        # Events related to these files trigger the management of the KernelSpec cache.  Should we find
+        # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
+        # files in the future) should be added to this list - at which time it should become configurable.
+        watched_files = ["kernel.json"]
+
+        def __init__(self, monitor: "KernelSpecWatchdogMonitor", **kwargs):
+            """Initialize the handler."""
+            super().__init__(**kwargs)
+            self.kernel_spec_cache = monitor.kernel_spec_cache
+            self.log = monitor.kernel_spec_cache.log
+
+        def dispatch(self, event):
+            """Dispatches events pertaining to kernelspecs to the appropriate methods.
 
 
-        The primary purpose of this method is to ensure the action is occurring against
-        the a file in the list of watched files and adds some additional attributes to
-        the event instance to make the actual event handling method easier.
-        :param event:
-            The event object representing the file system event.
-        :type event:
-            :class:`FileSystemEvent`
-        """
-        if os.path.basename(event.src_path) in self.watched_files:
-            src_resource_dir = os.path.dirname(event.src_path)
-            event.src_resource_dir = src_resource_dir
-            event.src_kernel_name = os.path.basename(src_resource_dir)
-            if type(event) is FileMovedEvent:
-                dest_resource_dir = os.path.dirname(event.dest_path)
-                event.dest_resource_dir = dest_resource_dir
-                event.dest_kernel_name = os.path.basename(dest_resource_dir)
+            The primary purpose of this method is to ensure the action is occurring against
+            the a file in the list of watched files and adds some additional attributes to
+            the event instance to make the actual event handling method easier.
+            :param event:
+                The event object representing the file system event.
+            :type event:
+                :class:`FileSystemEvent`
+            """
+            from watchdog.events import FileMovedEvent
 
-            super().dispatch(event)
+            if os.path.basename(event.src_path) in self.watched_files:
+                src_resource_dir = os.path.dirname(event.src_path)
+                event.src_resource_dir = src_resource_dir
+                event.src_kernel_name = os.path.basename(src_resource_dir)
+                if type(event) is FileMovedEvent:
+                    dest_resource_dir = os.path.dirname(event.dest_path)
+                    event.dest_resource_dir = dest_resource_dir
+                    event.dest_kernel_name = os.path.basename(dest_resource_dir)
 
-    def on_created(self, event):
-        """Fires when a watched file is created.
+                super().dispatch(event)
 
-        This will trigger a call to the configured KernelSpecManager to fetch the instance
-        associated with the created file, which is then added to the cache.
-        """
-        kernel_name = event.src_kernel_name
-        try:
-            kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
-            self.kernel_spec_cache.put_item(kernel_name, kernelspec)
-        except Exception as e:
-            self.log.warning(
-                "The following exception occurred creating cache entry for: {src_resource_dir} "
-                "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
-            )
+        def on_created(self, event):
+            """Fires when a watched file is created.
 
-    def on_deleted(self, event):
-        """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
-        kernel_name = event.src_kernel_name
-        self.kernel_spec_cache.remove_item(kernel_name)
+            This will trigger a call to the configured KernelSpecManager to fetch the instance
+            associated with the created file, which is then added to the cache.
+            """
+            kernel_name = event.src_kernel_name
+            try:
+                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+            except Exception as e:
+                self.log.warning(
+                    "The following exception occurred creating cache entry for: {src_resource_dir} "
+                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+                )
 
-    def on_modified(self, event):
-        """Fires when a watched file is modified.
+        def on_deleted(self, event):
+            """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
+            kernel_name = event.src_kernel_name
+            self.kernel_spec_cache.remove_item(kernel_name)
 
-        This will trigger a call to the configured KernelSpecManager to fetch the instance
-        associated with the modified file, which is then replaced in the cache.
-        """
-        kernel_name = event.src_kernel_name
-        try:
-            kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
-            self.kernel_spec_cache.put_item(kernel_name, kernelspec)
-        except Exception as e:
-            self.log.warning(
-                "The following exception occurred updating cache entry for: {src_resource_dir} "
-                "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
-            )
+        def on_modified(self, event):
+            """Fires when a watched file is modified.
 
-    def on_moved(self, event):
-        """Fires when a watched file is moved.
+            This will trigger a call to the configured KernelSpecManager to fetch the instance
+            associated with the modified file, which is then replaced in the cache.
+            """
+            kernel_name = event.src_kernel_name
+            try:
+                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+            except Exception as e:
+                self.log.warning(
+                    "The following exception occurred updating cache entry for: {src_resource_dir} "
+                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+                )
 
-        This will trigger the update of the existing cached item, replacing its resource_dir entry
-        with that of the new destination.
-        """
-        src_kernel_name = event.src_kernel_name
-        dest_kernel_name = event.dest_kernel_name
-        cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
-        cache_item["resource_dir"] = event.dest_resource_dir
-        self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)
+        def on_moved(self, event):
+            """Fires when a watched file is moved.
+
+            This will trigger the update of the existing cached item, replacing its resource_dir entry
+            with that of the new destination.
+            """
+            src_kernel_name = event.src_kernel_name
+            dest_kernel_name = event.dest_kernel_name
+            cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
+            cache_item["resource_dir"] = event.dest_resource_dir
+            self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)

--- a/jupyter_server/services/kernelspecs/kernelspec_cache.py
+++ b/jupyter_server/services/kernelspecs/kernelspec_cache.py
@@ -1,0 +1,302 @@
+"""Cache handling for kernel specs."""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+
+import os
+from typing import Dict, Optional, Union
+
+from jupyter_client.kernelspec import KernelSpec
+from traitlets.config import SingletonConfigurable
+from traitlets.traitlets import CBool, default
+from watchdog.events import FileMovedEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from jupyter_server.utils import ensure_async
+
+# Simplify the typing.  Cache items are essentially dictionaries of strings
+# to either strings or dictionaries.  The items themselves are indexed by
+# the kernel_name (case-insensitive).
+CacheItemType = Dict[str, Union[str, Dict]]
+
+
+class KernelSpecCache(SingletonConfigurable):
+    """The primary (singleton) instance for managing KernelSpecs.
+
+    This class contains the configured KernelSpecManager instance upon
+    which it uses to populate the cache (when enabled) or as a pass-thru
+    (when disabled).
+
+    Note that the KernelSpecManager returns different formats from methods
+    get_all_specs() and get_kernel_spec().  The format in which cache entries
+    are stored is that of the get_all_specs() results.  As a result, some
+    conversion between formats is necessary, depending on which method is called.
+    """
+
+    cache_enabled_env = "JUPYTER_KERNELSPEC_CACHE_ENABLED"
+    cache_enabled = CBool(
+        config=True,
+        help="""Enable Kernel Specification caching. (JUPYTER_KERNELSPEC_CACHE_ENABLED env var)""",
+    )
+
+    @default("cache_enabled")
+    def _cache_enabled_default(self):
+        return os.getenv(self.cache_enabled_env, "true").lower() in ("true", "1")
+
+    def __init__(self, kernel_spec_manager, **kwargs) -> None:
+        """Initialize the cache."""
+        super().__init__(**kwargs)
+        self.kernel_spec_manager = kernel_spec_manager
+        self._initialize()
+
+    async def get_kernel_spec(self, kernel_name: str) -> KernelSpec:
+        """Get the named kernel specification.
+
+        This method is equivalent to calling KernelSpecManager.get_kernel_spec().  If
+        caching is enabled, it will pull the item from the cache.  If no item is
+        returned (as will be the case if caching is disabled) it will defer to the
+        currently configured KernelSpecManager.  If an item is returned (and caching
+        is enabled), it will be added to the cache.
+        """
+        kernelspec = self.get_item(kernel_name)
+        if not kernelspec:
+            kernelspec = await ensure_async(self.kernel_spec_manager.get_kernel_spec(kernel_name))
+            if kernelspec:
+                self.put_item(kernel_name, kernelspec)
+        return kernelspec
+
+    async def get_all_specs(self) -> Dict[str, CacheItemType]:
+        """Get all available kernel specifications.
+
+        This method is equivalent to calling KernelSpecManager.get_all_specs().  If
+        caching is enabled, it will pull all items from the cache.  If no items are
+        returned (as will be the case if caching is disabled) it will defer to the
+        currently configured KernelSpecManager.  If items are returned (and caching
+        is enabled), they will be added to the cache.
+
+        Note that the return type of this method is not a dictionary or list of
+        KernelSpec instances, but rather a dictionary of kernel-name to kernel-info
+        dictionaries are returned - as is the case with the respective return values
+        of the KernelSpecManager methods.
+        """
+        kernelspecs = self.get_all_items()
+        if not kernelspecs:
+            kernelspecs = await ensure_async(self.kernel_spec_manager.get_all_specs())
+            if kernelspecs:
+                self.put_all_items(kernelspecs)
+        return kernelspecs
+
+    # Cache-related methods
+    def get_item(self, kernel_name: str) -> Optional[KernelSpec]:
+        """Retrieves a named kernel specification from the cache.
+
+        If cache is disabled or the item is not in the cache, None is returned;
+        otherwise, a KernelSpec instance of the item is returned.
+        """
+        kernelspec = None
+        if self.cache_enabled:
+            cache_item = self.cache_items.get(kernel_name.lower())
+            if cache_item:  # Convert to KernelSpec
+                # In certain conditions, like when the kernelspec is fetched prior to its removal from the cache,
+                # we can encounter a FileNotFoundError.  In those cases, treat as a cache miss as well.
+                try:
+                    kernelspec = KernelSpecCache.cache_item_to_kernel_spec(cache_item)
+                except FileNotFoundError:
+                    pass
+            if not kernelspec:
+                self.cache_misses += 1
+                self.log.debug(
+                    "Cache miss ({misses}) for kernelspec: {kernel_name}".format(
+                        misses=self.cache_misses, kernel_name=kernel_name
+                    )
+                )
+        return kernelspec
+
+    def get_all_items(self) -> Dict[str, CacheItemType]:
+        """Retrieves all kernel specification from the cache.
+
+        If cache is disabled or no items are in the cache, an empty dictionary is returned;
+        otherwise, a dictionary of kernel-name to specifications (kernel infos) are returned.
+        """
+        items = {}
+        if self.cache_enabled:
+            for kernel_name in self.cache_items:
+                cache_item = self.cache_items.get(kernel_name)
+                items[kernel_name] = cache_item
+            if not items:
+                self.cache_misses += 1
+        return items
+
+    def put_item(self, kernel_name: str, cache_item: Union[KernelSpec, CacheItemType]) -> None:
+        """Adds or updates a kernel specification in the cache.
+
+        This method can take either a KernelSpec (if called directly from the `get_kernel_spec()`
+        method, or a CacheItemItem (if called from a cache-related method) as that is the type
+        in which the cache items are stored.
+
+        If it determines the cache entry corresponds to a currently unwatched directory,
+        that directory will be added to list of observed directories and scheduled accordingly.
+        """
+        if self.cache_enabled:
+            self.log.info(f"KernelSpecCache: adding/updating kernelspec: {kernel_name}")
+            if type(cache_item) is KernelSpec:
+                cache_item = KernelSpecCache.kernel_spec_to_cache_item(cache_item)
+
+            resource_dir = cache_item["resource_dir"]
+            self.cache_items[kernel_name.lower()] = cache_item
+            observed_dir = os.path.dirname(resource_dir)
+            if observed_dir not in self.observed_dirs:
+                # New directory to watch, schedule it...
+                self.log.debug(
+                    "KernelSpecCache: observing directory: {observed_dir}".format(
+                        observed_dir=observed_dir
+                    )
+                )
+                self.observed_dirs.add(observed_dir)
+                self.observer.schedule(KernelSpecChangeHandler(self), observed_dir, recursive=True)
+
+    def put_all_items(self, kernelspecs: Dict[str, CacheItemType]) -> None:
+        """Adds or updates a dictionary of kernel specification in the cache."""
+        for kernel_name, cache_item in kernelspecs.items():
+            self.put_item(kernel_name, cache_item)
+
+    def remove_item(self, kernel_name: str) -> Optional[CacheItemType]:
+        """Removes the cache item corresponding to kernel_name from the cache."""
+        cache_item = None
+        if self.cache_enabled and kernel_name.lower() in self.cache_items:
+            cache_item = self.cache_items.pop(kernel_name.lower())
+            self.log.info(f"KernelSpecCache: removed kernelspec: {kernel_name}")
+        return cache_item
+
+    def _initialize(self):
+        """Initializes the cache and starts the observer."""
+
+        # The kernelspec cache consists of a dictionary mapping the kernel name to the actual
+        # kernelspec data (CacheItemType).
+        self.cache_items = {}  # Maps kernel name to kernelspec
+        self.observed_dirs = set()  # Tracks which directories are being watched
+        self.cache_misses = 0
+
+        # Seed the cache and start the observer
+        if self.cache_enabled:
+            self.observer = Observer()
+            kernelspecs = self.kernel_spec_manager.get_all_specs()
+            self.put_all_items(kernelspecs)
+            # Following adds, see if any of the manager's kernel dirs are not observed and add them
+            for kernel_dir in self.kernel_spec_manager.kernel_dirs:
+                if kernel_dir not in self.observed_dirs:
+                    if os.path.exists(kernel_dir):
+                        self.log.info(
+                            "KernelSpecCache: observing directory: {kernel_dir}".format(
+                                kernel_dir=kernel_dir
+                            )
+                        )
+                        self.observed_dirs.add(kernel_dir)
+                        self.observer.schedule(
+                            KernelSpecChangeHandler(self), kernel_dir, recursive=True
+                        )
+                    else:
+                        self.log.warning(
+                            "KernelSpecCache: kernel_dir '{kernel_dir}' does not exist"
+                            " and will not be observed.".format(kernel_dir=kernel_dir)
+                        )
+            self.observer.start()
+
+    @staticmethod
+    def kernel_spec_to_cache_item(kernelspec: KernelSpec) -> CacheItemType:
+        """Converts a KernelSpec instance to a CacheItemType for storage into the cache."""
+        cache_item = {"spec": kernelspec.to_dict(), "resource_dir": kernelspec.resource_dir}
+        return cache_item
+
+    @staticmethod
+    def cache_item_to_kernel_spec(cache_item: CacheItemType) -> KernelSpec:
+        """Converts a CacheItemType to a KernelSpec instance for user consumption."""
+        kernel_spec = KernelSpec(resource_dir=cache_item["resource_dir"], **cache_item["spec"])
+        return kernel_spec
+
+
+class KernelSpecChangeHandler(FileSystemEventHandler):
+    """Watchdog handler that filters on specific files deemed representative of a kernel specification."""
+
+    # Events related to these files trigger the management of the KernelSpec cache.  Should we find
+    # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
+    # files in the future) should be added to this list - at which time it should become configurable.
+    watched_files = ["kernel.json"]
+
+    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
+        """Initialize the handler."""
+        super().__init__(**kwargs)
+        self.kernel_spec_cache = kernel_spec_cache
+        self.log = kernel_spec_cache.log
+
+    def dispatch(self, event):
+        """Dispatches events pertaining to kernelspecs to the appropriate methods.
+
+
+        The primary purpose of this method is to ensure the action is occurring against
+        the a file in the list of watched files and adds some additional attributes to
+        the event instance to make the actual event handling method easier.
+        :param event:
+            The event object representing the file system event.
+        :type event:
+            :class:`FileSystemEvent`
+        """
+        if os.path.basename(event.src_path) in self.watched_files:
+            src_resource_dir = os.path.dirname(event.src_path)
+            event.src_resource_dir = src_resource_dir
+            event.src_kernel_name = os.path.basename(src_resource_dir)
+            if type(event) is FileMovedEvent:
+                dest_resource_dir = os.path.dirname(event.dest_path)
+                event.dest_resource_dir = dest_resource_dir
+                event.dest_kernel_name = os.path.basename(dest_resource_dir)
+
+            super().dispatch(event)
+
+    def on_created(self, event):
+        """Fires when a watched file is created.
+
+        This will trigger a call to the configured KernelSpecManager to fetch the instance
+        associated with the created file, which is then added to the cache.
+        """
+        kernel_name = event.src_kernel_name
+        try:
+            kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+            self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+        except Exception as e:
+            self.log.warning(
+                "The following exception occurred creating cache entry for: {src_resource_dir} "
+                "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+            )
+
+    def on_deleted(self, event):
+        """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
+        kernel_name = event.src_kernel_name
+        self.kernel_spec_cache.remove_item(kernel_name)
+
+    def on_modified(self, event):
+        """Fires when a watched file is modified.
+
+        This will trigger a call to the configured KernelSpecManager to fetch the instance
+        associated with the modified file, which is then replaced in the cache.
+        """
+        kernel_name = event.src_kernel_name
+        try:
+            kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+            self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+        except Exception as e:
+            self.log.warning(
+                "The following exception occurred updating cache entry for: {src_resource_dir} "
+                "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+            )
+
+    def on_moved(self, event):
+        """Fires when a watched file is moved.
+
+        This will trigger the update of the existing cached item, replacing its resource_dir entry
+        with that of the new destination.
+        """
+        src_kernel_name = event.src_kernel_name
+        dest_kernel_name = event.dest_kernel_name
+        cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
+        cache_item["resource_dir"] = event.dest_resource_dir
+        self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)

--- a/jupyter_server/services/kernelspecs/kernelspec_cache.py
+++ b/jupyter_server/services/kernelspecs/kernelspec_cache.py
@@ -51,13 +51,15 @@ class KernelSpecCache(LoggingConfigurable):
 
     kernel_spec_manager = Instance("jupyter_client.kernelspec.KernelSpecManager")
 
+    monitor_name_env = "JUPYTER_KERNELSPEC_MONITOR_NAME"
     monitor_name = Unicode(
-        help="""The name of the entry_point used to monitor changes to kernelspecs.""",
+        help="""The name of the entry_point used to monitor changes to kernelspecs.
+(JUPYTER_KERNELSPEC_MONITOR_NAME env var)""",
     ).tag(config=True)
 
     @default("monitor_name")
     def _monitor_name_default(self):
-        return "polling-monitor"
+        return os.getenv(self.monitor_name_env, "polling-monitor")
 
     # The kernelspec cache consists of a dictionary mapping the kernel name to the actual
     # kernelspec data (CacheItemType).

--- a/jupyter_server/services/kernelspecs/kernelspec_cache.py
+++ b/jupyter_server/services/kernelspecs/kernelspec_cache.py
@@ -9,7 +9,7 @@ from typing import Dict, Optional, Union
 
 from jupyter_client.kernelspec import KernelSpec
 from overrides import overrides
-from traitlets.config import SingletonConfigurable
+from traitlets.config import LoggingConfigurable
 from traitlets.traitlets import CBool, Instance, Type, default
 
 from jupyter_server.utils import ensure_async
@@ -20,7 +20,7 @@ from jupyter_server.utils import ensure_async
 CacheItemType = Dict[str, Union[str, Dict]]
 
 
-class KernelSpecCache(SingletonConfigurable):
+class KernelSpecCache(LoggingConfigurable):
     """The primary (singleton) instance for managing KernelSpecs.
 
     This class contains the configured KernelSpecManager instance upon

--- a/jupyter_server/services/kernelspecs/kernelspec_cache.py
+++ b/jupyter_server/services/kernelspecs/kernelspec_cache.py
@@ -4,13 +4,19 @@
 
 
 import os
-from abc import ABC, abstractmethod
+import sys
+from abc import ABC, ABCMeta, abstractmethod
 from typing import Dict, Optional, Union
 
+# See compatibility note on `group` keyword in https://docs.python.org/3/library/importlib.metadata.html#entry-points
+if sys.version_info < (3, 10):  # pragma: no cover
+    from importlib_metadata import EntryPoint, entry_points
+else:  # pragma: no cover
+    from importlib.metadata import EntryPoint, entry_points
+
 from jupyter_client.kernelspec import KernelSpec
-from overrides import overrides
 from traitlets.config import LoggingConfigurable
-from traitlets.traitlets import CBool, Instance, Type, default
+from traitlets.traitlets import CBool, Instance, Unicode, default
 
 from jupyter_server.utils import ensure_async
 
@@ -45,14 +51,13 @@ class KernelSpecCache(LoggingConfigurable):
 
     kernel_spec_manager = Instance("jupyter_client.kernelspec.KernelSpecManager")
 
-    monitor_class = Type(
-        klass="jupyter_server.services.kernelspecs.kernelspec_cache.KernelSpecMonitorBase",
-        help="""The monitor class to use to capture kernelspecs.""",
+    monitor_entry_point = Unicode(
+        help="""The monitor entry_point to use to capture kernelspecs updates.""",
     ).tag(config=True)
 
-    @default("monitor_class")
-    def _monitor_class_default(self):
-        return "jupyter_server.services.kernelspecs.kernelspec_cache.KernelSpecWatchdogMonitor"
+    @default("monitor_entry_point")
+    def _monitor_entry_point_default(self):
+        return "watchdog-monitor"
 
     # The kernelspec cache consists of a dictionary mapping the kernel name to the actual
     # kernelspec data (CacheItemType).
@@ -63,7 +68,9 @@ class KernelSpecCache(LoggingConfigurable):
         """Initialize the cache."""
         super().__init__(**kwargs)
         self.kernel_spec_manager = kernel_spec_manager
-        self.kernel_spec_monitor = KernelSpecMonitorBase.create_instance(self)
+        self.kernel_spec_monitor = None
+        if self.cache_enabled:
+            self.kernel_spec_monitor = KernelSpecMonitorBase.create_instance(self)
 
     async def get_kernel_spec(self, kernel_name: str) -> KernelSpec:
         """Get the named kernel specification.
@@ -182,15 +189,45 @@ class KernelSpecCache(LoggingConfigurable):
         return kernel_spec
 
 
-class KernelSpecMonitorBase(ABC):
+class KernelSpecMonitorMeta(ABCMeta, type(LoggingConfigurable)):  # type: ignore
+    pass
+
+
+class KernelSpecMonitorBase(  # type:ignore[misc]
+    ABC, LoggingConfigurable, metaclass=KernelSpecMonitorMeta
+):
+    GROUP_NAME = "jupyter_server.kernelspec_monitors"
+
     @classmethod
     def create_instance(
         cls, kernel_spec_cache: KernelSpecCache, **kwargs
     ) -> "KernelSpecMonitorBase":
         """Creates an instance of the monitor class configured on the KernelSpecCache instance."""
-        monitor_instance = kernel_spec_cache.monitor_class(kernel_spec_cache, **kwargs)
-        monitor_instance.initialize()
-        return monitor_instance
+
+        entry_point_name = kernel_spec_cache.monitor_entry_point
+        eps = entry_points(group=KernelSpecMonitorBase.GROUP_NAME, name=entry_point_name)
+        if eps:
+            ep: EntryPoint = eps[entry_point_name]
+            monitor_class = ep.load()
+            monitor_instance: KernelSpecMonitorBase = monitor_class(
+                kernel_spec_cache=kernel_spec_cache, **kwargs
+            )
+            if not isinstance(monitor_instance, KernelSpecMonitorBase):
+                msg = (
+                    f"Entrypoint '{kernel_spec_cache.monitor_entry_point}' of "
+                    f"group '{KernelSpecMonitorBase.GROUP_NAME}' is not a "
+                    f"subclass of '{KernelSpecMonitorBase.__name__}'"
+                )
+                raise RuntimeError(msg)
+
+            monitor_instance.initialize()
+            return monitor_instance
+        else:
+            msg = (
+                f"Entrypoint '{kernel_spec_cache.monitor_entry_point}' of "
+                f"group '{KernelSpecMonitorBase.GROUP_NAME}' cannot be located."
+            )
+            raise RuntimeError(msg)
 
     @abstractmethod
     def initialize(self) -> None:
@@ -201,140 +238,3 @@ class KernelSpecMonitorBase(ABC):
     def destroy(self) -> None:
         """Destroys the monitor."""
         pass
-
-
-class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
-    """Watchdog handler that filters on specific files deemed representative of a kernel specification."""
-
-    from watchdog.events import FileSystemEventHandler
-
-    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
-        """Initialize the handler."""
-        super().__init__(**kwargs)
-        self.kernel_spec_cache = kernel_spec_cache
-        self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
-        self.log = kernel_spec_cache.log
-        self.observed_dirs = set()  # Tracks which directories are being watched
-        self.observer = None
-
-    @overrides
-    def initialize(self):
-        """Initializes the cache and starts the observer."""
-        from watchdog.observers import Observer
-
-        # Seed the cache and start the observer
-        if self.kernel_spec_cache.cache_enabled:
-            self.observer = Observer()
-            kernelspecs = self.kernel_spec_manager.get_all_specs()
-            self.kernel_spec_cache.put_all_items(kernelspecs)
-            # Following adds, see if any of the manager's kernel dirs are not observed and add them
-            for kernel_dir in self.kernel_spec_manager.kernel_dirs:
-                if kernel_dir not in self.observed_dirs:
-                    if os.path.exists(kernel_dir):
-                        self.log.info(
-                            "KernelSpecCache: observing directory: {kernel_dir}".format(
-                                kernel_dir=kernel_dir
-                            )
-                        )
-                        self.observed_dirs.add(kernel_dir)
-                        self.observer.schedule(
-                            KernelSpecWatchdogMonitor.WatchDogHandler(self),
-                            kernel_dir,
-                            recursive=True,
-                        )
-                    else:
-                        self.log.warning(
-                            "KernelSpecCache: kernel_dir '{kernel_dir}' does not exist"
-                            " and will not be observed.".format(kernel_dir=kernel_dir)
-                        )
-            self.observer.start()
-
-    @overrides
-    def destroy(self) -> None:
-        self.observer = None
-
-    class WatchDogHandler(FileSystemEventHandler):
-        # Events related to these files trigger the management of the KernelSpec cache.  Should we find
-        # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
-        # files in the future) should be added to this list - at which time it should become configurable.
-        watched_files = ["kernel.json"]
-
-        def __init__(self, monitor: "KernelSpecWatchdogMonitor", **kwargs):
-            """Initialize the handler."""
-            super().__init__(**kwargs)
-            self.kernel_spec_cache = monitor.kernel_spec_cache
-            self.log = monitor.kernel_spec_cache.log
-
-        def dispatch(self, event):
-            """Dispatches events pertaining to kernelspecs to the appropriate methods.
-
-
-            The primary purpose of this method is to ensure the action is occurring against
-            the a file in the list of watched files and adds some additional attributes to
-            the event instance to make the actual event handling method easier.
-            :param event:
-                The event object representing the file system event.
-            :type event:
-                :class:`FileSystemEvent`
-            """
-            from watchdog.events import FileMovedEvent
-
-            if os.path.basename(event.src_path) in self.watched_files:
-                src_resource_dir = os.path.dirname(event.src_path)
-                event.src_resource_dir = src_resource_dir
-                event.src_kernel_name = os.path.basename(src_resource_dir)
-                if type(event) is FileMovedEvent:
-                    dest_resource_dir = os.path.dirname(event.dest_path)
-                    event.dest_resource_dir = dest_resource_dir
-                    event.dest_kernel_name = os.path.basename(dest_resource_dir)
-
-                super().dispatch(event)
-
-        def on_created(self, event):
-            """Fires when a watched file is created.
-
-            This will trigger a call to the configured KernelSpecManager to fetch the instance
-            associated with the created file, which is then added to the cache.
-            """
-            kernel_name = event.src_kernel_name
-            try:
-                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
-                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
-            except Exception as e:
-                self.log.warning(
-                    "The following exception occurred creating cache entry for: {src_resource_dir} "
-                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
-                )
-
-        def on_deleted(self, event):
-            """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
-            kernel_name = event.src_kernel_name
-            self.kernel_spec_cache.remove_item(kernel_name)
-
-        def on_modified(self, event):
-            """Fires when a watched file is modified.
-
-            This will trigger a call to the configured KernelSpecManager to fetch the instance
-            associated with the modified file, which is then replaced in the cache.
-            """
-            kernel_name = event.src_kernel_name
-            try:
-                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
-                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
-            except Exception as e:
-                self.log.warning(
-                    "The following exception occurred updating cache entry for: {src_resource_dir} "
-                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
-                )
-
-        def on_moved(self, event):
-            """Fires when a watched file is moved.
-
-            This will trigger the update of the existing cached item, replacing its resource_dir entry
-            with that of the new destination.
-            """
-            src_kernel_name = event.src_kernel_name
-            dest_kernel_name = event.dest_kernel_name
-            cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
-            cache_item["resource_dir"] = event.dest_resource_dir
-            self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)

--- a/jupyter_server/services/kernelspecs/kernelspec_cache.py
+++ b/jupyter_server/services/kernelspecs/kernelspec_cache.py
@@ -51,12 +51,12 @@ class KernelSpecCache(LoggingConfigurable):
 
     kernel_spec_manager = Instance("jupyter_client.kernelspec.KernelSpecManager")
 
-    monitor_entry_point = Unicode(
-        help="""The monitor entry_point to use to capture kernelspecs updates.""",
+    monitor_name = Unicode(
+        help="""The name of the entry_point used to monitor changes to kernelspecs.""",
     ).tag(config=True)
 
-    @default("monitor_entry_point")
-    def _monitor_entry_point_default(self):
+    @default("monitor_name")
+    def _monitor_name_default(self):
         return "polling-monitor"
 
     # The kernelspec cache consists of a dictionary mapping the kernel name to the actual
@@ -72,7 +72,7 @@ class KernelSpecCache(LoggingConfigurable):
         if self.cache_enabled:
             # Remove configurable traits that have no bearing on monitors
             kwargs.pop("cache_enabled", None)
-            kwargs.pop("monitor_entry_point", None)
+            kwargs.pop("monitor_name", None)
             self.kernel_spec_monitor = KernelSpecMonitorBase.create_instance(self, **kwargs)
 
     async def get_kernel_spec(self, kernel_name: str) -> KernelSpec:
@@ -214,7 +214,7 @@ class KernelSpecMonitorBase(  # type:ignore[misc]
         """Creates an instance of the monitor class configured on the KernelSpecCache instance."""
 
         kernel_spec_cache = kernel_spec_cache
-        entry_point_name = kernel_spec_cache.monitor_entry_point
+        entry_point_name = kernel_spec_cache.monitor_name
         eps = entry_points(group=KernelSpecMonitorBase.GROUP_NAME, name=entry_point_name)
         if eps:
             ep: EntryPoint = eps[entry_point_name]
@@ -222,7 +222,7 @@ class KernelSpecMonitorBase(  # type:ignore[misc]
             monitor_instance: KernelSpecMonitorBase = monitor_class(kernel_spec_cache, **kwargs)
             if not isinstance(monitor_instance, KernelSpecMonitorBase):
                 msg = (
-                    f"Entrypoint '{kernel_spec_cache.monitor_entry_point}' of "
+                    f"Entrypoint '{kernel_spec_cache.monitor_name}' of "
                     f"group '{KernelSpecMonitorBase.GROUP_NAME}' is not a "
                     f"subclass of '{KernelSpecMonitorBase.__name__}'"
                 )
@@ -232,7 +232,7 @@ class KernelSpecMonitorBase(  # type:ignore[misc]
             return monitor_instance
         else:
             msg = (
-                f"Entrypoint '{kernel_spec_cache.monitor_entry_point}' of "
+                f"Entrypoint '{kernel_spec_cache.monitor_name}' of "
                 f"group '{KernelSpecMonitorBase.GROUP_NAME}' cannot be located."
             )
             raise RuntimeError(msg)

--- a/jupyter_server/services/kernelspecs/monitors/__init__.py
+++ b/jupyter_server/services/kernelspecs/monitors/__init__.py
@@ -1,0 +1,1 @@
+from .watchdog_monitor import KernelSpecWatchdogMonitor  # noqa

--- a/jupyter_server/services/kernelspecs/monitors/__init__.py
+++ b/jupyter_server/services/kernelspecs/monitors/__init__.py
@@ -1,1 +1,2 @@
 from .watchdog_monitor import KernelSpecWatchdogMonitor  # noqa
+from .polling_monitor import KernelSpecPollingMonitor  # noqa

--- a/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
@@ -4,6 +4,7 @@
 import json
 import os
 from hashlib import md5
+from typing import Dict
 
 from overrides import overrides
 from traitlets.traitlets import Float, default
@@ -29,7 +30,7 @@ class KernelSpecPollingMonitor(KernelSpecMonitorBase):
 
     # Keep track of hash values for each entry placed into the cache.  This will lessen
     # the churn and noise when publishing events
-    hash_values: dict[str, str]
+    hash_values: Dict[str, str]
 
     def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
         """Initialize the handler."""

--- a/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
@@ -35,10 +35,8 @@ class KernelSpecPollingMonitor(KernelSpecMonitorBase):
         self.log.info(f"Starting {self.__class__.__name__} with interval: {self.interval} ...")
 
     @overrides
-    def initialize(self):
-        """Initializes the cache and starts the registers the periodic poller."""
-
-        # Seed the cache and start the observer
+    def initialize(self) -> None:
+        """Initializes the cache and starts the periodic poller."""
         if self.kernel_spec_cache.cache_enabled:
             self.poll()
             self.start()

--- a/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
@@ -1,0 +1,62 @@
+"""KernelSpec watchdog monitor used by KernelspecCache."""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from overrides import overrides
+from traitlets.traitlets import Float
+
+from ..kernelspec_cache import KernelSpecCache, KernelSpecMonitorBase
+
+
+class KernelSpecPollingMonitor(KernelSpecMonitorBase):
+    """Polling monitor that uses a periodic poll period to reload the kernelspec cache."""
+
+    interval = Float(
+        default_value=30.0,
+        config=True,
+        help="""The interval (in seconds) at which kernelspecs are updated in the cache.""",
+    )
+
+    _pcallback = None
+
+    def __init__(self, **kwargs):
+        """Initialize the handler."""
+        super().__init__(**kwargs)
+        self.kernel_spec_cache: KernelSpecCache = kwargs["parent"]
+        self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
+        self.log.info(f"Starting {self.__class__.__name__} with interval: {self.interval} ...")
+
+    @overrides
+    def initialize(self):
+        """Initializes the cache and starts the registers the periodic poller."""
+
+        # Seed the cache and start the observer
+        if self.kernel_spec_cache.cache_enabled:
+            self.poll()
+            self.start()
+
+    @overrides
+    def destroy(self) -> None:
+        self.stop()
+
+    def poll(self):
+        self.kernel_spec_cache.remove_all_items()
+        kernelspecs = self.kernel_spec_manager.get_all_specs()
+        self.kernel_spec_cache.put_all_items(kernelspecs)
+
+    def start(self):
+        """Start the polling of the kernel."""
+        if self._pcallback is None:
+            from tornado.ioloop import PeriodicCallback
+
+            self._pcallback = PeriodicCallback(
+                self.poll,
+                1000 * self.interval,
+            )
+            self._pcallback.start()
+
+    def stop(self):
+        """Stop the kernel polling."""
+        if self._pcallback is not None:
+            self._pcallback.stop()
+            self._pcallback = None

--- a/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
@@ -1,12 +1,12 @@
 """KernelSpec watchdog monitor used by KernelspecCache."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-
 import json
+import os
 from hashlib import md5
 
 from overrides import overrides
-from traitlets.traitlets import Float
+from traitlets.traitlets import Float, default
 
 from ..kernelspec_cache import KernelSpecCache, KernelSpecMonitorBase
 
@@ -14,11 +14,16 @@ from ..kernelspec_cache import KernelSpecCache, KernelSpecMonitorBase
 class KernelSpecPollingMonitor(KernelSpecMonitorBase):
     """Polling monitor that uses a periodic poll period to reload the kernelspec cache."""
 
+    interval_env = "JUPYTER_POLLING_MONITOR_INTERVAL"
     interval = Float(
-        default_value=30.0,
         config=True,
-        help="""The interval (in seconds) at which kernelspecs are updated in the cache.""",
+        help="""The interval (in seconds) at which kernelspecs are updated in the cache.
+(JUPYTER_POLLING_MONITOR_INTERVAL env var)""",
     )
+
+    @default("interval")
+    def _interval_default(self):
+        return float(os.getenv(self.interval_env, "30.0"))
 
     _pcallback = None
 

--- a/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
@@ -19,10 +19,10 @@ class KernelSpecPollingMonitor(KernelSpecMonitorBase):
 
     _pcallback = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
         """Initialize the handler."""
         super().__init__(**kwargs)
-        self.kernel_spec_cache: KernelSpecCache = kwargs["parent"]
+        self.kernel_spec_cache: KernelSpecCache = kernel_spec_cache
         self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
         self.log.info(f"Starting {self.__class__.__name__} with interval: {self.interval} ...")
 

--- a/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/polling_monitor.py
@@ -4,7 +4,7 @@
 import json
 import os
 from hashlib import md5
-from typing import Dict
+from typing import Any, Dict
 
 from overrides import overrides
 from traitlets.traitlets import Float, default
@@ -12,7 +12,7 @@ from traitlets.traitlets import Float, default
 from ..kernelspec_cache import KernelSpecCache, KernelSpecMonitorBase
 
 
-class KernelSpecPollingMonitor(KernelSpecMonitorBase):
+class KernelSpecPollingMonitor(KernelSpecMonitorBase):  # type:ignore[misc]
     """Polling monitor that uses a periodic poll period to reload the kernelspec cache."""
 
     interval_env = "JUPYTER_POLLING_MONITOR_INTERVAL"
@@ -32,7 +32,7 @@ class KernelSpecPollingMonitor(KernelSpecMonitorBase):
     # the churn and noise when publishing events
     hash_values: Dict[str, str]
 
-    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
+    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs: Any):
         """Initialize the handler."""
         super().__init__(**kwargs)
         self.kernel_spec_cache: KernelSpecCache = kernel_spec_cache

--- a/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
@@ -13,12 +13,11 @@ class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
 
     from watchdog.events import FileSystemEventHandler
 
-    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
+    def __init__(self, **kwargs):
         """Initialize the handler."""
         super().__init__(**kwargs)
-        self.kernel_spec_cache = kernel_spec_cache
+        self.kernel_spec_cache: KernelSpecCache = kwargs["parent"]
         self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
-        self.log = kernel_spec_cache.log
         self.observed_dirs = set()  # Tracks which directories are being watched
         self.observer = None
 

--- a/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
@@ -1,0 +1,145 @@
+"""KernelSpec watchdog monitor used by KernelspecCache."""
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+import os
+
+from overrides import overrides
+
+from ..kernelspec_cache import KernelSpecCache, KernelSpecMonitorBase
+
+
+class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
+    """Watchdog handler that filters on specific files deemed representative of a kernel specification."""
+
+    from watchdog.events import FileSystemEventHandler
+
+    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
+        """Initialize the handler."""
+        super().__init__(**kwargs)
+        self.kernel_spec_cache = kernel_spec_cache
+        self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
+        self.log = kernel_spec_cache.log
+        self.observed_dirs = set()  # Tracks which directories are being watched
+        self.observer = None
+
+    @overrides
+    def initialize(self):
+        """Initializes the cache and starts the observer."""
+        from watchdog.observers import Observer
+
+        # Seed the cache and start the observer
+        if self.kernel_spec_cache.cache_enabled:
+            self.observer = Observer()
+            kernelspecs = self.kernel_spec_manager.get_all_specs()
+            self.kernel_spec_cache.put_all_items(kernelspecs)
+            # Following adds, see if any of the manager's kernel dirs are not observed and add them
+            for kernel_dir in self.kernel_spec_manager.kernel_dirs:
+                if kernel_dir not in self.observed_dirs:
+                    if os.path.exists(kernel_dir):
+                        self.log.info(
+                            "KernelSpecCache: observing directory: {kernel_dir}".format(
+                                kernel_dir=kernel_dir
+                            )
+                        )
+                        self.observed_dirs.add(kernel_dir)
+                        self.observer.schedule(
+                            KernelSpecWatchdogMonitor.WatchDogHandler(self),
+                            kernel_dir,
+                            recursive=True,
+                        )
+                    else:
+                        self.log.warning(
+                            "KernelSpecCache: kernel_dir '{kernel_dir}' does not exist"
+                            " and will not be observed.".format(kernel_dir=kernel_dir)
+                        )
+            self.observer.start()
+
+    @overrides
+    def destroy(self) -> None:
+        self.observer = None
+
+    class WatchDogHandler(FileSystemEventHandler):
+        # Events related to these files trigger the management of the KernelSpec cache.  Should we find
+        # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
+        # files in the future) should be added to this list - at which time it should become configurable.
+        watched_files = ["kernel.json"]
+
+        def __init__(self, monitor: "KernelSpecWatchdogMonitor", **kwargs):
+            """Initialize the handler."""
+            super().__init__(**kwargs)
+            self.kernel_spec_cache = monitor.kernel_spec_cache
+            self.log = monitor.kernel_spec_cache.log
+
+        def dispatch(self, event):
+            """Dispatches events pertaining to kernelspecs to the appropriate methods.
+
+
+            The primary purpose of this method is to ensure the action is occurring against
+            the a file in the list of watched files and adds some additional attributes to
+            the event instance to make the actual event handling method easier.
+            :param event:
+                The event object representing the file system event.
+            :type event:
+                :class:`FileSystemEvent`
+            """
+            from watchdog.events import FileMovedEvent
+
+            if os.path.basename(event.src_path) in self.watched_files:
+                src_resource_dir = os.path.dirname(event.src_path)
+                event.src_resource_dir = src_resource_dir
+                event.src_kernel_name = os.path.basename(src_resource_dir)
+                if type(event) is FileMovedEvent:
+                    dest_resource_dir = os.path.dirname(event.dest_path)
+                    event.dest_resource_dir = dest_resource_dir
+                    event.dest_kernel_name = os.path.basename(dest_resource_dir)
+
+                super().dispatch(event)
+
+        def on_created(self, event):
+            """Fires when a watched file is created.
+
+            This will trigger a call to the configured KernelSpecManager to fetch the instance
+            associated with the created file, which is then added to the cache.
+            """
+            kernel_name = event.src_kernel_name
+            try:
+                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+            except Exception as e:
+                self.log.warning(
+                    "The following exception occurred creating cache entry for: {src_resource_dir} "
+                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+                )
+
+        def on_deleted(self, event):
+            """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
+            kernel_name = event.src_kernel_name
+            self.kernel_spec_cache.remove_item(kernel_name)
+
+        def on_modified(self, event):
+            """Fires when a watched file is modified.
+
+            This will trigger a call to the configured KernelSpecManager to fetch the instance
+            associated with the modified file, which is then replaced in the cache.
+            """
+            kernel_name = event.src_kernel_name
+            try:
+                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+            except Exception as e:
+                self.log.warning(
+                    "The following exception occurred updating cache entry for: {src_resource_dir} "
+                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+                )
+
+        def on_moved(self, event):
+            """Fires when a watched file is moved.
+
+            This will trigger the update of the existing cached item, replacing its resource_dir entry
+            with that of the new destination.
+            """
+            src_kernel_name = event.src_kernel_name
+            dest_kernel_name = event.dest_kernel_name
+            cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
+            cache_item["resource_dir"] = event.dest_resource_dir
+            self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)

--- a/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
@@ -4,14 +4,14 @@
 import os
 
 from overrides import overrides
+from watchdog.events import FileMovedEvent, FileSystemEventHandler
+from watchdog.observers import Observer
 
 from ..kernelspec_cache import KernelSpecCache, KernelSpecMonitorBase
 
 
 class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
     """Watchdog handler that filters on specific files deemed representative of a kernel specification."""
-
-    from watchdog.events import FileSystemEventHandler
 
     def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
         """Initialize the handler."""
@@ -24,9 +24,7 @@ class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
     @overrides
     def initialize(self) -> None:
         """Initializes the cache and starts the observer."""
-        from watchdog.observers import Observer
 
-        # Seed the cache and start the observer
         if self.kernel_spec_cache.cache_enabled:
             self.observer = Observer()
             kernelspecs = self.kernel_spec_manager.get_all_specs()
@@ -41,11 +39,7 @@ class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
                             )
                         )
                         self.observed_dirs.add(kernel_dir)
-                        self.observer.schedule(
-                            KernelSpecWatchdogMonitor.WatchDogHandler(self),
-                            kernel_dir,
-                            recursive=True,
-                        )
+                        self.observer.schedule(WatchDogHandler(self), kernel_dir, recursive=True)
                     else:
                         self.log.warning(
                             "KernelSpecCache: kernel_dir '{kernel_dir}' does not exist"
@@ -57,88 +51,83 @@ class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
     def destroy(self) -> None:
         self.observer = None
 
-    class WatchDogHandler(FileSystemEventHandler):
-        # Events related to these files trigger the management of the KernelSpec cache.  Should we find
-        # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
-        # files in the future) should be added to this list - at which time it should become configurable.
-        watched_files = ["kernel.json"]
 
-        def __init__(self, monitor: "KernelSpecWatchdogMonitor", **kwargs):
-            """Initialize the handler."""
-            super().__init__(**kwargs)
-            self.kernel_spec_cache = monitor.kernel_spec_cache
-            self.log = monitor.kernel_spec_cache.log
+class WatchDogHandler(FileSystemEventHandler):
+    # Events related to these files trigger the management of the KernelSpec cache.  Should we find
+    # other files qualify as indicators of a kernel specification's state (like perhaps detached parameter
+    # files in the future) should be added to this list - at which time it should become configurable.
+    watched_files = ["kernel.json"]
 
-        def dispatch(self, event):
-            """Dispatches events pertaining to kernelspecs to the appropriate methods.
+    def __init__(self, monitor: "KernelSpecWatchdogMonitor", **kwargs):
+        """Initialize the handler."""
+        super().__init__(**kwargs)
+        self.kernel_spec_cache = monitor.kernel_spec_cache
+        self.log = monitor.kernel_spec_cache.log
 
+    def dispatch(self, event):
+        """Dispatches events pertaining to kernelspecs to the appropriate methods.
 
-            The primary purpose of this method is to ensure the action is occurring against
-            the a file in the list of watched files and adds some additional attributes to
-            the event instance to make the actual event handling method easier.
-            :param event:
-                The event object representing the file system event.
-            :type event:
-                :class:`FileSystemEvent`
-            """
-            from watchdog.events import FileMovedEvent
+        The primary purpose of this method is to ensure the action is occurring against
+        a file in the list of watched files and adds some additional attributes to
+        the event instance to make the actual event handling method easier.
+        """
 
-            if os.path.basename(event.src_path) in self.watched_files:
-                src_resource_dir = os.path.dirname(event.src_path)
-                event.src_resource_dir = src_resource_dir
-                event.src_kernel_name = os.path.basename(src_resource_dir)
-                if type(event) is FileMovedEvent:
-                    dest_resource_dir = os.path.dirname(event.dest_path)
-                    event.dest_resource_dir = dest_resource_dir
-                    event.dest_kernel_name = os.path.basename(dest_resource_dir)
+        if os.path.basename(event.src_path) in self.watched_files:
+            src_resource_dir = os.path.dirname(event.src_path)
+            event.src_resource_dir = src_resource_dir
+            event.src_kernel_name = os.path.basename(src_resource_dir)
+            if type(event) is FileMovedEvent:
+                dest_resource_dir = os.path.dirname(event.dest_path)
+                event.dest_resource_dir = dest_resource_dir
+                event.dest_kernel_name = os.path.basename(dest_resource_dir)
 
-                super().dispatch(event)
+            super().dispatch(event)
 
-        def on_created(self, event):
-            """Fires when a watched file is created.
+    def on_created(self, event):
+        """Fires when a watched file is created.
 
-            This will trigger a call to the configured KernelSpecManager to fetch the instance
-            associated with the created file, which is then added to the cache.
-            """
-            kernel_name = event.src_kernel_name
-            try:
-                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
-                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
-            except Exception as e:
-                self.log.warning(
-                    "The following exception occurred creating cache entry for: {src_resource_dir} "
-                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
-                )
+        This will trigger a call to the configured KernelSpecManager to fetch the instance
+        associated with the created file, which is then added to the cache.
+        """
+        kernel_name = event.src_kernel_name
+        try:
+            kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+            self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+        except Exception as e:
+            self.log.warning(
+                "The following exception occurred creating cache entry for: {src_resource_dir} "
+                "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+            )
 
-        def on_deleted(self, event):
-            """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
-            kernel_name = event.src_kernel_name
-            self.kernel_spec_cache.remove_item(kernel_name)
+    def on_deleted(self, event):
+        """Fires when a watched file is deleted, triggering a removal of the corresponding item from the cache."""
+        kernel_name = event.src_kernel_name
+        self.kernel_spec_cache.remove_item(kernel_name)
 
-        def on_modified(self, event):
-            """Fires when a watched file is modified.
+    def on_modified(self, event):
+        """Fires when a watched file is modified.
 
-            This will trigger a call to the configured KernelSpecManager to fetch the instance
-            associated with the modified file, which is then replaced in the cache.
-            """
-            kernel_name = event.src_kernel_name
-            try:
-                kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
-                self.kernel_spec_cache.put_item(kernel_name, kernelspec)
-            except Exception as e:
-                self.log.warning(
-                    "The following exception occurred updating cache entry for: {src_resource_dir} "
-                    "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
-                )
+        This will trigger a call to the configured KernelSpecManager to fetch the instance
+        associated with the modified file, which is then replaced in the cache.
+        """
+        kernel_name = event.src_kernel_name
+        try:
+            kernelspec = self.kernel_spec_cache.kernel_spec_manager.get_kernel_spec(kernel_name)
+            self.kernel_spec_cache.put_item(kernel_name, kernelspec)
+        except Exception as e:
+            self.log.warning(
+                "The following exception occurred updating cache entry for: {src_resource_dir} "
+                "- continuing...  ({e})".format(src_resource_dir=event.src_resource_dir, e=e)
+            )
 
-        def on_moved(self, event):
-            """Fires when a watched file is moved.
+    def on_moved(self, event):
+        """Fires when a watched file is moved.
 
-            This will trigger the update of the existing cached item, replacing its resource_dir entry
-            with that of the new destination.
-            """
-            src_kernel_name = event.src_kernel_name
-            dest_kernel_name = event.dest_kernel_name
-            cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
-            cache_item["resource_dir"] = event.dest_resource_dir
-            self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)
+        This will trigger the update of the existing cached item, replacing its resource_dir entry
+        with that of the new destination.
+        """
+        src_kernel_name = event.src_kernel_name
+        dest_kernel_name = event.dest_kernel_name
+        cache_item = self.kernel_spec_cache.remove_item(src_kernel_name)
+        cache_item["resource_dir"] = event.dest_resource_dir
+        self.kernel_spec_cache.put_item(dest_kernel_name, cache_item)

--- a/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
@@ -22,7 +22,7 @@ class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
         self.observer = None
 
     @overrides
-    def initialize(self):
+    def initialize(self) -> None:
         """Initializes the cache and starts the observer."""
         from watchdog.observers import Observer
 

--- a/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
+++ b/jupyter_server/services/kernelspecs/monitors/watchdog_monitor.py
@@ -13,10 +13,10 @@ class KernelSpecWatchdogMonitor(KernelSpecMonitorBase):
 
     from watchdog.events import FileSystemEventHandler
 
-    def __init__(self, **kwargs):
+    def __init__(self, kernel_spec_cache: KernelSpecCache, **kwargs):
         """Initialize the handler."""
         super().__init__(**kwargs)
-        self.kernel_spec_cache: KernelSpecCache = kwargs["parent"]
+        self.kernel_spec_cache: KernelSpecCache = kernel_spec_cache
         self.kernel_spec_manager = self.kernel_spec_cache.kernel_spec_manager
         self.observed_dirs = set()  # Tracks which directories are being watched
         self.observer = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ jupyter-server = "jupyter_server.serverapp:main"
 
 [project.entry-points."jupyter_server.kernelspec_monitors"]
 watchdog-monitor = "jupyter_server.services.kernelspecs.monitors:KernelSpecWatchdogMonitor"
+polling-monitor = "jupyter_server.services.kernelspecs.monitors:KernelSpecPollingMonitor"
 
 [tool.hatch.envs.docs]
 features = ["docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "tornado>=6.2.0",
     "traitlets>=5.6.0",
     "websocket-client",
-    "watchdog",
     "jupyter_events>=0.6.0",
     "overrides"
 ]
@@ -90,13 +89,16 @@ docs = [
     # missing typing_extensions
     "typing_extensions"
 ]
+watchdog-monitor = [
+    "watchdog"
+]
 
 [project.scripts]
 jupyter-server = "jupyter_server.serverapp:main"
 
 [project.entry-points."jupyter_server.kernelspec_monitors"]
-watchdog-monitor = "jupyter_server.services.kernelspecs.monitors:KernelSpecWatchdogMonitor"
 polling-monitor = "jupyter_server.services.kernelspecs.monitors:KernelSpecPollingMonitor"
+watchdog-monitor = "jupyter_server.services.kernelspecs.monitors:KernelSpecWatchdogMonitor"
 
 [tool.hatch.envs.docs]
 features = ["docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ docs = [
 [project.scripts]
 jupyter-server = "jupyter_server.serverapp:main"
 
+[project.entry-points."jupyter_server.kernelspec_monitors"]
+watchdog-monitor = "jupyter_server.services.kernelspecs.monitors:KernelSpecWatchdogMonitor"
+
 [tool.hatch.envs.docs]
 features = ["docs"]
 [tool.hatch.envs.docs.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
     "traitlets>=5.6.0",
     "websocket-client",
     "jupyter_events>=0.6.0",
-    "overrides"
+    "overrides",
+    "importlib_metadata>=4.8.3;python_version<\"3.10\"",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,6 +265,8 @@ unfixable = [
 # S603 `subprocess` call: check for execution of untrusted input
 "jupyter_server/services/contents/filemanager.py" = ["S603", "S607"]
 "tests/unix_sockets/test_serverapp_integration.py" = ["S603", "S607"]
+# S324 Probable use of insecure hash functions in `hashlib`: `md5` (ok - used as checksum for kernelspec cache)
+"jupyter_server/services/kernelspecs/monitors/polling_monitor.py" = ["S324"]
 
 [tool.pytest.ini_options]
 addopts = "-raXs --durations 10 --color=yes --doctest-modules"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,9 @@ docs = [
     "tornado",
     # workaround for an unknown downstream library that is now
     # missing typing_extensions
-    "typing_extensions"
+    "typing_extensions",
+    # required to build api docs
+    "watchdog"
 ]
 watchdog-monitor = [
     "watchdog"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "tornado>=6.2.0",
     "traitlets>=5.6.0",
     "websocket-client",
+    "watchdog",
     "jupyter_events>=0.6.0",
     "overrides"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,9 @@ test = [
     "pytest-jupyter[server]>=0.4",
     "pytest>=7.0",
     "requests",
-    "pre-commit"
+    "pre-commit",
+    # needed to test kernelspec monitors
+    "watchdog"
 ]
 docs = [
     # needed because m2r uses deprecated APIs

--- a/tests/services/kernelspecs/test_kernelspec_cache.py
+++ b/tests/services/kernelspecs/test_kernelspec_cache.py
@@ -1,0 +1,195 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for KernelSpecCache."""
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+
+import jupyter_core.paths
+import pytest
+from jupyter_client.kernelspec import KernelSpecManager, NoSuchKernel
+
+from jupyter_server.services.kernelspecs.kernelspec_cache import KernelSpecCache
+
+
+# BEGIN - Remove once transition to jupyter_server occurs
+def mkdir(tmp_path, *parts):
+    path = tmp_path.joinpath(*parts)
+    if not path.exists():
+        path.mkdir(parents=True)
+    return path
+
+
+home_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "home"))
+data_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "data"))
+config_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "config"))
+runtime_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "runtime"))
+system_jupyter_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "share", "jupyter"))
+env_jupyter_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "env", "share", "jupyter"))
+system_config_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "etc", "jupyter"))
+env_config_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "env", "etc", "jupyter"))
+
+
+@pytest.fixture
+def environ(
+    monkeypatch,
+    tmp_path,
+    home_dir,
+    data_dir,
+    config_dir,
+    runtime_dir,
+    system_jupyter_path,
+    system_config_path,
+    env_jupyter_path,
+    env_config_path,
+):
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join(sys.path))
+    monkeypatch.setenv("JUPYTER_NO_CONFIG", "1")
+    monkeypatch.setenv("JUPYTER_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("JUPYTER_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("JUPYTER_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.setattr(jupyter_core.paths, "SYSTEM_JUPYTER_PATH", [str(system_jupyter_path)])
+    monkeypatch.setattr(jupyter_core.paths, "ENV_JUPYTER_PATH", [str(env_jupyter_path)])
+    monkeypatch.setattr(jupyter_core.paths, "SYSTEM_CONFIG_PATH", [str(system_config_path)])
+    monkeypatch.setattr(jupyter_core.paths, "ENV_CONFIG_PATH", [str(env_config_path)])
+
+
+# END - Remove once transition to jupyter_server occurs
+
+
+kernelspec_json = {
+    "argv": ["cat", "{connection_file}"],
+    "display_name": "Test kernel: {kernel_name}",
+}
+
+
+def _install_kernelspec(kernels_dir, kernel_name):
+    """install a sample kernel in a kernels directory"""
+    kernelspec_dir = os.path.join(kernels_dir, kernel_name)
+    os.makedirs(kernelspec_dir)
+    json_file = os.path.join(kernelspec_dir, "kernel.json")
+    named_json = kernelspec_json.copy()
+    named_json["display_name"] = named_json["display_name"].format(kernel_name=kernel_name)
+    with open(json_file, "w") as f:
+        json.dump(named_json, f)
+    return kernelspec_dir
+
+
+def _modify_kernelspec(kernelspec_dir, kernel_name):
+    json_file = os.path.join(kernelspec_dir, "kernel.json")
+    kernel_json = kernelspec_json.copy()
+    kernel_json["display_name"] = f"{kernel_name} modified!"
+    with open(json_file, "w") as f:
+        json.dump(kernel_json, f)
+
+
+kernelspec_location = pytest.fixture(lambda data_dir: mkdir(data_dir, "kernels"))
+other_kernelspec_location = pytest.fixture(
+    lambda env_jupyter_path: mkdir(env_jupyter_path, "kernels")
+)
+
+
+@pytest.fixture
+def setup_kernelspecs(environ, kernelspec_location):
+    # Only populate factory info
+    _install_kernelspec(str(kernelspec_location), "test1")
+    _install_kernelspec(str(kernelspec_location), "test2")
+    _install_kernelspec(str(kernelspec_location), "test3")
+
+
+@pytest.fixture
+def kernel_spec_manager(environ, setup_kernelspecs):
+    yield KernelSpecManager(ensure_native_kernel=False)
+
+
+@pytest.fixture
+def kernel_spec_cache(is_enabled, kernel_spec_manager):
+    kspec_cache = KernelSpecCache.instance(
+        kernel_spec_manager=kernel_spec_manager, cache_enabled=is_enabled
+    )
+    yield kspec_cache
+    kspec_cache = None
+    KernelSpecCache.clear_instance()
+
+
+@pytest.fixture(params=[False, True])  # Add types as needed
+def is_enabled(request):
+    return request.param
+
+
+async def tests_get_all_specs(kernel_spec_cache):
+    kspecs = await kernel_spec_cache.get_all_specs()
+    assert len(kspecs) == 3
+
+
+async def tests_get_named_spec(kernel_spec_cache):
+    kspec = await kernel_spec_cache.get_kernel_spec("test2")
+    assert kspec.display_name == "Test kernel: test2"
+
+
+async def tests_get_modified_spec(kernel_spec_cache):
+    kspec = await kernel_spec_cache.get_kernel_spec("test2")
+    assert kspec.display_name == "Test kernel: test2"
+
+    # Modify entry
+    _modify_kernelspec(kspec.resource_dir, "test2")
+    await asyncio.sleep(0.5)  # sleep for a half-second to allow cache to update item
+    kspec = await kernel_spec_cache.get_kernel_spec("test2")
+    assert kspec.display_name == "test2 modified!"
+
+
+async def tests_add_spec(kernel_spec_cache, kernelspec_location, other_kernelspec_location):
+    assert len(kernel_spec_cache.observed_dirs) == (1 if kernel_spec_cache.cache_enabled else 0)
+    assert (
+        str(kernelspec_location) in kernel_spec_cache.observed_dirs
+        if kernel_spec_cache.cache_enabled
+        else True
+    )
+
+    _install_kernelspec(str(other_kernelspec_location), "added")
+    kspec = await kernel_spec_cache.get_kernel_spec("added")
+
+    # Ensure new location has been added to observed_dirs
+    assert len(kernel_spec_cache.observed_dirs) == (2 if kernel_spec_cache.cache_enabled else 0)
+    assert (
+        str(other_kernelspec_location) in kernel_spec_cache.observed_dirs
+        if kernel_spec_cache.cache_enabled
+        else True
+    )
+
+    assert kspec.display_name == "Test kernel: added"
+    assert kernel_spec_cache.cache_misses == (1 if kernel_spec_cache.cache_enabled else 0)
+
+    # Add another to an existing observed directory, no cache miss here
+    _install_kernelspec(str(kernelspec_location), "added2")
+    await asyncio.sleep(
+        0.5
+    )  # sleep for a half-second to allow cache to add item (no cache miss in this case)
+    kspec = await kernel_spec_cache.get_kernel_spec("added2")
+
+    assert kspec.display_name == "Test kernel: added2"
+    assert kernel_spec_cache.cache_misses == (1 if kernel_spec_cache.cache_enabled else 0)
+
+
+async def tests_remove_spec(kernel_spec_cache):
+    kspec = await kernel_spec_cache.get_kernel_spec("test2")
+    assert kspec.display_name == "Test kernel: test2"
+
+    assert kernel_spec_cache.cache_misses == 0
+    shutil.rmtree(kspec.resource_dir)
+    await asyncio.sleep(0.5)  # sleep for a half-second to allow cache to remove item
+    with pytest.raises(NoSuchKernel):
+        await kernel_spec_cache.get_kernel_spec("test2")
+
+    assert kernel_spec_cache.cache_misses == (1 if kernel_spec_cache.cache_enabled else 0)
+
+
+async def tests_get_missing(kernel_spec_cache):
+    with pytest.raises(NoSuchKernel):
+        await kernel_spec_cache.get_kernel_spec("missing")
+
+    assert kernel_spec_cache.cache_misses == (1 if kernel_spec_cache.cache_enabled else 0)

--- a/tests/services/kernelspecs/test_kernelspec_cache.py
+++ b/tests/services/kernelspecs/test_kernelspec_cache.py
@@ -79,6 +79,8 @@ def kernel_spec_cache(
     )
     app = jp_configurable_serverapp(config=config)
     yield app.kernel_spec_cache
+    app.kernel_spec_cache = None
+    app.clear_instance()
 
 
 def get_delay_factor(kernel_spec_cache: KernelSpecCache):

--- a/tests/services/kernelspecs/test_kernelspec_cache.py
+++ b/tests/services/kernelspecs/test_kernelspec_cache.py
@@ -167,7 +167,7 @@ async def tests_remove_spec(kernel_spec_cache):
 
     assert kernel_spec_cache.cache_misses == 0
     shutil.rmtree(kspec.resource_dir)
-    await asyncio.sleep(1.5)  # sleep for a half-second to allow cache to remove item
+    await asyncio.sleep(0.5)  # sleep for a half-second to allow cache to remove item
     with pytest.raises(NoSuchKernel):
         await kernel_spec_cache.get_kernel_spec("test2")
 

--- a/tests/services/kernelspecs/test_kernelspec_cache.py
+++ b/tests/services/kernelspecs/test_kernelspec_cache.py
@@ -69,7 +69,7 @@ def kernel_spec_cache(
                 },
                 "KernelSpecCache": {
                     "cache_enabled": is_enabled,
-                    "monitor_entry_point": request.param,
+                    "monitor_name": request.param,
                 },
                 "KernelSpecPollingMonitor": {
                     "interval": 1.0 if request.param == "polling-monitor" else 30.0,
@@ -83,7 +83,7 @@ def kernel_spec_cache(
 
 def get_delay_factor(kernel_spec_cache: KernelSpecCache):
     if kernel_spec_cache.cache_enabled:
-        if kernel_spec_cache.monitor_entry_point == "polling-monitor":
+        if kernel_spec_cache.monitor_name == "polling-monitor":
             return 2.0
         return 1.0
     return 0.5

--- a/tests/services/kernelspecs/test_kernelspec_cache.py
+++ b/tests/services/kernelspecs/test_kernelspec_cache.py
@@ -108,12 +108,8 @@ def kernel_spec_manager(environ, setup_kernelspecs):
 
 @pytest.fixture
 def kernel_spec_cache(is_enabled, kernel_spec_manager):
-    kspec_cache = KernelSpecCache.instance(
-        kernel_spec_manager=kernel_spec_manager, cache_enabled=is_enabled
-    )
+    kspec_cache = KernelSpecCache(kernel_spec_manager=kernel_spec_manager, cache_enabled=is_enabled)
     yield kspec_cache
-    kspec_cache = None
-    KernelSpecCache.clear_instance()
 
 
 @pytest.fixture(params=[False, True])  # Add types as needed


### PR DESCRIPTION
# Kernelspec Caching
This pull request introduces a new configurable feature called KernelSpec Caching.  The `KernelSpecCache` instance supports the same retrieval methods as a `KernelSpecManager` and contains the configured `KernelSpecManager` instance.  If caching is not enabled (by default), the cache is a direct pass-through to the `KernelSpecManager`, otherwise it acts as a _read through_ cache, deferring to the `KernelSpecManager` on any cache misses.  This functionality has proven useful in Enterprise Gateway where it has existed for a few years.  In that implementation, the `watchdog` package is used to determine cache updates.

By introducing kernelspec caching, we can now define events corresponding to the addition, update, and deletion of kernel specifications and get closer to removing the 10-second polling performed by Lab once it has been updated to consume kernelspec events.

## Monitors
Besides its enablement via the `cache_enabled` configurable, `KernelSpecCache` supports pluggable _monitors_ that are responsible for detecting changes to the cached items and keeping the cache updated due to _out-of-band_ updates.  A kernelspec cache monitor is registered via the entry points group `"jupyter_server.kernelspec_monitors"` to introduce a layer of decoupling.  This pull request includes two monitors:
- `KernelSpecWatchdogMonitor` under the entry point name `"watchdog-monitor"`:
    This monitor uses the `watchdog` package to monitor changes to directories containing kernelspec definitions.  Because this monitor uses the `watchdog` package, an optional dependency has been added for users wishing to use this monitor: `pip install jupyter_server[watchdog-monitor]`
- `KernelSpecPollingMonitor` under the entry point name `"polling-monitor"`:
    This monitor periodically polls (via a configurable `interval` trait) for kernelspec changes and computes an MD5 hash on each entry to further determine changes.  It only updates the cache when the hash values have changed (or are new) and when it determines a kernelspec has been removed.  The interval's default value is 30 (sec).

`KernelSpecPollingMonitor` is the default monitor used since it does not introduce new packages.  

Other monitors that would be useful are:
- an _event consumer_ monitor where, once we add event _production_ to the cache, then an event _consumer_ monitor could be used to receive kernelspec update events from remote Kernel Servers (e.g., Gateway or jupyverse) rather than having to rely on polling.
- a monitor similar to the `"watchdog-monitor"`, but using `watchfiles` instead, since we have other needs for `watchfiles`.  At that point, we may be able to make `"watchfiles-monitor"` the default - assuming we include the `watchfiles` package.

KernelSpec caching is **disabled** by default.  If we want to enable it by default, we'll need to adjust some tests (probably only kernelspecs and perhaps kernels api tests) to configure a much shorter polling interval, or switch the default to the `"watchfiles-monitor"` (once implemented) since it sounds like there's a preference to `watchfiles` over `watchdog`.  (Note: Enterprise Gateway happened to use `watchdog` a few years ago, thus the reason the watchdog monitor exists.  If we built a `"watchfiles-monitor"`, I have no affinity for `"watchdog-monitor"` and see no reason to keep it unless we find advantages over `watchfiles`.)

## Class Hierarchy
`KernelSpecCache` contains instances of the `KernelSpecManager` and `KernelSpecMonitorBase` that corresponds to the `monitor_name` configurable.
```mermaid
---
title: KernelSpecCache Class Hierarchy
---
classDiagram
    KernelSpecCache --* KernelSpecManager
    KernelSpecCache --* KernelSpecMonitorBase
    KernelSpecMonitorBase <|-- KernelSpecWatchdogMonitor
    KernelSpecMonitorBase <|-- KernelSpecPollingMonitor
    KernelSpecMonitorBase <|-- BYOMonitor
    class KernelSpecCache{
      +str monitor_name
      +bool cache_enabled
      +get_kernel_spec(name)
      +get_all_specs()
      +get_item(name)
      +get_all_items()
      +put_item()
      +put_all_items()
      +remove_item(name)
      +remove_all_items()
    }
    class KernelSpecManager{
      +get_kernel_spec(name)
      +get_all_specs()
    }
    class KernelSpecMonitorBase["KernelSpecMonitorBase (ABC)"]{
      +initialize()*
      +destroy()*
    }
    class KernelSpecPollingMonitor{
      +float interval
    }
```

## Event Support (Future)
With caching in place, we should be able to fire _add_ and _update_ kernelspec events from `KernelSpecCache.put_item()` and _delete_ kernelspec events from `KernelSpecCache.remove_item()` since their corresponding _all items_ methods simply call on the singleton versions.