### PR TITLE
Close all sockets in _find_http_port explicitly

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2685,7 +2685,8 @@ class ServerApp(JupyterApp):
         for port in random_ports(self.port, self.port_retries + 1):
             try:
                 sockets = bind_sockets(port, self.ip)
-                sockets[0].close()
+                for s in sockets:
+                    s.close()
             except OSError as e:
                 if e.errno == errno.EADDRINUSE:
                     if self.port_retries:


### PR DESCRIPTION
This should fix the bug with IPv6 socket not being closed before starting http server when running on PyPy.
Please see the issue #1583 for the details.

closes #1583