### PR TITLE
Send user to custom URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Enhancements made
 
-- If ServerApp.ip is ipv6 use [::1] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
+- If ServerApp.ip is ipv6 use \[::1\] as local_url [#1495](https://github.com/jupyter-server/jupyter_server/pull/1495) ([@manics](https://github.com/manics))
 - Don't hide .so,.dylib files by default [#1457](https://github.com/jupyter-server/jupyter_server/pull/1457) ([@nokados](https://github.com/nokados))
 - Add async start hook to ExtensionApp API [#1417](https://github.com/jupyter-server/jupyter_server/pull/1417) ([@Zsailer](https://github.com/Zsailer))
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2359,9 +2359,9 @@ class ServerApp(JupyterApp):
         )
         return urlparts
 
-    @property
-    def public_url(self) -> str:
-        parts = self._get_urlparts(include_token=True)
+    def _customize_url(
+        self, parts: type[urllib.parse.ParseResult]
+    ) -> urllib.parse.ParseResult:
         # Update with custom pieces.
         if self.custom_display_url:
             # Parse custom display_url
@@ -2370,6 +2370,12 @@ class ServerApp(JupyterApp):
             custom_updates = {key: item for key, item in custom.items() if item}
             # Update public URL parts with custom pieces.
             parts = parts._replace(**custom_updates)
+        return parts
+
+    @property
+    def public_url(self) -> str:
+        parts = self._get_urlparts(include_token=True)
+        parts = self._customize_url(parts)
         return parts.geturl()
 
     @property
@@ -2394,6 +2400,7 @@ class ServerApp(JupyterApp):
     @property
     def connection_url(self) -> str:
         urlparts = self._get_urlparts(path=self.base_url)
+        urlparts = self._customize_url(urlparts)
         return urlparts.geturl()
 
     def init_signal(self) -> None:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2359,9 +2359,7 @@ class ServerApp(JupyterApp):
         )
         return urlparts
 
-    def _customize_url(
-        self, parts: type[urllib.parse.ParseResult]
-    ) -> urllib.parse.ParseResult:
+    def _customize_url(self, parts: type[urllib.parse.ParseResult]) -> urllib.parse.ParseResult:
         # Update with custom pieces.
         if self.custom_display_url:
             # Parse custom display_url


### PR DESCRIPTION
Send user to configured custom URL upon launch, instead of one constructed from bound IP address.

After configuring Notebook, I was redirected to an address like `http://127.0.0.1:8888/tree?token=...` instead of one based on `c.ServerApp.custom_display_url`, as I'd expected.