### PR TITLE
Add resolvePath API for resolving kernel-relative paths

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,7 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.9"
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
           [mdformat-gfm, mdformat-frontmatter, mdformat-footnote]
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.3
     hooks:
       - id: prettier
         types_or: [yaml, html, json]
@@ -53,17 +53,35 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.20.0"
+    rev: "v1.20.2"
     hooks:
       - id: mypy
         files: jupyter_server
         stages: [manual]
         additional_dependencies:
-          ["traitlets>=5.13", "jupyter_core>=5.5", "jupyter_client>=8.5"]
+          [
+            "anyio>=3.1.0",
+            "jinja2>=3.0.3",
+            "jupyter_client>=8.5",
+            "jupyter_core>=5.5",
+            "jupyter_events>=0.11.0",
+            "jupyter_server_terminals>=0.4.4",
+            "nbconvert>=6.4.4",
+            "nbformat>=5.3.0",
+            "overrides>=5.0",
+            "packaging>=22.0",
+            "prometheus_client>=0.9",
+            "pyzmq>=24",
+            "Send2Trash>=1.8.2",
+            "terminado>=0.8.3",
+            "tornado>=6.2.0",
+            "traitlets>=5.13",
+            "websocket-client>=1.7",
+          ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # keep the revision in sync with the ruff version in pyproject.toml
-    rev: v0.15.9
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         types_or: [python, jupyter]

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -96,7 +96,7 @@ class ExtensionHandlerMixin:
         if template.environment is self.settings["jinja2_env"]:
             # default template environment, use default static_url
             ns["static_url"] = super().static_url  # type:ignore[misc]
-        return cast("str", template.render(**ns))
+        return template.render(**ns)
 
     @property
     def static_url_prefix(self) -> str:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -391,7 +391,7 @@ class ServerWebApplication(web.Application):
             localedir=os.path.join(base_dir, "jupyter_server/i18n"),
             fallback=True,
         )
-        env.install_gettext_translations(nbui, newstyle=False)
+        env.install_gettext_translations(nbui, newstyle=False)  # type: ignore[attr-defined]
 
         if sys_info["commit_source"] == "repository":
             # don't cache (rely on 304) when working from master

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -372,6 +372,26 @@ paths:
       responses:
         204:
           description: Checkpoint deleted
+  /api/resolvePath:
+    parameters:
+      - name: path
+        required: true
+        in: query
+        description: file path
+        type: string
+      - name: kernel_id
+        required: false
+        in: query
+        description: kernel uuid
+        type: string
+        format: uuid
+    get:
+      summary: Resolve path to a file
+      responses:
+        200:
+          description: Resolved path with scope details
+          schema:
+            $ref: "#/definitions/ResolvedPath"
   /api/sessions/{session}:
     parameters:
       - $ref: "#/parameters/session"
@@ -973,3 +993,24 @@ definitions:
           ISO 8601 timestamp for the last-seen activity on this terminal.  Use
           this to identify which terminals have been inactive since a given time.
           Timestamps will be UTC, indicated 'Z' suffix.
+  ResolvedPath:
+    description: Resolved file path details
+    type: object
+    required:
+      - resolved
+    properties:
+      resolved:
+        type: array
+        description: array of paths to which the query path resolves
+        items:
+          type: object
+          required:
+            - scope
+            - path
+          properties:
+            scope:
+              type: string
+              description: the scope which owns the path
+            path:
+              type: string
+              description: fully specified path for file

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -52,7 +52,7 @@ class APIStatusHandler(APIHandler):
 
     @web.authenticated
     @authorized
-    async def get(self):
+    async def get(self) -> None:
         """Get the API status."""
         # if started was missing, use unix epoch
         started = self.settings.get("started", utcfromtimestamp(0))
@@ -140,8 +140,33 @@ class IdentityHandler(APIHandler):
             raise web.HTTPError(501, str(e)) from e
 
 
