### PR TITLE
Add Restart In Place API Support

### DIFF
--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -94,9 +94,9 @@ class KernelActionHandler(KernelsAPIHandler):
         if action == "interrupt":
             await ensure_async(km.interrupt_kernel(kernel_id))
             self.set_status(204)
-        if action == "restart":
+        if action == "restart" or action == "restart-in-place":
             try:
-                await km.restart_kernel(kernel_id)
+                await km.restart_kernel(kernel_id, restart_in_place=action == "restart-in-place")
             except Exception as e:
                 message = "Exception restarting kernel"
                 self.log.error(message, exc_info=True)
@@ -113,7 +113,7 @@ class KernelActionHandler(KernelsAPIHandler):
 # URL to handler mappings
 # -----------------------------------------------------------------------------
 _kernel_id_regex = r"(?P<kernel_id>\w+-\w+-\w+-\w+-\w+)"
-_kernel_action_regex = r"(?P<action>restart|interrupt)"
+_kernel_action_regex = r"(?P<action>restart|interrupt|restart-in-place)"
 
 default_handlers = [
     (r"/api/kernels", MainKernelHandler),

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -17,7 +17,10 @@ from typing import Dict as DictType
 from typing import Optional
 
 from jupyter_client.ioloop.manager import AsyncIOLoopKernelManager
-from jupyter_client.multikernelmanager import AsyncMultiKernelManager, MultiKernelManager
+from jupyter_client.multikernelmanager import (
+    AsyncMultiKernelManager,
+    MultiKernelManager,
+)
 from jupyter_client.session import Session
 from jupyter_core.paths import exists
 from jupyter_core.utils import ensure_async
@@ -207,7 +210,11 @@ class MappingKernelManager(MultiKernelManager):
     # TODO DEC 2022: Revise the type-ignore once the signatures have been changed upstream
     # https://github.com/jupyter/jupyter_client/pull/905
     async def _async_start_kernel(  # type:ignore[override]
-        self, *, kernel_id: Optional[str] = None, path: Optional[ApiPath] = None, **kwargs: str
+        self,
+        *,
+        kernel_id: Optional[str] = None,
+        path: Optional[ApiPath] = None,
+        **kwargs: str,
     ) -> str:
         """Start a kernel for a session and return its kernel_id.
 
@@ -434,10 +441,12 @@ class MappingKernelManager(MultiKernelManager):
 
     shutdown_kernel = _async_shutdown_kernel
 
-    async def _async_restart_kernel(self, kernel_id, now=False):
+    async def _async_restart_kernel(self, kernel_id, now=False, restart_in_place=False):
         """Restart a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        await self.pinned_superclass._async_restart_kernel(self, kernel_id, now=now)
+        await self.pinned_superclass._async_restart_kernel(
+            self, kernel_id, now=now, restart_in_place=restart_in_place
+        )
         kernel = self.get_kernel(kernel_id)
         # return a Future that will resolve when the kernel has successfully restarted
         channel = kernel.connect_shell()
@@ -743,7 +752,9 @@ def emit_kernel_action_event(success_msg: str = ""):  # type: ignore
                     "action": action,
                     "status": "success",
                     "msg": success_msg.format(
-                        kernel_id=self.kernel_id, kernel_name=self.kernel_name, action=action
+                        kernel_id=self.kernel_id,
+                        kernel_name=self.kernel_name,
+                        action=action,
                     ),
                 }
                 if self.kernel_id:

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -17,10 +17,7 @@ from typing import Dict as DictType
 from typing import Optional
 
 from jupyter_client.ioloop.manager import AsyncIOLoopKernelManager
-from jupyter_client.multikernelmanager import (
-    AsyncMultiKernelManager,
-    MultiKernelManager,
-)
+from jupyter_client.multikernelmanager import AsyncMultiKernelManager, MultiKernelManager
 from jupyter_client.session import Session
 from jupyter_core.paths import exists
 from jupyter_core.utils import ensure_async
@@ -210,11 +207,7 @@ class MappingKernelManager(MultiKernelManager):
     # TODO DEC 2022: Revise the type-ignore once the signatures have been changed upstream
     # https://github.com/jupyter/jupyter_client/pull/905
     async def _async_start_kernel(  # type:ignore[override]
-        self,
-        *,
-        kernel_id: Optional[str] = None,
-        path: Optional[ApiPath] = None,
-        **kwargs: str,
+        self, *, kernel_id: Optional[str] = None, path: Optional[ApiPath] = None, **kwargs: str
     ) -> str:
         """Start a kernel for a session and return its kernel_id.
 
@@ -752,9 +745,7 @@ def emit_kernel_action_event(success_msg: str = ""):  # type: ignore
                     "action": action,
                     "status": "success",
                     "msg": success_msg.format(
-                        kernel_id=self.kernel_id,
-                        kernel_name=self.kernel_name,
-                        action=action,
+                        kernel_id=self.kernel_id, kernel_name=self.kernel_name, action=action
                     ),
                 }
                 if self.kernel_id:


### PR DESCRIPTION
Jupyter Server implementation of [this JEP](https://github.com/jupyter/enhancement-proposals/issues/117)

- Adds a new API endpoint for restarting kernels in place
- Passes a boolean restart_in_place flag through MappingKernelManager