### PR TITLE
Strawman API Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ docs/gh-pages
 jupyter_server/i18n/*/LC_MESSAGES/*.mo
 jupyter_server/i18n/*/LC_MESSAGES/nbjs.json
 jupyter_server/static/style/*.min.css*
+jupyter_server/static/vendor/
 node_modules
 *.py[co]
 __pycache__

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -43,6 +43,18 @@ class APISpecHandler(web.StaticFileHandler, JupyterHandler):
         return "text/x-yaml"
 
 
+class APIDocsHandler(JupyterHandler):
+    """A handler for the documentation of the REST API."""
+
+    auth_resource = AUTH_RESOURCE
+
+    @web.authenticated
+    @authorized
+    async def get(self):
+        """Get the REST API documentation."""
+        return self.finish(self.render_template("apidocs.html"))
+
+
 class APIStatusHandler(APIHandler):
     """An API status handler."""
 
@@ -115,6 +127,7 @@ class IdentityHandler(APIHandler):
 
 
 default_handlers = [
+    (r"/api/apidocs", APIDocsHandler),
     (r"/api/spec.yaml", APISpecHandler),
     (r"/api/status", APIStatusHandler),
     (r"/api/me", IdentityHandler),

--- a/jupyter_server/templates/apidocs.html
+++ b/jupyter_server/templates/apidocs.html
@@ -1,0 +1,27 @@
+{% extends "page.html" %}
+
+{% block stylesheet %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ static_url('vendor/swagger-ui-dist/swagger-ui.css') }}" />
+    <style>
+        .swagger-ui .info .title small pre {
+            background-color: transparent;
+            border: 0;
+        }
+    </style>
+{% endblock stylesheet %}
+
+{% block site %}
+    <div id="swagger-ui"></div>
+{% endblock site %}
+
+{% block script %}
+    {{ super() }}
+    <script src="{{ static_url('vendor/swagger-ui-dist/swagger-ui-bundle.js') }}"></script>
+
+    <script>
+        ;(function(){
+            SwaggerUIBundle({ url: "./spec.yaml", dom_id: "#swagger-ui" });
+        }).call(this);
+    </script>
+{% endblock script %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "BSD",
       "dependencies": {
         "bootstrap": "^3.4.0",
-        "copyfiles": "^2.4.1"
+        "copyfiles": "^2.4.1",
+        "swagger-ui-dist": "^5.17.2"
       }
     },
     "node_modules/ansi-regex": {
@@ -287,6 +288,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.2.tgz",
+      "integrity": "sha512-V/NqUw6QoTrjSpctp2oLQvxrl3vW29UsUtZyq7B1CF0v870KOFbYGDQw8rpKaKm0JxTwHpWnW1SN9YuKZdiCyw=="
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -620,6 +626,11 @@
       "requires": {
         "ansi-regex": "^5.0.0"
       }
+    },
+    "swagger-ui-dist": {
+      "version": "5.17.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.2.tgz",
+      "integrity": "sha512-V/NqUw6QoTrjSpctp2oLQvxrl3vW29UsUtZyq7B1CF0v870KOFbYGDQw8rpKaKm0JxTwHpWnW1SN9YuKZdiCyw=="
     },
     "through2": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "version": "1.0.0",
   "license": "BSD",
   "scripts": {
-    "build": "copyfiles -f node_modules/bootstrap/dist/css/*.min.* jupyter_server/static/style"
+    "build": "npm run build:bootstrap && npm run build:swagger-ui",
+    "build:bootstrap": "copyfiles -f node_modules/bootstrap/dist/css/*.min.* jupyter_server/static/style",
+    "build:swagger-ui": "copyfiles -f \"node_modules/swagger-ui-dist/{NOTICE,LICENSE}\" \"node_modules/swagger-ui-dist/swagger-ui{.css,-bundle.js}\" jupyter_server/static/vendor/swagger-ui"
   },
   "dependencies": {
     "bootstrap": "^3.4.0",
-    "copyfiles": "^2.4.1"
+    "copyfiles": "^2.4.1",
+    "swagger-ui-dist": "^5.17.2"
   },
   "eslintIgnore": [
     "*.min.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run build:bootstrap && npm run build:swagger-ui",
     "build:bootstrap": "copyfiles -f node_modules/bootstrap/dist/css/*.min.* jupyter_server/static/style",
-    "build:swagger-ui": "copyfiles -f \"node_modules/swagger-ui-dist/{NOTICE,LICENSE}\" \"node_modules/swagger-ui-dist/swagger-ui{.css,-bundle.js}\" jupyter_server/static/vendor/swagger-ui"
+    "build:swagger-ui": "copyfiles -f \"node_modules/swagger-ui-dist/{NOTICE,LICENSE,swagger-ui.css,swagger-ui-bundle.js}\" jupyter_server/static/vendor/swagger-ui-dist"
   },
   "dependencies": {
     "bootstrap": "^3.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,10 @@ path = "jupyter_server/_version.py"
 validate-bump = false
 
 [tool.hatch.build]
-artifacts = ["jupyter_server/static/style"]
+artifacts = [
+  "jupyter_server/static/style",
+  "jupyter_server/static/vendor",
+]
 
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = ["hatch-jupyter-builder>=0.8.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,14 +134,14 @@ build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
   "jupyter_server/static/style/bootstrap.min.css",
   "jupyter_server/static/style/bootstrap-theme.min.css",
-  "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui.css",
-  "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui-bundle.js",
-  "jupyter_server/static/vendor/swagger-ui/LICENSE",
-  "jupyter_server/static/vendor/swagger-ui/NOTICE",
+  "jupyter_server/static/vendor/swagger-ui-dist/LICENSE",
+  "jupyter_server/static/vendor/swagger-ui-dist/NOTICE",
+  "jupyter_server/static/vendor/swagger-ui-dist/swagger-ui-bundle.js",
+  "jupyter_server/static/vendor/swagger-ui-dist/swagger-ui.css",
 ]
 skip-if-exists = [
   "jupyter_server/static/style/bootstrap.min.css",
-  "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui-bundle.js",
+  "jupyter_server/static/vendor/swagger-ui-dist/swagger-ui.css",
 ]
 install-pre-commit-hook = true
 optional-editable-build = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
   "jupyter_server/static/style/bootstrap.min.css",
   "jupyter_server/static/style/bootstrap-theme.min.css",
-  "jupyter_server/static/vendor/swagger-ui/dist/dist/swagger-ui.css",
+  "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui.css",
   "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui-bundle.js",
   "jupyter_server/static/vendor/swagger-ui/LICENSE",
   "jupyter_server/static/vendor/swagger-ui/NOTICE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,9 +133,16 @@ dependencies = ["hatch-jupyter-builder>=0.8.1"]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
   "jupyter_server/static/style/bootstrap.min.css",
-  "jupyter_server/static/style/bootstrap-theme.min.css"
+  "jupyter_server/static/style/bootstrap-theme.min.css",
+  "jupyter_server/static/vendor/swagger-ui/dist/dist/swagger-ui.css",
+  "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui-bundle.js",
+  "jupyter_server/static/vendor/swagger-ui/LICENSE",
+  "jupyter_server/static/vendor/swagger-ui/NOTICE",
 ]
-skip-if-exists = ["jupyter_server/static/style/bootstrap.min.css"]
+skip-if-exists = [
+  "jupyter_server/static/style/bootstrap.min.css",
+  "jupyter_server/static/vendor/swagger-ui/dist/swagger-ui-bundle.js",
+]
 install-pre-commit-hook = true
 optional-editable-build = true
 

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -12,8 +12,8 @@ from tornado.httputil import HTTPHeaders
 from jupyter_server.auth import AllowAllAuthorizer, IdentityProvider, User
 from jupyter_server.auth.decorator import allow_unauthenticated
 from jupyter_server.base.handlers import (
-    APIHandler,
     APIDocsHandler,
+    APIHandler,
     APIVersionHandler,
     AuthenticatedFileHandler,
     AuthenticatedHandler,

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -13,6 +13,7 @@ from jupyter_server.auth import AllowAllAuthorizer, IdentityProvider, User
 from jupyter_server.auth.decorator import allow_unauthenticated
 from jupyter_server.base.handlers import (
     APIHandler,
+    APIDocsHandler,
     APIVersionHandler,
     AuthenticatedFileHandler,
     AuthenticatedHandler,
@@ -234,6 +235,15 @@ async def test_api_version_handler(jp_serverapp):
     request.connection = MagicMock()
     handler = APIVersionHandler(app.web_app, request)
     handler._transforms = []
+    handler.get()
+    assert handler.get_status() == 200
+
+
+async def test_api_docs_handler(jp_serverapp):
+    app: ServerApp = jp_serverapp
+    request = HTTPRequest("GET")
+    request.connection = MagicMock()
+    handler = APIDocsHandler(app.web_app, request)
     handler.get()
     assert handler.get_status() == 200
 

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -12,7 +12,6 @@ from tornado.httputil import HTTPHeaders
 from jupyter_server.auth import AllowAllAuthorizer, IdentityProvider, User
 from jupyter_server.auth.decorator import allow_unauthenticated
 from jupyter_server.base.handlers import (
-    APIDocsHandler,
     APIHandler,
     APIVersionHandler,
     AuthenticatedFileHandler,
@@ -23,6 +22,7 @@ from jupyter_server.base.handlers import (
     RedirectWithParams,
 )
 from jupyter_server.serverapp import ServerApp
+from jupyter_server.services.api.handlers import APIDocsHandler
 from jupyter_server.utils import url_path_join
 
 

--- a/tests/base/test_handlers.py
+++ b/tests/base/test_handlers.py
@@ -22,7 +22,6 @@ from jupyter_server.base.handlers import (
     RedirectWithParams,
 )
 from jupyter_server.serverapp import ServerApp
-from jupyter_server.services.api.handlers import APIDocsHandler
 from jupyter_server.utils import url_path_join
 
 
@@ -235,15 +234,6 @@ async def test_api_version_handler(jp_serverapp):
     request.connection = MagicMock()
     handler = APIVersionHandler(app.web_app, request)
     handler._transforms = []
-    handler.get()
-    assert handler.get_status() == 200
-
-
-async def test_api_docs_handler(jp_serverapp):
-    app: ServerApp = jp_serverapp
-    request = HTTPRequest("GET")
-    request.connection = MagicMock()
-    handler = APIDocsHandler(app.web_app, request)
     handler.get()
     assert handler.get_status() == 200
 

--- a/tests/services/api/test_api.py
+++ b/tests/services/api/test_api.py
@@ -13,6 +13,11 @@ async def test_get_spec(jp_fetch):
     assert response.code == 200
 
 
+async def test_get_api_docs(jp_fetch):
+    response = await jp_fetch("api", "apidocs", method="GET")
+    assert response.code == 200
+
+
 async def test_get_status(jp_fetch):
     response = await jp_fetch("api", "status", method="GET")
     assert response.code == 200


### PR DESCRIPTION
## references
- #1418

## code changes
- [x] add [swagger-ui-dist](https://swagger.io/tools/swagger-ui) to `package.json`
- [x] add `/api/apidocs` endpoint

## alternatives

- looked at `redoc` per https://github.com/jupyter-server/jupyter_server/issues/1418#issuecomment-2090954016
  - has hard-coded tracking logo served from third-party site
  - don't feel like hostile-forking it
  - also brought in ~100mb of `node_modules`
- mounting it on `/api` (or even `api/spec.yaml?docs`) would be strictly better, but these both seemed finicky to sniff based on headers, and _sometimes_ be static file or JSON or whatever, and probably not worth the hassle
- _could_ be separately configurable, but if you have the rights to access the `spec.yaml`

## assessment

- this is an important feature
  - but not convinced this belongs in core, given the size
  - however, an officially-supported extension, potentially with a `jupyter_server[apidocs]` would probably be pretty good

## screens

| note | screen |
|-|-|
| basic | ![image](https://github.com/jupyter-server/jupyter_server/assets/45380/c645ab4d-749f-4a99-bbd4-0b2f9638ba65)
| build-a-GET | ![image](https://github.com/jupyter-server/jupyter_server/assets/45380/d1569e91-f990-491a-885f-d8ecb718e4e9)
| GOT | ![image](https://github.com/jupyter-server/jupyter_server/assets/45380/48c02510-b73a-4bb1-9abc-066272223f5f)
| 400% | ![image](https://github.com/jupyter-server/jupyter_server/assets/45380/17c6ad3a-1830-4597-a793-041aa618e087)


:bell: @Zsailer @tonyfast