### PR TITLE
Fix double write when refusing hidden files in contents handler

### DIFF
--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -151,7 +151,6 @@ class ContentsHandler(ContentsAPIHandler):
             )
             return
 
-
         try:
             expect_hash = require_hash
             try:

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -149,6 +149,8 @@ class ContentsHandler(ContentsAPIHandler):
             await self._finish_error(
                 HTTPStatus.NOT_FOUND, f"file or directory {path!r} does not exist"
             )
+            return
+
 
         try:
             expect_hash = require_hash


### PR DESCRIPTION
Fix double write when refusing hidden files in contents handler

When a request targets a hidden file or directory and `allow_hidden` is false,
the contents handler finishes a 404 response but continues execution and later
attempts to write again. This results in a secondary
`RuntimeError: Cannot write() after finish()`.

This change adds an early return after finishing the error response, preventing
further processing and avoiding the double write, without changing behavior.

Fixes #1563
