### PR TITLE
Add support of using custom env variables

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -472,7 +472,7 @@ class ServerWebApplication(web.Application):
             # default: set xsrf cookie on base_url
             settings["xsrf_cookie_kwargs"] = {"path": base_url}
         return settings
-    
+
     def page_config_hook(self, handler, page_config):
         page_config["allow_custom_env_variables"] = self.allow_custom_env_variables
         return page_config
@@ -1438,7 +1438,6 @@ class ServerApp(JupyterApp):
         config=True,
         help="""Allow to use custom env variables""",
     )
-
 
     browser = Unicode(
         "",

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3043,9 +3043,9 @@ class ServerApp(JupyterApp):
         if self.allow_custom_env_variables:
             print("allow_custom_env_variables present")
             print(self.allow_custom_env_variables)
-            self.kernel_spec_manager.allow_custom_env_variables(
-                self.allow_custom_env_variables
-            )
+            #self.kernel_spec_manager.allow_custom_env_variables(
+            #    self.allow_custom_env_variables
+            #)
 
         if self.identity_provider.token and self.identity_provider.token_generated:
             # log full URL with generated token, so there's a copy/pasteable link

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -457,6 +457,7 @@ class ServerWebApplication(web.Application):
             "config": jupyter_app.config,
             "config_dir": jupyter_app.config_dir,
             "allow_password_change": jupyter_app.allow_password_change,
+            "accept_kernel_env_var": jupyter_app.accept_kernel_env_var,
             "server_root_dir": root_dir,
             "jinja2_env": env,
             "serverapp": jupyter_app,
@@ -1427,7 +1428,7 @@ class ServerApp(JupyterApp):
                         """,
     )
 
-    allow_setup_custom_env_variables = Bool(
+    accept_kernel_env_vars = Bool(
         False,
         config=True,
         help="""Allow a user to setup custom env variables while launching or selecting a kernel""",

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -459,7 +459,7 @@ class ServerWebApplication(web.Application):
             "allow_password_change": jupyter_app.allow_password_change,
             "server_root_dir": root_dir,
             "jinja2_env": env,
-            "serverapp": jupyter_app
+            "serverapp": jupyter_app,
         }
 
         # allow custom overrides for the tornado web app.

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -401,8 +401,6 @@ class ServerWebApplication(web.Application):
             # collapse $HOME to ~
             root_dir = "~" + root_dir[len(home) :]
 
-        self.allow_custom_env_variables = jupyter_app.allow_custom_env_variables
-
         settings = {
             # basics
             "log_function": log_request,
@@ -461,8 +459,7 @@ class ServerWebApplication(web.Application):
             "allow_password_change": jupyter_app.allow_password_change,
             "server_root_dir": root_dir,
             "jinja2_env": env,
-            "serverapp": jupyter_app,
-            "page_config_hook": (self.page_config_hook),
+            "serverapp": jupyter_app
         }
 
         # allow custom overrides for the tornado web app.
@@ -472,10 +469,6 @@ class ServerWebApplication(web.Application):
             # default: set xsrf cookie on base_url
             settings["xsrf_cookie_kwargs"] = {"path": base_url}
         return settings
-
-    def page_config_hook(self, handler, page_config):
-        page_config["allow_custom_env_variables"] = self.allow_custom_env_variables
-        return page_config
 
     def init_handlers(self, default_services, settings):
         """Load the (URL pattern, handler) tuples for each component."""
@@ -1434,10 +1427,10 @@ class ServerApp(JupyterApp):
                         """,
     )
 
