### PR TITLE
Use st_birthtime for file created timestamp on macOS/BSD

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -44,6 +44,31 @@ except ImportError:
 _script_exporter = None
 
 
+def _get_created_timestamp(info: os.stat_result) -> float:
+    """Get best-effort file creation timestamp from stat result.
+
+    Uses st_birthtime (actual creation time) when available (macOS, BSD,
+    and Linux with kernel 4.11+ via statx on supported filesystems).
+    On Windows, st_ctime is the creation time.
+    On Linux/other, falls back to st_ctime (note: this is inode change time,
+    not creation time, so operations like chmod may update 'created').
+
+    Falls back to st_ctime if st_birthtime is unavailable, non-numeric,
+    negative, or non-finite. Returns st_ctime as final fallback, which
+    is validated in _base_model() during datetime conversion.
+    """
+    birthtime = getattr(info, "st_birthtime", None)
+    # Validate: must be numeric, non-negative, and finite.
+    # Some FUSE/network filesystems may return None or non-numeric values.
+    # Note: birthtime >= 0 rejects pre-1970 dates as these typically indicate
+    # invalid or uninitialized values rather than legitimate historical dates.
+    if isinstance(birthtime, (int, float)) and birthtime >= 0 and math.isfinite(birthtime):
+        return birthtime
+    # Fallback to st_ctime; validation happens in _base_model() during datetime conversion
+    # where OverflowError and other conversion errors are caught and handled
+    return info.st_ctime
+
+
 class FileContentsManager(FileManagerMixin, ContentsManager):
     """A file contents manager."""
 
@@ -245,7 +270,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         try:
             last_modified = tz.utcfromtimestamp(info.st_mtime)
-        except (ValueError, OSError):
+        except (ValueError, OverflowError, OSError):
             # Files can rarely have an invalid timestamp
             # https://github.com/jupyter/notebook/issues/2539
             # https://github.com/jupyter/notebook/issues/2757
@@ -253,10 +278,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             self.log.warning("Invalid mtime %s for %s", info.st_mtime, os_path)
             last_modified = datetime(1970, 1, 1, 0, 0, tzinfo=tz.UTC)
 
+        raw_created = _get_created_timestamp(info)
         try:
-            created = tz.utcfromtimestamp(info.st_ctime)
-        except (ValueError, OSError):  # See above
-            self.log.warning("Invalid ctime %s for %s", info.st_ctime, os_path)
+            created = tz.utcfromtimestamp(raw_created)
+        except (ValueError, OverflowError, OSError):  # See above
+            self.log.warning("Invalid creation time %s for %s", raw_created, os_path)
             created = datetime(1970, 1, 1, 0, 0, tzinfo=tz.UTC)
 
         # Create the base model.


### PR DESCRIPTION
Instrumental in implementing 'Created' column in JupyterLab and solving https://github.com/jupyter/notebook/issues/7797

On macOS/BSD, `st_birthtime` provides the actual file creation time, while `st_ctime` (currently used) is inode change time that updates on chmod, chown, etc.

Changes:
- Add `_get_created_timestamp()` helper that uses `st_birthtime` when available and valid
- Fall back to `st_ctime` on Linux/Windows or when `st_birthtime` is invalid
- Add `OverflowError` to timestamp exception handling
- Add tests for timestamp behavior and edge cases

| Platform | `created` source |
|----------|------------------|
| macOS/BSD | `st_birthtime` |
| Windows | `st_ctime` (creation time) |
| Linux | `st_ctime` (inode change time) |

---

**AI Disclosure:** Developed with Claude Code (Opus 4.5); code review via Cursor Agents (opus-4.5-thinking, gpt-5.2-high, gemini-3-pro). All code reviewed by author.