### PR TITLE
[Feature] New API to discover, fetch, and call tools from server extensions

### DIFF
--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -16,6 +16,7 @@ from .config import ExtensionConfigManager
 from .utils import ExtensionMetadataError, ExtensionModuleNotFound, get_loader, get_metadata
 
 
+# probably this should go in it's own file? Not sure where though
 MCP_TOOL_SCHEMA = {
     "type": "object",
     "properties": {
@@ -144,10 +145,11 @@ class ExtensionPoint(HasTraits):
         try:
             definitions = tools_func()
             for name, tool in definitions.items():
+                # not sure if we should just pick MCP schema or make the schema something the user can pass
                 jsonschema.validate(instance=tool["metadata"], schema=MCP_TOOL_SCHEMA)
                 tools[name] = tool
         except Exception as e:
-            # You could also `self.log.warning(...)` if you pass the log around
+            # not sure if this should fail quietly, raise an error, or log it? 
             print(f"[tool-discovery] Failed to load tools from {self.module_name}: {e}")
         return tools
 
@@ -508,7 +510,7 @@ class ExtensionManager(LoggingConfigurable):
                 continue
 
             for point in ext_pkg.extension_points.values():
-                for name, tool in point.tools.items():  # 🔥 <— new property!
+                for name, tool in point.tools.items():  # <— new property!
                     if name in all_tools:
                         raise ValueError(f"Duplicate tool name detected: '{name}'")
                     all_tools[name] = tool

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -130,8 +130,11 @@ class ExtensionPoint(HasTraits):
         return self._module
 
     @property
-    def tools(self):
-        """Structured tools exposed by this extension point, if any."""
+    def tools(self): 
+        """Structured tools exposed by this extension point, if any.
+
+        Searches for a `jupyter_server_extension_tools` function on the extension module or app.
+        """
         loc = self.app or self.module
         if not loc:
             return {}
@@ -499,7 +502,7 @@ class ExtensionManager(LoggingConfigurable):
             self.load_extension(name)
 
     def get_tools(self) -> Dict[str, Any]:
-        """Aggregate tools from all extensions that expose them."""
+        """Aggregate and return structured tools (with metadata) from all enabled extensions."""
         all_tools = {}
 
         for ext_name, ext_pkg in self.extensions.items():
@@ -507,7 +510,7 @@ class ExtensionManager(LoggingConfigurable):
                 continue
 
             for point in ext_pkg.extension_points.values():
-                for name, tool in point.tools.items():  # <— new property!
+                for name, tool in point.tools.items(): 
                     if name in all_tools:
                         raise ValueError(f"Duplicate tool name detected: '{name}'")
                     all_tools[name] = tool

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 import importlib
 from itertools import starmap
 
+import jsonschema
 from tornado.gen import multi
 from traitlets import Any, Bool, Dict, HasTraits, Instance, List, Unicode, default, observe
 from traitlets import validate as validate_trait
 from traitlets.config import LoggingConfigurable
-import jsonschema
-
 
 from .config import ExtensionConfigManager
 from .utils import ExtensionMetadataError, ExtensionModuleNotFound, get_loader, get_metadata
-
 
 # probably this should go in it's own file? Not sure where though
 MCP_TOOL_SCHEMA = {
@@ -27,9 +25,9 @@ MCP_TOOL_SCHEMA = {
             "properties": {
                 "type": {"type": "string", "enum": ["object"]},
                 "properties": {"type": "object"},
-                "required": {"type": "array", "items": {"type": "string"}}
+                "required": {"type": "array", "items": {"type": "string"}},
             },
-            "required": ["type", "properties"]
+            "required": ["type", "properties"],
         },
         "annotations": {
             "type": "object",
@@ -38,14 +36,15 @@ MCP_TOOL_SCHEMA = {
                 "readOnlyHint": {"type": "boolean"},
                 "destructiveHint": {"type": "boolean"},
                 "idempotentHint": {"type": "boolean"},
-                "openWorldHint": {"type": "boolean"}
+                "openWorldHint": {"type": "boolean"},
             },
-            "additionalProperties": True
-        }
+            "additionalProperties": True,
+        },
     },
     "required": ["name", "inputSchema"],
-    "additionalProperties": False
+    "additionalProperties": False,
 }