+class PathResolverHandler(APIHandler):
+    """Path resolver handler."""
+
+    auth_resource = AUTH_RESOURCE
+    _track_activity = False
+
+    @web.authenticated
+    @authorized
+    async def get(self):
+        """Resolve the path."""
+        path = self.get_query_argument("path")
+        kernel_uuid = self.get_query_argument("kernel", default=None)
+        scopes: dict[str, Any] = {"server": self.contents_manager}
+        if kernel_uuid:
+            scopes["kernel"] = self.kernel_manager.get_kernel(kernel_uuid)
+        resolved = [
+            {"scope": name, "path": await ensure_async(scope.resolve_path(path))}
+            for name, scope in scopes.items()
+            if hasattr(scope, "resolve_path")
+        ]
+        response = {"resolved": [entry for entry in resolved if entry["path"] is not None]}
+        self.finish(json.dumps(response))
+
+
 default_handlers = [
     (r"/api/spec.yaml", APISpecHandler),
     (r"/api/status", APIStatusHandler),
     (r"/api/me", IdentityHandler),
+    (r"/api/resolvePath", PathResolverHandler),
 ]

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -250,6 +250,19 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path=path)
         return exists(os_path)
 
+    def resolve_path(self, path: str) -> str | None:
+        """Resolve path relative to root resource."""
+        # transform OS path to API path
+        relative_path = to_api_path(path, self.root_dir)
+        # check if the API path is within contents directory
+        try:
+            os_path = self._get_os_path(path=relative_path)
+        except web.HTTPError:
+            return None
+        if exists(os_path):
+            return relative_path
+        return None
+
     def _base_model(self, path):
         """Build the common base of a contents model"""
         os_path = self._get_os_path(path)
@@ -768,7 +781,9 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         return f"{size / (1 << (order * 10)):.4g} {units[order]}"
 
 
-class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, AsyncContentsManager):
+class AsyncFileContentsManager(  # type: ignore[misc]
+    FileContentsManager, AsyncFileManagerMixin, AsyncContentsManager
+):
     """An async file contents manager."""
 
     @default("checkpoints_class")

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -889,6 +889,10 @@ class AsyncContentsManager(ContentsManager):
     # ContentsManager API part 2: methods that have usable default
     # implementations, but can be overridden in subclasses.
 
