### PR TITLE
proposal: add subprotocol for token-authenticated websockets

### DIFF
--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -17,6 +17,7 @@ import typing as t
 import uuid
 from dataclasses import asdict, dataclass
 from http.cookies import Morsel
+from urllib.parse import unquote
 
 from tornado import escape, httputil, web
 from tornado.websocket import WebSocketHandler
@@ -435,6 +436,12 @@ class IdentityProvider(LoggingConfigurable):
                 for subprotocol in subprotocols:
                     if subprotocol.startswith(_TOKEN_SUBPROTOCOL + "."):
                         user_token = subprotocol[len(_TOKEN_SUBPROTOCOL) + 1 :]
+                        try:
+                            user_token = unquote(user_token)
+                        except ValueError:
+                            # leave tokens that fail to decode
+                            # these won't be accepted, but proceed with validation
+                            pass
                         break
 
         return user_token

--- a/jupyter_server/base/websocket.py
+++ b/jupyter_server/base/websocket.py
@@ -1,4 +1,7 @@
 """Base websocket classes."""
+
+from __future__ import annotations
+
 import re
 import warnings
 from typing import Optional, no_type_check
@@ -164,3 +167,14 @@ class WebSocketMixin:
     def on_pong(self, data):
         """Handle a pong message."""
         self.last_pong = ioloop.IOLoop.current().time()
+
+    def select_subprotocol(self, subprotocols: list[str]) -> str | None:
+        # default subprotocol
+        # some clients (Chrome)
+        # require selected subprotocol to match one of the requested subprotocols
+        # otherwise connection is rejected
+        token_subprotocol = "v1.token.websocket.jupyter.org"
+        if token_subprotocol in subprotocols:
+            return token_subprotocol
+        else:
+            return None

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -14,6 +14,7 @@ from tornado import web, websocket
 
 from jupyter_server.auth.decorator import authorized, ws_authenticated
 from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.base.websocket import WebSocketMixin
 
 from ...base.handlers import APIHandler
 
@@ -21,6 +22,7 @@ AUTH_RESOURCE = "events"
 
 
 class SubscribeWebsocket(
+    WebSocketMixin,
     JupyterHandler,
     websocket.WebSocketHandler,
 ):

--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -90,6 +90,12 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler): 
             preferred_protocol = "v1.kernel.websocket.jupyter.org"
         elif preferred_protocol == "":
             preferred_protocol = None
-        selected_subprotocol = preferred_protocol if preferred_protocol in subprotocols else None
+
+        # super() subprotocol enables token authentication via subprotocol
+        selected_subprotocol = (
+            preferred_protocol
+            if preferred_protocol in subprotocols
+            else super().select_subprotocol(subprotocols)
+        )
         # None is the default, "legacy" protocol
         return selected_subprotocol

--- a/tests/base/test_websocket.py
+++ b/tests/base/test_websocket.py
@@ -149,10 +149,11 @@ async def test_websocket_token_subprotocol_auth(jp_serverapp, jp_ws_fetch):
         "ws",
         headers={
             "Authorization": "",
-            "Sec-WebSocket-Protocol": "v1.kernel.websocket.jupyter.org, v1.token.websocket.jupyter.org."
+            "Sec-WebSocket-Protocol": "v1.kernel.websocket.jupyter.org, v1.token.websocket.jupyter.org, v1.token.websocket.jupyter.org."
             + token,
         },
     )
+    assert ws.protocol.selected_subprotocol == "v1.token.websocket.jupyter.org"
     ws.close()
 
 

--- a/tests/base/test_websocket.py
+++ b/tests/base/test_websocket.py
@@ -10,7 +10,7 @@ from tornado.httputil import HTTPHeaders
 from tornado.websocket import WebSocketClosedError, WebSocketHandler
 
 from jupyter_server.auth import IdentityProvider, User
