### PR TITLE
Implement get_checkpoint to allow content retrieval without restoration

### DIFF
--- a/jupyter_server/services/contents/checkpoints.py
+++ b/jupyter_server/services/contents/checkpoints.py
@@ -53,7 +53,7 @@ class Checkpoints(LoggingConfigurable):
 
     def get_checkpoint(self, checkpoint_id, path):
         """Retrieve the content of a checkpoint without restoring it.
-        
+
         Must return a model dictionary.
         """
         raise NotImplementedError
@@ -148,7 +148,7 @@ class GenericCheckpointsMixin:
             }
         """
         raise NotImplementedError
-    
+
     def get_checkpoint(self, checkpoint_id, path):
         """Get the content of a checkpoint."""
         raise NotImplementedError("This logic depends on the specific implementation.")
@@ -268,13 +268,13 @@ class AsyncGenericCheckpointsMixin(GenericCheckpointsMixin):
             }
         """
         raise NotImplementedError
-    
+
     async def get_checkpoint(self, checkpoint_id, path, type_=None):
         """Retrieve a checkpoint asynchronously."""
         if type_ is None:
             model = await self.parent.get(path, content=False)
             type_ = model["type"]
-            
+
         if type_ == "notebook":
             return await self.get_notebook_checkpoint(checkpoint_id, path)
         elif type_ == "file":

--- a/jupyter_server/services/contents/checkpoints.py
+++ b/jupyter_server/services/contents/checkpoints.py
@@ -51,6 +51,13 @@ class Checkpoints(LoggingConfigurable):
         for checkpoint in self.list_checkpoints(path):
             self.delete_checkpoint(checkpoint["id"], path)
 
+    def get_checkpoint(self, checkpoint_id, path):
+        """Retrieve the content of a checkpoint without restoring it.
+        
+        Must return a model dictionary.
+        """
+        raise NotImplementedError
+
 
 class GenericCheckpointsMixin:
     """
@@ -141,6 +148,10 @@ class GenericCheckpointsMixin:
             }
         """
         raise NotImplementedError
+    
+    def get_checkpoint(self, checkpoint_id, path):
+        """Get the content of a checkpoint."""
+        raise NotImplementedError("This logic depends on the specific implementation.")
 
 
 class AsyncCheckpoints(Checkpoints):
@@ -177,6 +188,10 @@ class AsyncCheckpoints(Checkpoints):
         """Delete all checkpoints for the given path."""
         for checkpoint in await self.list_checkpoints(path):
             await self.delete_checkpoint(checkpoint["id"], path)
+
+    async def get_checkpoint(self, checkpoint_id, path):
+        """Retrieve the content of a checkpoint without restoring it asynchronously."""
+        raise NotImplementedError
 
 
 class AsyncGenericCheckpointsMixin(GenericCheckpointsMixin):
@@ -253,3 +268,16 @@ class AsyncGenericCheckpointsMixin(GenericCheckpointsMixin):
             }
         """
         raise NotImplementedError
+    
+    async def get_checkpoint(self, checkpoint_id, path, type_=None):
+        """Retrieve a checkpoint asynchronously."""
+        if type_ is None:
+            model = await self.parent.get(path, content=False)
+            type_ = model["type"]
+            
+        if type_ == "notebook":
+            return await self.get_notebook_checkpoint(checkpoint_id, path)
+        elif type_ == "file":
+            return await self.get_file_checkpoint(checkpoint_id, path)
+        else:
+            raise HTTPError(500, "Unexpected type %s" % type_)

--- a/jupyter_server/services/contents/filecheckpoints.py
+++ b/jupyter_server/services/contents/filecheckpoints.py
@@ -134,7 +134,7 @@ class FileCheckpoints(FileManagerMixin, Checkpoints):
     # Error Handling
     def no_such_checkpoint(self, path, checkpoint_id):
         raise HTTPError(404, f"Checkpoint does not exist: {path}@{checkpoint_id}")
-    
+
     def get_checkpoint(self, checkpoint_id, path, type=None):
         os_path = self.checkpoint_path(checkpoint_id, path)
         if not os.path.isfile(os_path):
@@ -216,7 +216,7 @@ class AsyncFileCheckpoints(FileCheckpoints, AsyncFileManagerMixin, AsyncCheckpoi
             return []
         else:
             return [await self.checkpoint_model(checkpoint_id, os_path)]
-        
+
     async def get_checkpoint(self, checkpoint_id, path, type=None):
         os_path = self.checkpoint_path(checkpoint_id, path)
         if not os.path.isfile(os_path):


### PR DESCRIPTION
The Problem:
Currently, FileCheckpoints and AsyncFileCheckpoints do not implement the get_checkpoint method. This makes it impossible to retrieve the content of a specific checkpoint without performing a full restoration, which can lead to data loss of the current unsaved work.

The Solution:
This PR implements the get_checkpoint method in both synchronous and asynchronous classes.

Key Changes:
Direct File Access: Used internal _read_file and _read_notebook methods to read checkpoint data directly from the filesystem.

Path Handling: Implemented proper OS path to API path mapping to ensure compatibility across different operating systems, especially Windows.

Bypassing Hidden Directory Restrictions: By reading files directly, we bypass the ContentsManager 404 errors that occur when trying to access the hidden .ipynb_checkpoints directory via the standard API.

Testing:
I have verified the implementation using pytest and manual testing:

Synchronous test: Successfully retrieved versioned content of .txt files.

Asynchronous test: Successfully retrieved content using AsyncFileCheckpoints.

Windows Compatibility: Confirmed that path separators are handled correctly.