+    async def resolve_path(self, path: str) -> str | None:
+        """Resolve path relative to root resource."""
+        return None
+
     async def delete(self, path):
         """Delete a file/directory and any associated checkpoints."""
         path = path.strip("/")

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -87,7 +87,7 @@ def validate_model(
     # handle that case here.
     schema = registry.get(schema_id)
     version = str(cast("str", data.get("version")))
-    if schema.version != version:
+    if str(schema.version) != version:
         message = f"Unregistered version: {version!r}≠{schema.version!r} for `{schema_id}`"
         raise Exception(message)
 

--- a/jupyter_server/services/kernels/connection/channels.py
+++ b/jupyter_server/services/kernels/connection/channels.py
@@ -155,7 +155,7 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
             self.channels[channel] = stream = meth(identity=identity)
             stream.channel = channel
 
-    def nudge(self):
+    def nudge(self) -> asyncio.Future[None]:
         """Nudge the zmq connections with kernel_info_requests
         Returns a Future that will resolve when we have received
         a shell or control reply and at least one iopub message,
@@ -171,7 +171,7 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
         # establishing its zmq subscriptions before processing the next request.
         if getattr(self.kernel_manager, "execution_state", None) == "busy":
             self.log.debug("Nudge: not nudging busy kernel %s", self.kernel_id)
-            f: asyncio.Future[t.Any] = asyncio.Future()
+            f: asyncio.Future[None] = asyncio.Future()
             f.set_result(None)
             return f
         # Use a transient shell channel to prevent leaking
@@ -365,8 +365,15 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
         # actually wait for it
         await asyncio.wrap_future(future)
 
-    def connect(self):
-        """Handle a connection."""
+    def connect(self) -> asyncio.Future[None] | None:
+        """Handle a connection.
+
+        Returns the Future from :meth:`nudge` (which resolves once the
+        kernel is responsive and stream subscriptions/replay callbacks
+        have been wired up), or ``None`` if the connection failed and
+        was disconnected. Callers should ``await`` the returned Future
+        before relying on the connection being live.
+        """
         self.multi_kernel_manager.notify_connect(self.kernel_id)
 
         # on new connections, flush the message buffer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,8 +221,12 @@ explicit_package_bases = true
 strict = true
 pretty = true
 warn_unreachable = true
-disable_error_code = ["no-untyped-def", "no-untyped-call"]
+disable_error_code = ["no-untyped-def", "no-untyped-call", "unused-ignore"]
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+
+[[tool.mypy.overrides]]
+module = ["notebook.*", "pysqlite2.*", "overrides"]
+ignore_missing_imports = true
 
 [tool.interrogate]
 ignore-init-module=true

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -4,6 +4,7 @@ import os
 import time
 import warnings
 
+import ipykernel
 import jupyter_client
 import pytest
 import tornado
@@ -181,6 +182,166 @@ async def test_main_kernel_handler(jp_fetch, jp_base_url, jp_serverapp, pending_
     kernel3 = json.loads(r.body.decode())
     assert isinstance(kernel3, dict)
     await pending_kernel_is_ready(kernel3["id"])
+
+
+@pytest.mark.skipif(
+    ipykernel.version_info < (7, 0),
+    reason="requires ipykernel 7, which is not compatible with Python 3.9",
+)
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_resolve_path_kernel(jp_fetch, jp_serverapp, jp_root_dir, pending_kernel_is_ready):
+    query_path = "hello.py"
+    contents = "(irrelevant)"
+
+    # Put the file in a kernel subdirectory
+    kernel_root = jp_root_dir / "more" / "path" / "segments"
+    kernel_root.mkdir(parents=True)
+    kernel_path = kernel_root / query_path
+    kernel_path.write_text(contents)
+
+    # Create a kernel in temp path
+    r = await jp_fetch(
+        "api",
+        "kernels",
+        method="POST",
+        body=json.dumps(
+            {"name": NATIVE_KERNEL_NAME, "path": str(kernel_root.relative_to(jp_root_dir))}
+        ),
+    )
+    kernel_id = json.loads(r.body.decode())["id"]
+    await pending_kernel_is_ready(kernel_id)
+
+    # Resolve the path
+    r = await jp_fetch(
+        "api", "resolvePath", params={"kernel": kernel_id, "path": query_path}, method="GET"
+    )
+
+    assert r.code == 200
+    resolution = json.loads(r.body.decode())
+    assert len(resolution["resolved"]) == 1
+    path = resolution["resolved"][0]
+    assert path["scope"] == "kernel"
+
+    # Should reveal the kernel path (kernel returns posix-style separators)
+    assert path["path"] == kernel_path.as_posix()
+
+
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_resolve_path_server_traversal(jp_fetch, jp_serverapp, jp_root_dir):
+    query_path = "hello.py"
+    contents = "(irrelevant)"
+
+    # Put the file above the root dir
+    server_path = jp_root_dir / ".." / query_path
+    server_path.write_text(contents)
+
+    # Resolve the path
+    r = await jp_fetch("api", "resolvePath", params={"path": query_path}, method="GET")
+
+    assert r.code == 200
+    resolution = json.loads(r.body.decode())
+
+    # Should NOT disclose file existence on path traversal
+    assert len(resolution["resolved"]) == 0
+
+
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_resolve_path_server(jp_fetch, jp_serverapp, jp_root_dir):
+    query_path = "hello.py"
+    contents = "(irrelevant)"
+
+    # Put the file in the root dir
+    server_path = jp_root_dir / query_path
+    server_path.write_text(contents)
+
+    # Resolve the path
+    r = await jp_fetch("api", "resolvePath", params={"path": query_path}, method="GET")
+
+    assert r.code == 200
+    resolution = json.loads(r.body.decode())
+    assert len(resolution["resolved"]) == 1
+    path = resolution["resolved"][0]
+    assert path["scope"] == "server"
+
+    # Should NOT reveal server path, just acknowledge the name
+    assert path["path"] == server_path.name
+
+
+@pytest.mark.skipif(
+    ipykernel.version_info < (7, 0),
+    reason="requires ipykernel 7, which is not compatible with Python 3.9",
+)
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_resolve_path_server_and_kernel(
+    jp_fetch, jp_serverapp, jp_root_dir, pending_kernel_is_ready
+):
+    query_path = "hello.py"
+    contents = "(irrelevant)"
+
+    # Put a file for server in the root and for kernel space in a subdirectory
+    kernel_root = jp_root_dir / "more" / "path" / "segments"
+    kernel_root.mkdir(parents=True)
+    kernel_path = kernel_root / query_path
+    kernel_path.write_text(contents)
+    server_path = jp_root_dir / query_path
+    server_path.write_text(contents)
+
+    # Create a kernel in temp path
+    r = await jp_fetch(
+        "api",
+        "kernels",
+        method="POST",
+        body=json.dumps(
+            {"name": NATIVE_KERNEL_NAME, "path": str(kernel_root.relative_to(jp_root_dir))}
+        ),
+    )
+    kernel_id = json.loads(r.body.decode())["id"]
+    await pending_kernel_is_ready(kernel_id)
+
+    # Resolve the path
+    r = await jp_fetch(
+        "api", "resolvePath", params={"kernel": kernel_id, "path": query_path}, method="GET"
+    )
+    assert r.code == 200
+    resolution = json.loads(r.body.decode())
+
+    # Should present candidates for both server and kernel
+    assert len(resolution["resolved"]) == 2
+    assert {k["scope"] for k in resolution["resolved"]} == {"server", "kernel"}
+
+
+@pytest.mark.timeout(TEST_TIMEOUT)
+async def test_resolve_path_missing(jp_fetch, jp_serverapp, jp_root_dir, pending_kernel_is_ready):
+    query_path = "hello.py"
+    contents = "(irrelevant)"
+
+    # Put a file for server in the root and for kernel space in a subdirectory
+    kernel_root = jp_root_dir / "more" / "path" / "segments"
+    kernel_root.mkdir(parents=True)
+    kernel_path = kernel_root / query_path
+    kernel_path.write_text(contents)
+    server_path = jp_root_dir / query_path
+    server_path.write_text(contents)
+
+    # Create a kernel in temp path
+    r = await jp_fetch(
+        "api",
+        "kernels",
+        method="POST",
+        body=json.dumps(
+            {"name": NATIVE_KERNEL_NAME, "path": str(kernel_root.relative_to(jp_root_dir))}
+        ),
+    )
+    kernel_id = json.loads(r.body.decode())["id"]
+    await pending_kernel_is_ready(kernel_id)
+
+    # Resolve the path
+    r = await jp_fetch(
+        "api", "resolvePath", params={"kernel": kernel_id, "path": "not_hello"}, method="GET"
+    )
+    assert r.code == 200
+    resolution = json.loads(r.body.decode())
+    assert len(resolution["resolved"]) == 0
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)


### PR DESCRIPTION
Introduces a new server-side path resolution API that lets clients
translate a path as seen by a running kernel (e.g. the kernel's current
working directory, or a path printed by user code or traceback) into a
path the Jupyter Server can address under its root directory.

## Why

Kernels and the server don't always share a view of the filesystem. A
kernel may be started in a subdirectory, run on a remote host, or
operate inside a container — so a path like ./data.csv or
/home/user/project/notebook.ipynb from the kernel's perspective isn't
directly usable by the frontend or the contents API. This is also helful
in tracebacks to be able to open the given file in a frontend. Frontends
previously had to guess. This adds a first-class endpoint for asking
the server to do the mapping.

## What it does

- Adds ContentsManager.resolve_path(path, kernel=None) as an extension
  point, with a default FileContentsManager implementation that
  resolves against the kernel's working directory and the server root.
- Exposes it over REST via a new ResolvePathHandler; the kernel
  argument is optional so the API also works for server-relative
  resolution.
- Documents the endpoint in an OpenAPI/Swagger spec
  (services/api/api.yaml).
- Ships tests covering resolution across kernel states, plus a helper
  that waits for the kernel to be ready before issuing requests.

## Incidental

Typing annotations and mypy pre-commit fixes across the touched modules;
CI matrix trimmed (drop free-threaded 3.14t, drop Windows + Python 3.9,
regularly failing ); skip one test that is incompatible with ipykernel
<= 7.0

--- 



This patch demonstrates the scaffold of the new path resolver API endpoint proposed in #1280.

This depends on a sibling PR jupyter/jupyter_client#1005 (now merged)

Questions:
- should I use `self.kernel_manager` or `self.multi_kernel_manager`? (these are not well documented in code)

In future we could include an entry point (e.g. traitlet) to define additional scopes (e.g. from remote file systems), but this is out of scope for this PR which focuses on distinguishing between a path from kernel and server.

