### PR TITLE
Fix when base_url is used in combination with a gateway client

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -33,6 +33,7 @@ from traitlets import (
 from traitlets.config import LoggingConfigurable, SingletonConfigurable
 
 from jupyter_server import DEFAULT_EVENTS_SCHEMA_PATH, JUPYTER_SERVER_EVENTS_URI
+from jupyter_server.utils import url_path_join
 
 ERROR_STATUS = "error"
 SUCCESS_STATUS = "success"
@@ -170,6 +171,18 @@ will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (
             raise TraitError(message)
         return value
 
+    base_url = Unicode(
+        default_value="/",
+        config=True,
+        help="""The gateway API base_url for fixing default kernel endpoints""",
+    )
+
+    @observe("base_url")
+    def _base_url(self, change):
+        self.kernels_endpoint = self._kernels_endpoint_default()
+        self.kernelspecs_endpoint = self._kernelspecs_endpoint_default()
+        self.kernelspecs_resource_endpoint = self._kernelspecs_resource_endpoint_default()
+
     kernels_endpoint_default_value = "/api/kernels"
     kernels_endpoint_env = "JUPYTER_GATEWAY_KERNELS_ENDPOINT"
     kernels_endpoint = Unicode(
@@ -180,7 +193,7 @@ will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (
 
     @default("kernels_endpoint")
     def _kernels_endpoint_default(self):
-        return os.environ.get(self.kernels_endpoint_env, self.kernels_endpoint_default_value)
+        return os.environ.get(self.kernels_endpoint_env, url_path_join(self.base_url, self.kernels_endpoint_default_value))
 
     kernelspecs_endpoint_default_value = "/api/kernelspecs"
     kernelspecs_endpoint_env = "JUPYTER_GATEWAY_KERNELSPECS_ENDPOINT"
@@ -193,7 +206,7 @@ will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (
     @default("kernelspecs_endpoint")
     def _kernelspecs_endpoint_default(self):
         return os.environ.get(
-            self.kernelspecs_endpoint_env, self.kernelspecs_endpoint_default_value
+            self.kernelspecs_endpoint_env, url_path_join(self.base_url, self.kernelspecs_endpoint_default_value)
         )
 
     kernelspecs_resource_endpoint_default_value = "/kernelspecs"
@@ -209,7 +222,7 @@ will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (
     def _kernelspecs_resource_endpoint_default(self):
         return os.environ.get(
             self.kernelspecs_resource_endpoint_env,
-            self.kernelspecs_resource_endpoint_default_value,
+            url_path_join(self.base_url, self.kernelspecs_resource_endpoint_default_value),
         )
 
     connect_timeout_default_value = 40.0

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -193,7 +193,10 @@ will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (
 
     @default("kernels_endpoint")
     def _kernels_endpoint_default(self):
-        return os.environ.get(self.kernels_endpoint_env, url_path_join(self.base_url, self.kernels_endpoint_default_value))
+        return os.environ.get(
+            self.kernels_endpoint_env,
+            url_path_join(self.base_url, self.kernels_endpoint_default_value),
+        )
 
     kernelspecs_endpoint_default_value = "/api/kernelspecs"
     kernelspecs_endpoint_env = "JUPYTER_GATEWAY_KERNELSPECS_ENDPOINT"
@@ -206,7 +209,8 @@ will correspond to the value of the Gateway url with 'ws' in place of 'http'.  (
     @default("kernelspecs_endpoint")
     def _kernelspecs_endpoint_default(self):
         return os.environ.get(
-            self.kernelspecs_endpoint_env, url_path_join(self.base_url, self.kernelspecs_endpoint_default_value)
+            self.kernelspecs_endpoint_env,
+            url_path_join(self.base_url, self.kernelspecs_endpoint_default_value),
         )
 
     kernelspecs_resource_endpoint_default_value = "/kernelspecs"

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -54,6 +54,7 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
     def __init__(self, **kwargs):
         """Initialize a gateway mapping kernel manager."""
         super().__init__(**kwargs)
+        GatewayClient.instance().base_url = self.parent.base_url
         self.kernels_url = url_path_join(
             GatewayClient.instance().url or "", GatewayClient.instance().kernels_endpoint or ""
         )
@@ -218,6 +219,8 @@ class GatewayKernelSpecManager(KernelSpecManager):
     def __init__(self, **kwargs):
         """Initialize a gateway kernel spec manager."""
         super().__init__(**kwargs)
+        GatewayClient.instance().base_url = self.parent.base_url
+
         base_endpoint = url_path_join(
             GatewayClient.instance().url or "", GatewayClient.instance().kernelspecs_endpoint
         )
@@ -248,7 +251,7 @@ class GatewayKernelSpecManager(KernelSpecManager):
             resources = kernelspecs[kernel_name]["resources"]
             for resource_name in resources:
                 original_path = resources[resource_name]
-                split_eg_base_url = str.rsplit(original_path, sep="/kernelspecs/", maxsplit=1)
+                split_eg_base_url = str.rsplit(original_path, sep="/kernelspecs", maxsplit=1)
                 if len(split_eg_base_url) > 1:
                     new_path = url_path_join(
                         self.parent.base_url, "kernelspecs", split_eg_base_url[1]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -65,7 +65,9 @@ kernelspecs: dict = {
     "kernelspecs": {
         "kspec_foo": generate_kernelspec("kspec_foo", "/foo/kernelspecs"),
         "kspec_bar": generate_kernelspec("kspec_bar", "/bar/kernelspecs/"),
-        "kspec_baz": generate_kernelspec("kspec_baz", GatewayClient.kernelspecs_endpoint_default_value),
+        "kspec_baz": generate_kernelspec(
+            "kspec_baz", GatewayClient.kernelspecs_endpoint_default_value
+        ),
     },
 }
 
@@ -762,10 +764,10 @@ async def test_websocket_connection_with_session_id(init_gateway, jp_serverapp, 
         handler.connection = conn
         await conn.connect()
         assert conn.session_id != None
-        expected_ws_url = (
-            url_path_join(mock_gateway_ws_url,
-                          jp_serverapp.base_url,
-                          f"/api/kernels/{kernel_id}/channels?session_id={conn.session_id}")
+        expected_ws_url = url_path_join(
+            mock_gateway_ws_url,
+            jp_serverapp.base_url,
+            f"/api/kernels/{kernel_id}/channels?session_id={conn.session_id}",
         )
         assert (
             expected_ws_url in caplog.text

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -28,13 +28,14 @@ from jupyter_server.gateway.connections import GatewayWebSocketConnection
 from jupyter_server.gateway.gateway_client import GatewayTokenRenewerBase, NoOpTokenRenewer
 from jupyter_server.gateway.managers import ChannelQueue, GatewayClient, GatewayKernelManager
 from jupyter_server.services.kernels.websocket import KernelWebsocketHandler
+from jupyter_server.utils import url_path_join
 
 from .utils import expected_http_error
 
 pytest_plugins = ["jupyter_events.pytest_plugin"]
 
 
-def generate_kernelspec(name):
+def generate_kernelspec(name, kernelspecs_endpoint):
     argv_stanza = ["python", "-m", "ipykernel_launcher", "-f", "{connection_file}"]
     spec_stanza = {
         "spec": {
@@ -52,6 +53,7 @@ def generate_kernelspec(name):
         "resources": {
             "logo-64x64": f"f/kernelspecs/{name}/logo-64x64.png",
             "url": "https://example.com/example-url",
+            "kernelspec": kernelspecs_endpoint,
         },
     }
     return kernelspec_stanza
@@ -61,8 +63,9 @@ def generate_kernelspec(name):
 kernelspecs: dict = {
     "default": "kspec_foo",
     "kernelspecs": {
-        "kspec_foo": generate_kernelspec("kspec_foo"),
-        "kspec_bar": generate_kernelspec("kspec_bar"),
+        "kspec_foo": generate_kernelspec("kspec_foo", "/foo/kernelspecs"),
+        "kspec_bar": generate_kernelspec("kspec_bar", "/bar/kernelspecs/"),
+        "kspec_baz": generate_kernelspec("kspec_baz", GatewayClient.kernelspecs_endpoint_default_value),
     },
 }
 
@@ -437,10 +440,19 @@ async def test_gateway_get_kernelspecs(init_gateway, jp_fetch, jp_serverapp):
         assert r.code == 200
         content = json.loads(r.body.decode("utf-8"))
         kspecs = content.get("kernelspecs")
-        assert len(kspecs) == 2
+        assert len(kspecs) == 3
         assert kspecs.get("kspec_bar").get("name") == "kspec_bar"
         assert (
             kspecs.get("kspec_bar").get("resources")["logo-64x64"].startswith(jp_serverapp.base_url)
+        )
+        assert (
+            kspecs.get("kspec_bar").get("resources")["kernelspec"].startswith(jp_serverapp.base_url)
+        )
+        assert (
+            kspecs.get("kspec_foo").get("resources")["kernelspec"].startswith(jp_serverapp.base_url)
+        )
+        assert (
+            kspecs.get("kspec_baz").get("resources")["kernelspec"].startswith(jp_serverapp.base_url)
         )
 
 
@@ -751,7 +763,9 @@ async def test_websocket_connection_with_session_id(init_gateway, jp_serverapp, 
         await conn.connect()
         assert conn.session_id != None
         expected_ws_url = (
-            f"{mock_gateway_ws_url}/api/kernels/{kernel_id}/channels?session_id={conn.session_id}"
+            url_path_join(mock_gateway_ws_url,
+                          jp_serverapp.base_url,
+                          f"/api/kernels/{kernel_id}/channels?session_id={conn.session_id}")
         )
         assert (
             expected_ws_url in caplog.text


### PR DESCRIPTION
Fix for #1549 .

I am operating under the assumption that the preferred order of operations for the url paths should be:
1) env var overrides by way of `JUPYTER_GATEWAY_KERNELSPECS_ENDPOINT`/`JUPYTER_GATEWAY_KERNELS_ENDPOINT`
2) Use `base_url` to extend the paths when provided
3) Use the default paths, e.g. `/api/kernelspecs` as a last resort

This was the only way I could figure out how to fix the issue. The challenge as I see it is the combination of the order of operations above and the widespread usage of `gateway_client.GatewayClient` throughout the project. If there is some other way that `base_url` can get contextualized into `gateway_client` (I am not an expert in the codebase), I think that would be preferable to the approach I ended up taking.