-    allow_custom_env_variables = Bool(
+    allow_setup_custom_env_variables = Bool(
         False,
         config=True,
-        help="""Allow to use custom env variables""",
+        help="""Allow a user to setup custom env variables while launching or selecting a kernel""",
     )
 
     browser = Unicode(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3039,13 +3039,6 @@ class ServerApp(JupyterApp):
         # Handle the browser opening.
         if self.open_browser and not self.sock:
             self.launch_browser()
-        
-        if self.allow_custom_env_variables:
-            print("allow_custom_env_variables present")
-            print(self.allow_custom_env_variables)
-            #self.kernel_spec_manager.allow_custom_env_variables(
-            #    self.allow_custom_env_variables
-            #)
 
         if self.identity_provider.token and self.identity_provider.token_generated:
             # log full URL with generated token, so there's a copy/pasteable link

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1436,7 +1436,7 @@ class ServerApp(JupyterApp):
     allow_custom_env_variables = Bool(
         False,
         config=True,
-        help="""Allow to use insecure kernelspec parameters""",
+        help="""Allow to use custom env variables""",
     )
 
 

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -224,6 +224,7 @@ class MappingKernelManager(MultiKernelManager):
             The name identifying which kernel spec to launch. This is ignored if
             an existing kernel is returned, but it may be checked in the future.
         """
+        #
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs["cwd"] = self.cwd_for_path(path, env=kwargs.get("env", {}))

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -224,6 +224,8 @@ class MappingKernelManager(MultiKernelManager):
             The name identifying which kernel spec to launch. This is ignored if
             an existing kernel is returned, but it may be checked in the future.
         """
+
+        print('??????????????????????????????????/')
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs["cwd"] = self.cwd_for_path(path, env=kwargs.get("env", {}))

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -225,7 +225,6 @@ class MappingKernelManager(MultiKernelManager):
             an existing kernel is returned, but it may be checked in the future.
         """
 
-        print('??????????????????????????????????/')
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs["cwd"] = self.cwd_for_path(path, env=kwargs.get("env", {}))

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -224,7 +224,6 @@ class MappingKernelManager(MultiKernelManager):
             The name identifying which kernel spec to launch. This is ignored if
             an existing kernel is returned, but it may be checked in the future.
         """
-
         if kernel_id is None or kernel_id not in self:
             if path is not None:
                 kwargs["cwd"] = self.cwd_for_path(path, env=kwargs.get("env", {}))

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -77,7 +77,7 @@ class SessionRootHandler(SessionsAPIHandler):
         kernel = model.get("kernel", {})
         kernel_name = kernel.get("name", None)
         kernel_id = kernel.get("id", None)
-        custom_env_vars = kernel.get("custom_env_vars", {})
+        custom_env_vars = kernel.get("env", {})
 
         if not kernel_id and not kernel_name:
             self.log.debug("No kernel specified, using default kernel")
@@ -154,8 +154,8 @@ class SessionHandler(SessionsAPIHandler):
             changes["name"] = model["name"]
         if "type" in model:
             changes["type"] = model["type"]
-        if "custom_env_vars" in model:
-            changes["custom_env_vars"] = model["custom_env_vars"]
+        if "env" in model:
+            changes["custom_env_vars"] = model["env"]
         if "kernel" in model:
             # Kernel id takes precedence over name.
             if model["kernel"].get("id") is not None:
@@ -164,8 +164,8 @@ class SessionHandler(SessionsAPIHandler):
                     raise web.HTTPError(400, "No such kernel: %s" % kernel_id)
                 changes["kernel_id"] = kernel_id
             elif model["kernel"].get("name") is not None:
-                if "custom_env_vars" in model["kernel"]:
-                    custom_env_vars = model["kernel"]["custom_env_vars"]
+                if "env" in model["kernel"]:
+                    custom_env_vars = model["kernel"]["env"]
                 else:
                     custom_env_vars = {}
 

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -77,7 +77,7 @@ class SessionRootHandler(SessionsAPIHandler):
         kernel = model.get("kernel", {})
         kernel_name = kernel.get("name", None)
         kernel_id = kernel.get("id", None)
-        custom_env = kernel.get("custom_env", {})
+        custom_env_vars = kernel.get("custom_env_vars", {})
 
         if not kernel_id and not kernel_name:
             self.log.debug("No kernel specified, using default kernel")
@@ -94,7 +94,7 @@ class SessionRootHandler(SessionsAPIHandler):
                     kernel_id=kernel_id,
                     name=name,
                     type=mtype,
-                    custom_env=custom_env,
+                    custom_env_vars=custom_env_vars,
                 )
             except NoSuchKernel:
                 msg = (
@@ -154,8 +154,8 @@ class SessionHandler(SessionsAPIHandler):
             changes["name"] = model["name"]
         if "type" in model:
             changes["type"] = model["type"]
-        if "custom_env" in model:
-            changes["custom_env"] = model["custom_env"]
+        if "custom_env_vars" in model:
+            changes["custom_env_vars"] = model["custom_env_vars"]
         if "kernel" in model:
             # Kernel id takes precedence over name.
             if model["kernel"].get("id") is not None:
@@ -164,10 +164,11 @@ class SessionHandler(SessionsAPIHandler):
                     raise web.HTTPError(400, "No such kernel: %s" % kernel_id)
                 changes["kernel_id"] = kernel_id
             elif model["kernel"].get("name") is not None:
-                if "custom_env" in model["kernel"]:
-                    custom_env = model["kernel"]["custom_env"]
+                if "custom_env_vars" in model["kernel"]:
+                    custom_env_vars = model["kernel"]["custom_env_vars"]
                 else:
-                    custom_env = None
+                    custom_env_vars = {}
+                
                 kernel_name = model["kernel"]["name"]
                 kernel_id = await sm.start_kernel_for_session(
                     session_id,
@@ -175,7 +176,7 @@ class SessionHandler(SessionsAPIHandler):
                     name=before["name"],
                     path=before["path"],
                     type=before["type"],
-                    custom_env=custom_env,
+                    custom_env_vars=custom_env_vars,
                 )
                 changes["kernel_id"] = kernel_id
 

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -168,7 +168,11 @@ class SessionHandler(SessionsAPIHandler):
                     raise web.HTTPError(400, "No such kernel: %s" % kernel_id)
                 changes["kernel_id"] = kernel_id
             elif model["kernel"].get("name") is not None:
-                custom_env_vars = model["kernel"]["env"] if "env" in model["kernel"] and accept_kernel_env_vars else {}
+                custom_env_vars = (
+                    model["kernel"]["env"]
+                    if "env" in model["kernel"] and accept_kernel_env_vars
+                    else {}
+                )
 
                 kernel_name = model["kernel"]["name"]
                 kernel_id = await sm.start_kernel_for_session(

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -168,7 +168,7 @@ class SessionHandler(SessionsAPIHandler):
                     custom_env_vars = model["kernel"]["custom_env_vars"]
                 else:
                     custom_env_vars = {}
-                
+
                 kernel_name = model["kernel"]["name"]
                 kernel_id = await sm.start_kernel_for_session(
                     session_id,

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -164,10 +164,7 @@ class SessionHandler(SessionsAPIHandler):
                     raise web.HTTPError(400, "No such kernel: %s" % kernel_id)
                 changes["kernel_id"] = kernel_id
             elif model["kernel"].get("name") is not None:
-                if "env" in model["kernel"]:
-                    custom_env_vars = model["kernel"]["env"]
-                else:
-                    custom_env_vars = {}
+                custom_env_vars = model["kernel"]["env"] if "env" in model["kernel"] else {}
 
                 kernel_name = model["kernel"]["name"]
                 kernel_id = await sm.start_kernel_for_session(

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -290,7 +290,7 @@ class SessionManager(LoggingConfigurable):
         record.kernel_id = kernel_id
         self._pending_sessions.update(record)
         result = await self.save_session(
-              session_id, path=path, name=name, type=type, kernel_id=kernel_id
+            session_id, path=path, name=name, type=type, kernel_id=kernel_id
         )
         self._pending_sessions.remove(record)
         return cast(Dict[str, Any], result)
@@ -482,10 +482,11 @@ class SessionManager(LoggingConfigurable):
 
             # if we have custom env than we have to add them to available env variables
             if self._custom_envs is not None and isinstance(self._custom_envs, dict):
-                if self._custom_envs[kernel_id] is not None and isinstance(self._custom_envs[kernel_id], dict):
+                if self._custom_envs[kernel_id] is not None and isinstance(
+                    self._custom_envs[kernel_id], dict
+                ):
                     for key, value in self._custom_envs[kernel_id].items():
                         env[key] = value
-
 
             self.kernel_manager.update_env(kernel_id=kernel_id, env=env)
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -205,12 +205,11 @@ class SessionManager(LoggingConfigurable):
         super().__init__(*args, **kwargs)
         self._pending_sessions = KernelSessionRecordList()
 
+    _custom_envs: Dict[str, str] = {}
     # Session database initialized below
     _cursor = None
     _connection = None
     _columns = {"session_id", "path", "name", "type", "kernel_id"}
-    _custom_envs = {}
-
     @property
     def cursor(self):
         """Start a cursor and create a database called 'session'"""
@@ -481,7 +480,7 @@ class SessionManager(LoggingConfigurable):
             env = self.get_kernel_env(path, name)
 
             # if we have custom env than we have to add them to available env variables
-            if self._custom_envs is not None and isinstance(self._custom_envs, dict):
+            if isinstance(self._custom_envs, dict):
                 if self._custom_envs[kernel_id] is not None and isinstance(
                     self._custom_envs[kernel_id], dict
                 ):

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -459,7 +459,6 @@ class SessionManager(LoggingConfigurable):
         """
 
         await self.get_session(session_id=session_id)
-
         if not kwargs:
             # no changes
             return
@@ -477,7 +476,6 @@ class SessionManager(LoggingConfigurable):
                 "SELECT path, name, kernel_id FROM session WHERE session_id=?", [session_id]
             )
             path, name, kernel_id = self.cursor.fetchone()
-
             env = self.get_kernel_env(path, name)
 
             # if we have custom env than we have to add them to available env variables
@@ -486,7 +484,6 @@ class SessionManager(LoggingConfigurable):
                 if custom_env is not None and isinstance(custom_env, dict):
                     for key, value in custom_env.items():
                         env[key] = value
-
             self.kernel_manager.update_env(kernel_id=kernel_id, env=env)
 
     async def kernel_culled(self, kernel_id: str) -> bool:

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -210,6 +210,7 @@ class SessionManager(LoggingConfigurable):
     _cursor = None
     _connection = None
     _columns = {"session_id", "path", "name", "type", "kernel_id"}
+
     @property
     def cursor(self):
         """Start a cursor and create a database called 'session'"""

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -205,7 +205,7 @@ class SessionManager(LoggingConfigurable):
         super().__init__(*args, **kwargs)
         self._pending_sessions = KernelSessionRecordList()
 
-    _custom_envs: Dict[str, str] = {}
+    _custom_envs: Dict[str, Optional[Dict[str, Any]]] = {}
     # Session database initialized below
     _cursor = None
     _connection = None
@@ -481,10 +481,9 @@ class SessionManager(LoggingConfigurable):
 
             # if we have custom env than we have to add them to available env variables
             if isinstance(self._custom_envs, dict):
-                if self._custom_envs[kernel_id] is not None and isinstance(
-                    self._custom_envs[kernel_id], dict
-                ):
-                    for key, value in self._custom_envs[kernel_id].items():
+                custom_env = self._custom_envs.get(kernel_id)
+                if custom_env is not None and isinstance(custom_env, dict):
+                    for key, value in custom_env.items():
                         env[key] = value
 
             self.kernel_manager.update_env(kernel_id=kernel_id, env=env)

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -1,6 +1,5 @@
 import asyncio
 from datetime import datetime
-
 import pytest
 from tornado import web
 from traitlets import TraitError
@@ -318,6 +317,15 @@ async def test_update_session(session_manager):
     }
     assert model == expected
 
+async def test_update_session_with_custom_env_vars(session_manager):
+    custom_env_vars= {'test_env_name': 'test_env_value'}
+    await session_manager.create_session(
+        path="/path/to/test.ipynb", kernel_name="julia", type="notebook", custom_env_vars=custom_env_vars,
+    )
+    kernel_id = "A"
+    custom_envs = session_manager._custom_envs[kernel_id]
+    expected = 'test_env_value'
+    assert custom_envs['test_env_name'] == expected
 
 async def test_bad_update_session(session_manager):
     # try to update a session with a bad keyword ~ raise error

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+
 import pytest
 from tornado import web
 from traitlets import TraitError
@@ -317,15 +318,20 @@ async def test_update_session(session_manager):
     }
     assert model == expected
 
+
 async def test_update_session_with_custom_env_vars(session_manager):
-    custom_env_vars= {'test_env_name': 'test_env_value'}
+    custom_env_vars = {"test_env_name": "test_env_value"}
     await session_manager.create_session(
-        path="/path/to/test.ipynb", kernel_name="julia", type="notebook", custom_env_vars=custom_env_vars,
+        path="/path/to/test.ipynb",
+        kernel_name="julia",
+        type="notebook",
+        custom_env_vars=custom_env_vars,
     )
     kernel_id = "A"
     custom_envs = session_manager._custom_envs[kernel_id]
-    expected = 'test_env_value'
-    assert custom_envs['test_env_name'] == expected
+    expected = "test_env_value"
+    assert custom_envs["test_env_name"] == expected
+
 
 async def test_bad_update_session(session_manager):
     # try to update a session with a bad keyword ~ raise error


### PR DESCRIPTION
## References

This PR is the part of solution of the feature where users can set up custom env variables for a kernel which has not been run yet.
UI is on https://github.com/AnastasiaSliusar/jupyterlab/pull/2 

## Code changes
 - This PR includes `accept_kernel_env_var` flag which can be used during launching the application. If it is true then a user can see UI for configuring custom env variables when they select another not used kernel from the kernel select dialog or when they call a context menu for a certain kernel icon on Launcher
 - This PR includes  support of `custom_env_vars` variable which has user selection and it is used to setup custom env variables for a certain kernel
