### PR TITLE
Added `extra_env` in `terminado_settings`

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1490,10 +1490,18 @@ class ServerApp(JupyterApp):
         """
         ),
     )
+
     terminado_settings = Dict(
-        Union([List(), Unicode()]),
+        per_key_traits={
+            "shell_command": Union(
+                [List(), Unicode()], help="The shell command to execute in the terminal."
+            ),
+            "extra_env": Dict(
+                Unicode(), help="Extra environment variables to set in the terminal."
+            ),
+        },
         config=True,
-        help=_i18n('Supply overrides for terminado. Currently only supports "shell_command".'),
+        help=_i18n("Supply overrides for terminado."),
     )
 
     cookie_options = Dict(

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -296,6 +296,17 @@ def test_shell_command_override(
         assert app.web_app.settings["terminal_manager"].shell_command == expected_shell
 
 
+def test_terminal_extra_env_override(jp_configurable_serverapp):
+    config = Config({"ServerApp": {"terminado_settings": {"extra_env": {"PS1": "jupyter> "}}}})
+
+    app = jp_configurable_serverapp(config=config)
+    terminado_settings = getattr(app, "terminado_settings", {})
+
+    assert "extra_env" in terminado_settings
+    assert "PS1" in terminado_settings["extra_env"]
+    assert terminado_settings["extra_env"]["PS1"] == "jupyter> "
+
+
 def test_importing_shims():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")


### PR DESCRIPTION
This PR uses per-key traitlets to accept `shell_command` as an union of string/list and `extra_env` as a dict with string keys, in `terminado_settings`. This will help in passing `extra_env` down to terminado to set PS1 variable in terminals.

Fixes #1537 