+
 
 class ExtensionPoint(HasTraits):
     """A simple API for connecting to a Jupyter Server extension
@@ -129,9 +128,9 @@ class ExtensionPoint(HasTraits):
     def module(self):
         """The imported module (using importlib.import_module)"""
         return self._module
-    
+
     @property
-    def tools(self): 
+    def tools(self):
         """Structured tools exposed by this extension point, if any."""
         loc = self.app or self.module
         if not loc:
@@ -149,7 +148,7 @@ class ExtensionPoint(HasTraits):
                 jsonschema.validate(instance=tool["metadata"], schema=MCP_TOOL_SCHEMA)
                 tools[name] = tool
         except Exception as e:
-            # not sure if this should fail quietly, raise an error, or log it? 
+            # not sure if this should fail quietly, raise an error, or log it?
             print(f"[tool-discovery] Failed to load tools from {self.module_name}: {e}")
         return tools
 
@@ -166,7 +165,6 @@ class ExtensionPoint(HasTraits):
                 lambda serverapp: None,
             )
         return linker
-
 
     def _get_loader(self):
         """Get a loader."""
@@ -500,7 +498,6 @@ class ExtensionManager(LoggingConfigurable):
         for name in self.sorted_extensions:
             self.load_extension(name)
 
-    
     def get_tools(self) -> Dict[str, Any]:
         """Aggregate tools from all extensions that expose them."""
         all_tools = {}

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -145,10 +145,16 @@ class ExtensionPoint(HasTraits):
 
         tools = {}
         try:
-            definitions = tools_func()
-            for name, tool in definitions.items():
-                # not sure if we should just pick MCP schema or make the schema something the user can pass
-                jsonschema.validate(instance=tool["metadata"], schema=MCP_TOOL_SCHEMA)
+            result = tools_func()
+            # Support (tools_dict, schema) or just tools_dict
+            if isinstance(result, tuple) and len(result) == 2:
+                tools_dict, schema = result
+            else:
+                tools_dict = result
+                schema = MCP_TOOL_SCHEMA
+                
+            for name, tool in tools_dict.items():
+                jsonschema.validate(instance=tool["metadata"], schema=schema)
                 tools[name] = tool
         except Exception as e:
             # not sure if this should fail quietly, raise an error, or log it?

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2542,7 +2542,7 @@ class ServerApp(JupyterApp):
 
 
     def get_tools(self): 
-        """Aggregate and return tools + tool metadata from all the extensions that expose them."""
+        """Return tools exposed by all extensions."""
         return self.extension_manager.get_tools()
 
     def init_mime_overrides(self) -> None:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2540,6 +2540,9 @@ class ServerApp(JupyterApp):
         """
         self.extension_manager.load_all_extensions()
 
+    def get_tools(self): 
+        return self.extension_manager.get_tools()
+
     def init_mime_overrides(self) -> None:
         # On some Windows machines, an application has registered incorrect
         # mimetypes in the registry.

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2540,6 +2540,7 @@ class ServerApp(JupyterApp):
         """
         self.extension_manager.load_all_extensions()
 
+    # is this how I would expose it? and Is this a good name? 
     def get_tools(self): 
         return self.extension_manager.get_tools()
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2540,8 +2540,8 @@ class ServerApp(JupyterApp):
         """
         self.extension_manager.load_all_extensions()
 
