### PR TITLE
fix context pollution

### DIFF
--- a/jupyter_server/base/call_context.py
+++ b/jupyter_server/base/call_context.py
@@ -2,7 +2,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import copy
 from contextvars import Context, ContextVar, copy_context
 from typing import Any
 
@@ -42,7 +41,6 @@ class CallContext:
             The value associated with the named variable for this call context
         """
         name_value_map = CallContext._get_map()
-
         if name in name_value_map:
             return name_value_map[name]
         return None  # TODO: should this raise `LookupError` (or a custom error derived from said)
@@ -62,7 +60,7 @@ class CallContext:
         -------
         None
         """
-        name_value_map = copy.deepcopy(CallContext._get_map())
+        name_value_map = CallContext._get_map().copy()
         name_value_map[name] = value
         CallContext._name_value_map.set(name_value_map)
 

--- a/jupyter_server/base/call_context.py
+++ b/jupyter_server/base/call_context.py
@@ -2,6 +2,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import copy
 from contextvars import Context, ContextVar, copy_context
 from typing import Any
 
@@ -61,8 +62,9 @@ class CallContext:
         -------
         None
         """
-        name_value_map = CallContext._get_map()
+        name_value_map = copy.deepcopy(CallContext._get_map())
         name_value_map[name] = value
+        CallContext._name_value_map.set(name_value_map)
 
     @classmethod
     def context_variable_names(cls) -> list[str]:


### PR DESCRIPTION
fix https://github.com/jupyter-server/jupyter_server/issues/1462
When using CallContext together with copy_context().run(), multiple contexts may accidentally share the same underlying dictionary reference. This leads to context pollution when concurrent tasks modify the same variable keys.
