### PR TITLE
extensions_manager: add extension_web_apps interface

### DIFF
--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -1188,6 +1188,23 @@ class PublicStaticFileHandler(web.StaticFileHandler):
         return super().get(path, include_body)
 
 
+class ExtensionAppsHandler(JupyterHandler):
+    """Return Jupyter Server extension web applications."""
+
+    @allow_unauthenticated
+    def get(self) -> None:
+        self.set_header("Content-Type", "application/json")
+        if self.serverapp:
+            self.finish(
+                json.dumps(
+                    self.serverapp.extension_manager.extension_web_apps()
+                )
+            )
+        else:
+            # self.serverapp can be None
+            raise web.HTTPError(500, 'Server has not started correctly.')
+
+
 # -----------------------------------------------------------------------------
 # URL pattern fragments for reuse
 # -----------------------------------------------------------------------------
@@ -1205,4 +1222,5 @@ default_handlers = [
     (r"api", APIVersionHandler),
     (r"/(robots\.txt|favicon\.ico)", PublicStaticFileHandler),
     (r"/metrics", PrometheusMetricsHandler),
+    (r"/extensions", ExtensionAppsHandler),
 ]

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -1195,14 +1195,10 @@ class ExtensionAppsHandler(JupyterHandler):
     def get(self) -> None:
         self.set_header("Content-Type", "application/json")
         if self.serverapp:
-            self.finish(
-                json.dumps(
-                    self.serverapp.extension_manager.extension_web_apps()
-                )
-            )
+            self.finish(json.dumps(self.serverapp.extension_manager.extension_web_apps()))
         else:
             # self.serverapp can be None
-            raise web.HTTPError(500, 'Server has not started correctly.')
+            raise web.HTTPError(500, "Server has not started correctly.")
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import importlib
-from itertools import starmap
 import re
+from itertools import starmap
 
 from tornado.gen import multi
 from traitlets import Any, Bool, Dict, HasTraits, Instance, List, Unicode, default, observe
@@ -14,8 +14,7 @@ from traitlets.config import LoggingConfigurable
 from .config import ExtensionConfigManager
 from .utils import ExtensionMetadataError, ExtensionModuleNotFound, get_loader, get_metadata
 
-
-RE_SLASH = x = re.compile(r'/+')  # match any number of slashes
+RE_SLASH = x = re.compile(r"/+")  # match any number of slashes
 
 
 class ExtensionPoint(HasTraits):
@@ -306,11 +305,12 @@ class ExtensionManager(LoggingConfigurable):
         extensions which provide a default_url (i.e. a web application).
         """
         return {
-            app.name: RE_SLASH.sub('/', f'{self.serverapp.base_url}/{app.default_url}')
+            app.name: RE_SLASH.sub("/", f"{self.serverapp.base_url}/{app.default_url}")
             for extension_apps in self.serverapp.extension_manager.extension_apps.values()
             # filter out extensions that do not provide a default_url OR
             # set it to the root endpoint.
-            for app in extension_apps if getattr(app, 'default_url', '/') != '/'
+            for app in extension_apps
+            if getattr(app, "default_url", "/") != "/"
         }
 
     @property

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import importlib
-import re
 import logging
+import re
 from itertools import starmap
 
 from tornado.gen import multi

--- a/tests/extension/mockextensions/app.py
+++ b/tests/extension/mockextensions/app.py
@@ -50,6 +50,7 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
     static_paths = [STATIC_PATH]  # type:ignore[assignment]
     mock_trait = Unicode("mock trait", config=True)
     loaded = False
+    default_url = '/mockextension'
 
     serverapp_config = {"jpserver_extensions": {"tests.extension.mockextensions.mock1": True}}
 

--- a/tests/extension/mockextensions/app.py
+++ b/tests/extension/mockextensions/app.py
@@ -50,7 +50,7 @@ class MockExtensionApp(ExtensionAppJinjaMixin, ExtensionApp):
     static_paths = [STATIC_PATH]  # type:ignore[assignment]
     mock_trait = Unicode("mock trait", config=True)
     loaded = False
-    default_url = '/mockextension'
+    default_url = "/mockextension"
 
     serverapp_config = {"jpserver_extensions": {"tests.extension.mockextensions.mock1": True}}
 

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -191,3 +191,17 @@ async def test_events(jp_serverapp, jp_fetch):
     stream.truncate(0)
     stream.seek(0)
     assert output["msg"] == "Hello, world!"
+
+
+async def test_extension_web_apps(jp_serverapp):
+    jp_serverapp.extension_manager.load_all_extensions()
+
+    # there should be (at least) two extension applications
+    assert set(jp_serverapp.extension_manager.extension_apps) == {
+        'tests.extension.mockextensions', 'jupyter_server_terminals'
+    }
+
+    # but only one extension web application
+    assert jp_serverapp.extension_manager.extension_web_apps == {
+        'mockextension': '/a%40b/mockextension'
+    }

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -198,10 +198,11 @@ async def test_extension_web_apps(jp_serverapp):
 
     # there should be (at least) two extension applications
     assert set(jp_serverapp.extension_manager.extension_apps) == {
-        'tests.extension.mockextensions', 'jupyter_server_terminals'
+        "tests.extension.mockextensions",
+        "jupyter_server_terminals",
     }
 
     # but only one extension web application
     assert jp_serverapp.extension_manager.extension_web_apps == {
-        'mockextension': '/a%40b/mockextension'
+        "mockextension": "/a%40b/mockextension"
     }


### PR DESCRIPTION
Add `extension_web_apps interface`:

* Add an interface for listing extension applications that provide a default URL (i.e. extensions which provide a web application).
* Add an endpoint for querying this interface.
* Partially addresses #1414 by allowing Jupyter web applications to query for the existence of other Jupyter web applications.

The end goal here is to improve the interoperability of Jupyter web applications in cases where more than one is provided by the same Jupyter Server instance . At present, users must manually edit the URL to switch extensions (e.g. edit ".../lab" to ".../myextension"). 

This endpoint should allow Jupyter web apps to list any other apps that are installed and provide links to open them. E.g, this could be used to populate a menu dropdown.

Questions:

* `/extensions` endpoint:
  * Happy with the name `/extensions` route? Suggest a different name?
  * Happy having a dedicated endpoint for this? Suggest another endpoint to merge this into?
  * Any future plans for extension endpoints? Any way I could leave this more open to future work?