-    # is this how I would expose it? and Is this a good name? 
-    def get_tools(self): 
+    # is this how I would expose it? and Is this a good name?
+    def get_tools(self):
         return self.extension_manager.get_tools()
 
     def init_mime_overrides(self) -> None:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2540,8 +2540,9 @@ class ServerApp(JupyterApp):
         """
         self.extension_manager.load_all_extensions()
 
-    # is this how I would expose it? and Is this a good name?
-    def get_tools(self):
+
+    def get_tools(self): 
+        """Aggregate and return tools + tool metadata from all the extensions that expose them."""
         return self.extension_manager.get_tools()
 
     def init_mime_overrides(self) -> None:

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -423,12 +423,13 @@ class TrustNotebooksHandler(JupyterHandler):
         self.set_status(201)
         self.finish()
 
-# Somehow this doesn't feel like the right service for this to go in? 
+
+# Somehow this doesn't feel like the right service for this to go in?
 class ListToolInfoHandler(APIHandler):
     @web.authenticated
     async def get(self):
         tools = self.serverapp.extension_manager.discover_tools()
-        self.finish({"discovered_tools": tools}) 
+        self.finish({"discovered_tools": tools})
 
 
 # -----------------------------------------------------------------------------
@@ -449,5 +450,4 @@ default_handlers = [
     (r"/api/contents%s" % path_regex, ContentsHandler),
     (r"/api/notebooks/?(.*)", NotebooksRedirectHandler),
     (r"/api/tools", ListToolInfoHandler),
-
 ]

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -424,13 +424,6 @@ class TrustNotebooksHandler(JupyterHandler):
         self.finish()
 
 
-# Somehow this doesn't feel like the right service for this to go in?
-class ListToolInfoHandler(APIHandler):
-    @web.authenticated
-    async def get(self):
-        tools = self.serverapp.extension_manager.discover_tools()
-        self.finish({"discovered_tools": tools})
-
 
 # -----------------------------------------------------------------------------
 # URL to handler mappings
@@ -449,5 +442,4 @@ default_handlers = [
     (r"/api/contents%s/trust" % path_regex, TrustNotebooksHandler),
     (r"/api/contents%s" % path_regex, ContentsHandler),
     (r"/api/notebooks/?(.*)", NotebooksRedirectHandler),
-    (r"/api/tools", ListToolInfoHandler),
 ]

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -423,11 +423,12 @@ class TrustNotebooksHandler(JupyterHandler):
         self.set_status(201)
         self.finish()
 
+# Somehow this doesn't feel like the right service for this to go in? 
 class ListToolInfoHandler(APIHandler):
     @web.authenticated
     async def get(self):
         tools = self.serverapp.extension_manager.discover_tools()
-        self.finish({"discovered_tools": tools})
+        self.finish({"discovered_tools": tools}) 
 
 
 # -----------------------------------------------------------------------------

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -423,6 +423,12 @@ class TrustNotebooksHandler(JupyterHandler):
         self.set_status(201)
         self.finish()
 
+class ListToolInfoHandler(APIHandler):
+    @web.authenticated
+    async def get(self):
+        tools = self.serverapp.extension_manager.discover_tools()
+        self.finish({"discovered_tools": tools})
+
 
 # -----------------------------------------------------------------------------
 # URL to handler mappings
@@ -441,4 +447,6 @@ default_handlers = [
     (r"/api/contents%s/trust" % path_regex, TrustNotebooksHandler),
     (r"/api/contents%s" % path_regex, ContentsHandler),
     (r"/api/notebooks/?(.*)", NotebooksRedirectHandler),
+    (r"/api/tools", ListToolInfoHandler),
+
 ]

--- a/jupyter_server/services/tools/handlers.py
+++ b/jupyter_server/services/tools/handlers.py
@@ -1,0 +1,14 @@
+from tornado import web
+from jupyter_server.base.handlers import APIHandler
+
+class ListToolInfoHandler(APIHandler):
+    @web.authenticated
+    async def get(self):
+        tools = self.serverapp.extension_manager.discover_tools()
+        self.finish({"discovered_tools": tools}) 
+
+
+
+default_handlers = [
+        (r"/api/tools", ListToolInfoHandler),
+]

--- a/tests/extension/mockextensions/mockext_tool.py
+++ b/tests/extension/mockextensions/mockext_tool.py
@@ -1,0 +1,22 @@
+"""A mock extension exposing a structured tool."""
+
+def jupyter_server_extension_tools():
+    return {
+        "mock_tool": {
+            "metadata": {
+                "name": "mock_tool",
+                "description": "A mock tool for testing.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "input": {"type": "string"}
+                    },
+                    "required": ["input"]
+                }
+            },
+            "callable": lambda input: f"Echo: {input}"
+        }
+    }
+
+def _load_jupyter_server_extension(serverapp):
+    serverapp.log.info("Loaded mock tool extension.")

--- a/tests/extension/mockextensions/mockext_tool_dupes.py
+++ b/tests/extension/mockextensions/mockext_tool_dupes.py
@@ -1,0 +1,21 @@
+"""A mock extension that defines a duplicate tool name to test conflict handling."""
+
+def jupyter_server_extension_tools():
+    return {
+        "mock_tool": {  # <-- duplicate on purpose
+            "metadata": {
+                "name": "mock_tool",
+                "description": "Conflicting tool name.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "input": {"type": "string"}
+                    }
+                }
+            },
+            "callable": lambda input: f"Echo again: {input}"
+        }
+    }
+
+def _load_jupyter_server_extension(serverapp):
+    serverapp.log.info("Loaded dupe tool extension.")

--- a/tests/extension/mockextensions/mockext_tool_schema.py
+++ b/tests/extension/mockextensions/mockext_tool_schema.py
@@ -1,0 +1,39 @@
+"""A mock extension that provides a custom validation schema."""
+
+OPENAI_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "input": {"type": "string"}
+            },
+            "required": ["input"]
+        }
+    },
+    "required": ["name", "parameters"]
+}
+
+def jupyter_server_extension_tools():
+    tools = {
+        "openai_style_tool": {
+            "metadata": {
+                "name": "openai_style_tool",
+                "description": "Tool using OpenAI-style parameters",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "input": {"type": "string"}
+                    },
+                    "required": ["input"]
+                }
+            },
+            "callable": lambda input: f"Got {input}"
+        }
+    }
+    return (tools, OPENAI_TOOL_SCHEMA)
+
+def _load_jupyter_server_extension(serverapp):
+    serverapp.log.info("Loaded mock custom-schema extension.")

--- a/tests/extension/test_manager.py
+++ b/tests/extension/test_manager.py
@@ -167,3 +167,28 @@ def test_disable_no_import(jp_serverapp, has_app):
     assert ext_pkg.extension_points == {}
     assert ext_pkg.version == ""
     assert ext_pkg.metadata == []
+
+
+def test_extension_point_tools_default_schema():
+    ep = ExtensionPoint(metadata={"module": "tests.extension.mockextensions.mockext_tool"})
+    assert "mock_tool" in ep.tools
+
+
+def test_extension_point_tools_custom_schema():
+    ep = ExtensionPoint(metadata={"module": "tests.extension.mockextensions.mockext_customschema"})
+    assert "openai_style_tool" in ep.tools
+    metadata = ep.tools["openai_style_tool"]["metadata"]
+    assert "parameters" in metadata
+
+
+def test_extension_manager_duplicate_tool_name_raises(jp_serverapp):
+    from jupyter_server.extension.manager import ExtensionManager
+
+    manager = ExtensionManager(serverapp=jp_serverapp)
+    manager.add_extension("tests.extension.mockextensions.mockext_tool", enabled=True)
+    manager.add_extension("tests.extension.mockextensions.mockext_dupes", enabled=True)
+    manager.link_all_extensions()
+
+    with pytest.raises(ValueError, match="Duplicate tool name detected: 'mock_tool'"):
+        manager.get_tools()
+

--- a/tests/services/tools/test_api.py
+++ b/tests/services/tools/test_api.py
@@ -1,0 +1,29 @@
+import json
+import pytest
+
+@pytest.fixture
+def jp_server_config():
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "tests.extension.mockextensions.mockext_tool": True,
+                "tests.extension.mockextensions.mockext_customschema": True,
+            }
+        }
+    }
+
+@pytest.mark.asyncio
+async def test_multiple_tools_present(jp_fetch):
+    response = await jp_fetch("api", "tools", method="GET")
+    assert response.code == 200
+
+    body = json.loads(response.body.decode())
+    tools = body["discovered_tools"]
+
+    # Check default schema tool
+    assert "mock_tool" in tools
+    assert "inputSchema" in tools["mock_tool"]
+
+    # Check custom schema tool
+    assert "openai_style_tool" in tools
+    assert "parameters" in tools["openai_style_tool"]

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -644,6 +644,24 @@ def test_immutable_cache_trait():
     assert serverapp.web_app.settings["static_immutable_cache"] == ["/test/immutable"]
 
 
+# testing get_tools
+def test_serverapp_get_tools_empty(jp_serverapp):
+    # testing the default empty state
+    tools = jp_serverapp.get_tools()
+    assert tools == {}
+
+def test_serverapp_get_tools(jp_serverapp):
+    jp_serverapp.extension_manager.add_extension(
+        "tests.extension.mockextensions.mockext_tool", enabled=True
+    )
+    jp_serverapp.extension_manager.link_all_extensions()
+
+    tools = jp_serverapp.get_tools()
+    assert "mock_tool" in tools
+    metadata = tools["mock_tool"]["metadata"]
+    assert metadata["name"] == "mock_tool"
+
+
 def test():
     pass
 


### PR DESCRIPTION
This adds a structured tool discovery interface via ExtensionPoint.tools, aggregated through ExtensionManager.get_tools, and exposed in ServerApp via get_tools. Was not sure how far to 'lift' this functionality. 

It also introduces a new REST endpoint at /api/tools, implemented in a new ListToolInfoHandler class under services/contents/handlers.py. I am also unsure if this is the best place to put the ListToolInfoHandler. 

Still exploring if we should, and how best we would integrate the "run tool" functionality from structured tool calls — would love guidance on that.

Still needs unit tests, will probably implement those once the full functionality integration is complete.

Feedback welcome and needed!

@Zsailer Would love your thoughts on:

* Overall structure

* Handler placement (under services/contents or maybe a new service? services/tools?)

* Logger usage (especially in ExtensionPoint.tools)