### PR TITLE
Add more informative error message when opening notebook and disk is full

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -11,6 +11,7 @@ import json
 import mimetypes
 import os
 import re
+import sqlite3
 import types
 import warnings
 from collections.abc import Awaitable, Coroutine, Sequence
@@ -769,6 +770,12 @@ class APIHandler(JupyterHandler):
             if isinstance(e, HTTPError):
                 reply["message"] = e.log_message or message
                 reply["reason"] = e.reason
+            elif (
+                isinstance(e, sqlite3.OperationalError)
+                and e.sqlite_errorcode == sqlite3.SQLITE_FULL
+            ):
+                reply["message"] = "Disk is full"
+                reply["reason"] = e.sqlite_errorname
             else:
                 reply["message"] = "Unhandled error"
                 reply["reason"] = None

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -11,7 +11,6 @@ import json
 import mimetypes
 import os
 import re
-import sqlite3
 import types
 import warnings
 from collections.abc import Awaitable, Coroutine, Sequence
@@ -37,6 +36,7 @@ from jupyter_server.services.security import csp_report_uri
 from jupyter_server.utils import (
     ensure_async,
     filefind,
+    is_sqlite_disk_full_error,
     url_escape,
     url_is_absolute,
     url_path_join,
@@ -770,12 +770,9 @@ class APIHandler(JupyterHandler):
             if isinstance(e, HTTPError):
                 reply["message"] = e.log_message or message
                 reply["reason"] = e.reason
-            elif (
-                isinstance(e, sqlite3.OperationalError)
-                and e.sqlite_errorcode == sqlite3.SQLITE_FULL
-            ):
+            elif is_sqlite_disk_full_error(e):
                 reply["message"] = "Disk is full"
-                reply["reason"] = e.sqlite_errorname
+                reply["reason"] = str(e)
             else:
                 reply["message"] = "Unhandled error"
                 reply["reason"] = None

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -426,3 +426,12 @@ class JupyterServerAuthWarning(RuntimeWarning):
     Intended for filtering out expected warnings in tests, including
     downstream tests, rather than for users to silence this warning.
     """
+
+
+def is_sqlite_disk_full_error(e: Exception) -> bool:
+    try:
+        import sqlite3
+
+        return isinstance(e, sqlite3.OperationalError) and e.sqlite_errorcode == sqlite3.SQLITE_FULL  # type: ignore[attr-defined]
+    except (AttributeError, ImportError) as e:
+        return "database or disk is full" in str(e)


### PR DESCRIPTION
Currently, when trying to load a jupyter notebook when the disk is full, you may see an error as follows:

![image](https://github.com/user-attachments/assets/97ad5f6a-18c9-485c-b087-7685bf1cd1e0)

(The reason is, opening a notebook involves SQLite updating the `last_seen` field in the `nbsignatures` table, as done by `mark_trusted_cells`.)

This MR gives a slightly more informative error in this scenario:

![image](https://github.com/user-attachments/assets/983d3a2b-3955-46e4-a59a-348303567c5b)
