### PR TITLE
Allow ServerApp.no_browser_open_file option to be set via config

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1755,7 +1755,11 @@ class ServerApp(JupyterApp):
         return os.path.join(self.runtime_dir, info_file)
 
     no_browser_open_file = Bool(
-        False, help="If True, do not write redirect HTML file disk, or show in messages."
+        False,
+        config=True,
+        help=_i18n(
+            "If True, do not write redirect HTML file disk, or show in startup output messages."
+        ),
     )
 
     browser_open_file = Unicode()

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -607,13 +607,20 @@ def test_running_server_info(jp_serverapp):
 
 
 @pytest.mark.parametrize("should_exist", [True, False])
-async def test_browser_open_files(jp_configurable_serverapp, should_exist, caplog):
+async def test_no_browser_open_file(jp_configurable_serverapp, should_exist, caplog):
     app = jp_configurable_serverapp(no_browser_open_file=not should_exist)
     await app._post_start()
     assert os.path.exists(app.browser_open_file) == should_exist
     url = urljoin("file:", pathname2url(app.browser_open_file))
     url_messages = [rec.message for rec in caplog.records if url in rec.message]
     assert url_messages if should_exist else not url_messages
+
+
+@pytest.mark.parametrize("should_exist", [True, False])
+def test_no_browser_open_file_cli(jp_configurable_serverapp, should_exist):
+    argv = ["--ServerApp.no_browser_open_file=" + str(should_exist)]
+    app = jp_configurable_serverapp(argv=argv)
+    assert app.no_browser_open_file == should_exist
 
 
 def test_deprecated_notebook_dir_priority(jp_configurable_serverapp, tmp_path):


### PR DESCRIPTION
I was looking to turn off the local filesystem file message in the server output, as it doesn't work in my local dockerized setup, and found this option `no_browser_open_file`.

The change here allows it to be set via configuration / command line arguments. Also added a test for that.