### PR TITLE
Make ServerKernelManager client traits configurable

### DIFF
--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -859,7 +859,7 @@ class ServerKernelManager(AsyncIOLoopKernelManager):
         - kernel_manager
         - blocking
         - loop
-        """
+        """,
     )
 
     client_factory = Type(
@@ -869,7 +869,7 @@ class ServerKernelManager(AsyncIOLoopKernelManager):
         help="""The kernel client factory class to use for creating client instances.
 
         This should be a subclass of KernelClient.
-        """
+        """,
     )
 
     # Define activity-related attributes:

--- a/tests/services/kernels/test_config.py
+++ b/tests/services/kernels/test_config.py
@@ -1,10 +1,13 @@
 import pytest
-from traitlets.config import Config
-
 from jupyter_client.asynchronous.client import AsyncKernelClient
 from jupyter_client.blocking.client import BlockingKernelClient
 from jupyter_client.client import KernelClient
-from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager, ServerKernelManager
+from traitlets.config import Config
+
+from jupyter_server.services.kernels.kernelmanager import (
+    AsyncMappingKernelManager,
+    ServerKernelManager,
+)
 from jupyter_server.utils import import_item
 
 


### PR DESCRIPTION
  This change enables configuration of kernel client classes in `ServerKernelManager`, 

This was motivated by work we're doing in [jupyter-server-documents](https://github.com/jupyter-ai-contrib/jupyter-server-documents) to move the notebook model to the server, via ydoc. The project needs to provide a custom kernel client that can intercept messages to the client and route them through a server-side ydoc, enabling documents to be moved to the server.

  ### Changes

  - **Made `client_class` and `client_factory` traits configurable** by adding `config=True`
   tag to trait definitions in `ServerKernelManager`
  - **Added unit tests** to verify configuration works via both command line
  arguments and Config objects