-from jupyter_server.auth.decorator import allow_unauthenticated
+from jupyter_server.auth.decorator import allow_unauthenticated, ws_authenticated
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.base.websocket import WebSocketMixin
 from jupyter_server.serverapp import ServerApp
@@ -75,6 +75,12 @@ class NoAuthRulesWebsocketHandler(MockJupyterHandler):
     pass
 
 
+class AuthenticatedWebsocketHandler(MockJupyterHandler):
+    @ws_authenticated
+    def get(self, *args, **kwargs) -> None:
+        return super().get(*args, **kwargs)
+
+
 class PermissiveWebsocketHandler(MockJupyterHandler):
     @allow_unauthenticated
     def get(self, *args, **kwargs) -> None:
@@ -124,6 +130,30 @@ async def test_websocket_auth_required(jp_serverapp, jp_ws_fetch):
     with pytest.raises(HTTPClientError) as exception:
         ws = await jp_ws_fetch("no-rules", headers={"Authorization": ""})
     assert exception.value.code == 403
+
+
+async def test_websocket_token_subprotocol_auth(jp_serverapp, jp_ws_fetch):
+    app: ServerApp = jp_serverapp
+    app.web_app.add_handlers(
+        ".*$",
+        [
+            (url_path_join(app.base_url, "ws"), AuthenticatedWebsocketHandler),
+        ],
+    )
+
+    with pytest.raises(HTTPClientError) as exception:
+        ws = await jp_ws_fetch("ws", headers={"Authorization": ""})
+    assert exception.value.code == 403
+    token = jp_serverapp.identity_provider.token
+    ws = await jp_ws_fetch(
+        "ws",
+        headers={
+            "Authorization": "",
+            "Sec-WebSocket-Protocol": "v1.kernel.websocket.jupyter.org, v1.token.websocket.jupyter.org."
+            + token,
+        },
+    )
+    ws.close()
 
 
 class IndiscriminateIdentityProvider(IdentityProvider):


### PR DESCRIPTION
follows [kubernetes' example](https://github.com/kubernetes/kubernetes/pull/47740) of smuggling the token in the subprotocol itself. Maybe not great, but solves our problem and is simple and appears to work.

To authenticate websockets via new mechanism, clients should:

```javascript
ws = new WebSocket(wss://..., ['v1.token.websocket.jupyter.org', `v1.token.websocket.jupyter.org.${token}`, ...])
```

which sets the header:

```
Sec-WebSocket-Protocol: v1.token.websocket.jupyter.org, v1.token.websocket.jupyter.org.abc123
```

The response will have the header:

```
Sec-WebSocket-Protocol: v1.token.websocket.jupyter.org
```


<del>This is transparently ignored if unrecognized, so fully backward compatible for both clients and servers, and fully compatible with specifying other subprotocols, etc.</del>

This is transparently ignored if unrecognized by servers and _most_ clients, but at least Chrome checks that the server's response includes one of the requested subprotocols if any are specified. For backward-compatibility, a client must try with subprotocols, then retry without them. This is the reason for the `v1.token.websocket.juptyer.org` subprotocol in addition to the protocol including the token itself.

This seems like the simplest path to not sending the token in URL parameters. The alternative of using a handshake message is more complex and protocol-breaking, and further allows clients that never authenticate to hold open connections indefinitely.

Notable difference: kubernetes base64-encodes the token on the end. I haven't done that because negotiating url-safe-base64-without-padding seems like a pain because:

- neither [Python](https://github.com/python/cpython/issues/73613) nor Javascript actually implement the required unpadded urlsafe-base64 in the standard library
- base64 encoding only makes an already-valid string longer
- While we don't _technically_ specify that tokens must be safe strings in header fields like this, it is always true in practice, so we could without any practical loss. There's a good chance we already have this requirement elsewhere by accident (e.g. we don't escape tokens when passed in URL params).

I think the only question that remains is whether and how servers advertise support for this.

[via](https://github.com/whatwg/websockets/issues/16#issuecomment-1705316320)