### PR TITLE
Improve local URL detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Enhancements made
 
-- If ServerApp.ip is ipv6 use \[::1\] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
+- If ServerApp.ip is ipv6 use `[::1]` as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
 - Don't hide .so,.dylib files by default [#1457](https://github.com/jupyter-server/jupyter_server/pull/1457) ([@nokados](https://github.com/nokados))
 - Add async start hook to ExtensionApp API [#1417](https://github.com/jupyter-server/jupyter_server/pull/1417) ([@Zsailer](https://github.com/Zsailer))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Enhancements made
 
-- If ServerApp.ip is ipv6 use [::1] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
+- If ServerApp.ip is ipv6 use \[::1\] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
 - Don't hide .so,.dylib files by default [#1457](https://github.com/jupyter-server/jupyter_server/pull/1457) ([@nokados](https://github.com/nokados))
 - Add async start hook to ExtensionApp API [#1417](https://github.com/jupyter-server/jupyter_server/pull/1417) ([@Zsailer](https://github.com/Zsailer))
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2377,7 +2377,13 @@ class ServerApp(JupyterApp):
         parts = self._get_urlparts(include_token=True)
         # Update with custom pieces.
         if not self.sock:
-            localhost = "[::1]" if ":" in self.ip else self.ip if self.ip.startswith("127.") else "127.0.0.1"
+            localhost = (
+                "[::1]"
+                if ":" in self.ip
+                else self.ip
+                if self.ip.startswith("127.")
+                else "127.0.0.1"
+            )
             parts = parts._replace(netloc=f"{localhost}:{self.port}")
         return parts.geturl()
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2377,7 +2377,7 @@ class ServerApp(JupyterApp):
         parts = self._get_urlparts(include_token=True)
         # Update with custom pieces.
         if not self.sock:
-            localhost = "[::1]" if ":" in self.ip else "127.0.0.1"
+            localhost = "[::1]" if ":" in self.ip else self.ip if self.ip.startswith("127.") else "127.0.0.1"
             parts = parts._replace(netloc=f"{localhost}:{self.port}")
         return parts.geturl()
 


### PR DESCRIPTION
IPv4 loopback is `127/8`, so treat entire range as local. This prevents an unused address being offered when binding to other loopback addresses, e.g. `127.33.22.11`.