### PR TITLE
Fix notebook URL opened in browser when redirect file not used

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2781,6 +2781,10 @@ class ServerApp(JupyterApp):
             if self.identity_provider.token:
                 uri = url_concat(uri, {"token": self.identity_provider.token})
 
+            if self.file_to_run:
+                file_to_run_relpath = self._resolve_file_to_run_and_root_dir()
+                uri = url_escape(url_path_join(uri, *file_to_run_relpath.split(os.sep)))
+
         if self.file_to_run:  # noqa
             # Create a separate, temporary open-browser-file
             # pointing at a specific file.


### PR DESCRIPTION
Fix #1325.

With `notebook~=7.0` ServerApp is responsible for launching browser, not NotebookApp anymore. In `notebook~=6.0`, `launch_browser` will [append notebook path](https://github.com/jupyter/notebook/blob/e946154112daa5ef997d7f549953cce91b336d3d/notebook/notebookapp.py#L2171) for opening in browser even when `use_redirect_file` is set to `false`.

ServerApp used to do the same, last time in [v1.3.0](https://github.com/jupyter-server/jupyter_server/blob/75f9798aec93ef24ba954b355b720961d28eb379/jupyter_server/serverapp.py#L1931). The change in behavior/bug seems to be introduced in [1bbcbcb359](https://github.com/jupyter-server/jupyter_server/commit/1bbcbcb359601f6b0a9e1afd16720df09920aa64), released as 1.4.0.