### PR TITLE
Support running kernels in multiple locations (locally or remote) simultaneously.

### DIFF
--- a/docs/source/api/jupyter_server.services.kernels.rst
+++ b/docs/source/api/jupyter_server.services.kernels.rst
@@ -25,6 +25,12 @@ Submodules
    :undoc-members:
 
 
+.. automodule:: jupyter_server.services.kernels.routing
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+
 .. automodule:: jupyter_server.services.kernels.websocket
    :members:
    :show-inheritance:

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -31,6 +31,7 @@ from ..services.kernels.kernelmanager import (
     emit_kernel_action_event,
 )
 from ..services.sessions.sessionmanager import SessionManager
+from ..transutils import _i18n
 from ..utils import url_path_join
 from .connections import GatewayWebSocketConnection
 from .gateway_client import GatewayClient, gateway_request
@@ -212,6 +213,13 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
         """Override cull_kernels, so we can be sure their state is current."""
         await self.list_kernels()
         await super().cull_kernels()
+
+    @property
+    def info(self):
+        return (
+            _i18n("\nKernels will be managed by the Gateway server running at:\n%s")
+            % self.kernels_url
+        )
 
 
 class GatewayKernelSpecManager(KernelSpecManager):

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -8,6 +8,7 @@ import asyncio
 import datetime
 import json
 import os
+import warnings
 from queue import Empty, Queue
 from threading import Thread
 from time import monotonic
@@ -359,22 +360,13 @@ class GatewaySessionManager(SessionManager):
 
     kernel_manager = Instance("jupyter_server.gateway.managers.GatewayMappingKernelManager")
 
-    async def kernel_culled(self, kernel_id: str) -> bool:  # typing: ignore
-        """Checks if the kernel is still considered alive and returns true if it's not found."""
-        km: Optional[GatewayKernelManager] = None
-        try:
-            # Since we keep the models up-to-date via client polling, use that state to determine
-            # if this kernel no longer exists on the gateway server rather than perform a redundant
-            # fetch operation - especially since this is called at approximately the same interval.
-            # This has the effect of reducing GET /api/kernels requests against the gateway server
-            # by 50%!
-            # Note that should the redundant polling be consolidated, or replaced with an event-based
-            # notification model, this will need to be revisited.
-            km = self.kernel_manager.get_kernel(kernel_id)
-        except Exception:
-            # Let exceptions here reflect culled kernel
-            pass
-        return km is None
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "The GatewaySessionManager class is deprecated and will not be supported in Jupyter Server 3.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
 
 class GatewayKernelManager(ServerKernelManager):

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -32,6 +32,7 @@ from ..services.kernels.kernelmanager import (
 )
 from ..services.sessions.sessionmanager import SessionManager
 from ..utils import url_path_join
+from .connections import GatewayWebSocketConnection
 from .gateway_client import GatewayClient, gateway_request
 
 if TYPE_CHECKING:
@@ -398,6 +399,11 @@ class GatewayKernelManager(ServerKernelManager):
 
     client_class = DottedObjectName("jupyter_server.gateway.managers.GatewayKernelClient")
     client_factory = Type(klass="jupyter_server.gateway.managers.GatewayKernelClient")
+
+    def create_websocket_connection(self, websocket_handler, config=None):
+        return GatewayWebSocketConnection(
+            parent=self, websocket_handler=websocket_handler, config=config
+        )
 
     # --------------------------------------------------------------------------
     # create a Client connected to our Kernel

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -217,7 +217,7 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
     @property
     def info(self):
         return (
-            _i18n("\nKernels will be managed by the Gateway server running at:\n%s")
+            _i18n("Kernels will be managed by the Gateway server running at:\n%s")
             % self.kernels_url
         )
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2871,11 +2871,8 @@ class ServerApp(JupyterApp):
         info += _i18n("Jupyter Server {version} is running at:\n{url}").format(
             version=ServerApp.version, url=self.display_url
         )
-        if self.gateway_config.gateway_enabled:
-            info += (
-                _i18n("\nKernels will be managed by the Gateway server running at:\n%s")
-                % self.gateway_config.url
-            )
+        if hasattr(self.kernel_manager, "info"):
+            info += self.kernel_manager.info
         return info
 
     def server_info(self) -> dict[str, t.Any]:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1632,8 +1632,6 @@ class ServerApp(JupyterApp):
 
     @default("session_manager_class")
     def _default_session_manager_class(self) -> t.Union[str, type[SessionManager]]:
-        if self.gateway_config.gateway_enabled:
-            return "jupyter_server.gateway.managers.GatewaySessionManager"
         return SessionManager
 
     kernel_websocket_connection_class = Type(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -103,7 +103,6 @@ from jupyter_server.base.handlers import (
 from jupyter_server.extension.config import ExtensionConfigManager
 from jupyter_server.extension.manager import ExtensionManager
 from jupyter_server.extension.serverextension import ServerExtensionApp
-from jupyter_server.gateway.connections import GatewayWebSocketConnection
 from jupyter_server.gateway.gateway_client import GatewayClient
 from jupyter_server.gateway.managers import (
     GatewayKernelSpecManager,
@@ -896,7 +895,6 @@ class ServerApp(JupyterApp):
         GatewayMappingKernelManager,
         GatewayKernelSpecManager,
         GatewaySessionManager,
-        GatewayWebSocketConnection,
         GatewayClient,
         Authorizer,
         EventLogger,
@@ -1644,8 +1642,6 @@ class ServerApp(JupyterApp):
     def _default_kernel_websocket_connection_class(
         self,
     ) -> t.Union[str, type[ZMQChannelsWebsocketConnection]]:
-        if self.gateway_config.gateway_enabled:
-            return "jupyter_server.gateway.connections.GatewayWebSocketConnection"
         return ZMQChannelsWebsocketConnection
 
     websocket_ping_interval = Integer(

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -107,7 +107,6 @@ from jupyter_server.gateway.gateway_client import GatewayClient
 from jupyter_server.gateway.managers import (
     GatewayKernelSpecManager,
     GatewayMappingKernelManager,
-    GatewaySessionManager,
 )
 from jupyter_server.log import log_request
 from jupyter_server.prometheus.metrics import (
@@ -129,6 +128,10 @@ from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebso
 from jupyter_server.services.kernels.kernelmanager import (
     AsyncMappingKernelManager,
     MappingKernelManager,
+)
+from jupyter_server.services.kernels.routing import (
+    RoutingKernelSpecManager,
+    RoutingMappingKernelManager,
 )
 from jupyter_server.services.sessions.sessionmanager import SessionManager
 from jupyter_server.utils import (
@@ -892,13 +895,14 @@ class ServerApp(JupyterApp):
         AsyncContentsManager,
         AsyncFileContentsManager,
         NotebookNotary,
-        GatewayMappingKernelManager,
         GatewayKernelSpecManager,
-        GatewaySessionManager,
+        GatewayMappingKernelManager,
         GatewayClient,
         Authorizer,
         EventLogger,
         ZMQChannelsWebsocketConnection,
+        RoutingKernelSpecManager,
+        RoutingMappingKernelManager,
     ]
 
     subcommands: dict[str, t.Any] = {
@@ -1619,9 +1623,7 @@ class ServerApp(JupyterApp):
 
     @default("kernel_manager_class")
     def _default_kernel_manager_class(self) -> t.Union[str, type[AsyncMappingKernelManager]]:
-        if self.gateway_config.gateway_enabled:
-            return "jupyter_server.gateway.managers.GatewayMappingKernelManager"
-        return AsyncMappingKernelManager
+        return RoutingMappingKernelManager
 
     session_manager_class = Type(
         config=True,
@@ -1691,8 +1693,16 @@ class ServerApp(JupyterApp):
 
     @default("kernel_spec_manager_class")
     def _default_kernel_spec_manager_class(self) -> t.Union[str, type[KernelSpecManager]]:
-        if self.gateway_config.gateway_enabled:
-            return "jupyter_server.gateway.managers.GatewayKernelSpecManager"
+        if issubclass(
+            self.kernel_manager_class,
+            RoutingMappingKernelManager,
+        ):
+            return RoutingKernelSpecManager
+        elif issubclass(
+            self.kernel_manager_class,
+            GatewayMappingKernelManager,
+        ):
+            return GatewayKernelSpecManager
         return KernelSpecManager
 
     login_handler_class = Type(
@@ -2872,7 +2882,7 @@ class ServerApp(JupyterApp):
             version=ServerApp.version, url=self.display_url
         )
         if hasattr(self.kernel_manager, "info"):
-            info += self.kernel_manager.info
+            info += "\n" + self.kernel_manager.info
         return info
 
     def server_info(self) -> dict[str, t.Any]:

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -899,6 +899,10 @@ class ServerKernelManager(AsyncIOLoopKernelManager):
                 pass
         return logger
 
+    def create_websocket_connection(self, websocket_handler, config=None):
+        connection_class = websocket_handler.kernel_websocket_connection_class
+        return connection_class(parent=self, websocket_handler=websocket_handler, config=config)
+
     def emit(self, schema_id, data):
         """Emit an event from the kernel manager."""
         self.event_logger.emit(schema_id=schema_id, data=data)

--- a/jupyter_server/services/kernels/routing.py
+++ b/jupyter_server/services/kernels/routing.py
@@ -1,0 +1,374 @@
+import copy
+import typing as t
+
+from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client.manager import in_pending_state
+from jupyter_client.managerabc import KernelManagerABC
+from jupyter_core.utils import ensure_async, run_sync
+from traitlets import (
+    Dict,
+    Instance,
+    List,
+    Type,
+    Unicode,
+    default,
+    observe,
+)
+from traitlets.config import LoggingConfigurable
+
+from jupyter_server.gateway.gateway_client import GatewayClient
+from jupyter_server.gateway.managers import GatewayKernelSpecManager, GatewayMappingKernelManager
+from jupyter_server.services.kernels.connection.base import BaseKernelWebsocketConnection
+from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebsocketConnection
+from jupyter_server.services.kernels.kernelmanager import (
+    AsyncMappingKernelManager,
+    ServerKernelManager,
+)
+from jupyter_server.transutils import _i18n
+
+
+class RoutingProvider(LoggingConfigurable):
+    connection_dir = Unicode("")
+
+    primary_manager = Instance(AsyncMappingKernelManager)
+
+    additional_managers = List(trait=Instance(AsyncMappingKernelManager))
+
+    @default("primary_manager")
+    def _default_primary_manager(self):
+        ksm = KernelSpecManager(parent=self.parent)
+        return AsyncMappingKernelManager(
+            parent=self.parent,
+            log=self.log,
+            connection_dir=self.connection_dir,
+            kernel_spec_manager=ksm,
+        )
+
+    info = Unicode("")
+
+    @default("info")
+    def _default_info(self):
+        all_infos = []
+        if hasattr(self.primary_manager, "info"):
+            all_infos.append(self.primary_manager.info)
+        for additional_manager in self.additional_managers:
+            if hasattr(additional_manager, "info"):
+                all_infos.append(additional_manager.info)
+        return "\n".join(all_infos)
+
+
+class RemoteOnlyRoutingProvider(RoutingProvider):
+    @default("primary_manager")
+    def _default_primary_manager(self):
+        ksm = GatewayKernelSpecManager(parent=self.parent)
+        return GatewayMappingKernelManager(
+            parent=self.parent,
+            log=self.log,
+            connection_dir=self.connection_dir,
+            kernel_spec_manager=ksm,
+        )
+
+
+class SideBySideRoutingProvider(RoutingProvider):
+    @default("additional_managers")
+    def _default_additional_managers(self):
+        ksm = GatewayKernelSpecManager(parent=self.parent)
+        return [
+            GatewayMappingKernelManager(
+                parent=self.parent,
+                log=self.log,
+                connection_dir=self.connection_dir,
+                kernel_spec_manager=ksm,
+            )
+        ]
+
+
+class AsyncRoutingKernelSpecManager(KernelSpecManager):
+    """KernelSpecManager that routes to multiple nested kernel spec managers.
+
+    This async version of the wrapper exists because the base KernelSpecManager
+    class only has synchronous methods, but some child classes (in particular,
+    GatewayKernelManager) change those methods to be async.
+
+    In order to support both versions, we first implement the routing in this async
+    class, but then make it synchronous in the child, RoutingKernelSpecManager class.
+    """
+
+    @property
+    def primary_manager(self) -> AsyncMappingKernelManager:
+        # This kernelspec manager can only be used when the corresponding kernel
+        # manager can tell us how to route requests to the nested managers.
+        assert self.parent is not None
+        assert hasattr(self.parent.kernel_manager, "routing_provider")
+        assert isinstance(self.parent.kernel_manager.routing_provider, RoutingProvider)
+
+        km = self.parent.kernel_manager.routing_provider.primary_manager
+
+        # On the odd chance that an administrator explicitly configured a routing
+        # provider with a nested routing kernelspec manager, all attempts to list
+        # or get kernelspecs will result in an infinite loop.
+        #
+        # Accordingly, we use an assert to catch this early.
+        assert not isinstance(km.kernel_spec_manager, AsyncRoutingKernelSpecManager)
+
+        return km
+
+    @property
+    def additional_managers(self):
+        # This kernelspec manager can only be used when the corresponding kernel
+        # manager can tell us how to route requests to the nested managers.
+        assert self.parent is not None
+        assert hasattr(self.parent.kernel_manager, "routing_provider")
+
+        kms = self.parent.kernel_manager.routing_provider.additional_managers
+
+        # Similarly to the `primary_manager` property, we want to ensure that
+        # none of the nested kernelspec managers are instances of this same class,
+        # in order to prevent infinite loops and to catch the configuration
+        # issues that could cause such loops early.
+        for km in kms:
+            assert not isinstance(km.kernel_spec_manager, AsyncRoutingKernelSpecManager)
+
+        return kms
+
+    spec_to_manager_map = Dict(key_trait=Unicode(), value_trait=Instance(AsyncMappingKernelManager))
+
+    async def get_all_specs(self):
+        ksm = self.primary_manager.kernel_spec_manager
+        assert ksm is not None
+        ks = await ensure_async(ksm.get_all_specs())
+        for spec_name, _spec in ks.items():
+            self.spec_to_manager_map[spec_name] = self.primary_manager
+        for additional_manager in self.additional_managers:
+            additional_ks = await ensure_async(
+                additional_manager.kernel_spec_manager.get_all_specs()
+            )
+            for spec_name, spec in additional_ks.items():
+                if spec_name not in ks:
+                    ks[spec_name] = spec
+                    self.spec_to_manager_map[spec_name] = additional_manager
+        return ks
+
+    def get_mapping_kernel_manager(self, kernel_name: str) -> AsyncMappingKernelManager:
+        km = self.spec_to_manager_map.get(kernel_name, None)
+        if km is None:
+            return self.primary_manager
+        return km
+
+    async def get_kernel_spec(self, kernel_name, **kwargs):
+        wrapped_manager = self.get_mapping_kernel_manager(kernel_name).kernel_spec_manager
+        assert wrapped_manager is not None
+
+        return await ensure_async(wrapped_manager.get_kernel_spec(kernel_name, **kwargs))
+
+    async def get_kernel_spec_resource(self, kernel_name, path):
+        wrapped_manager = self.get_mapping_kernel_manager(kernel_name).kernel_spec_manager
+        assert wrapped_manager is not None
+
+        if hasattr(wrapped_manager, "get_kernel_spec_resource"):
+            return await ensure_async(wrapped_manager.get_kernel_spec_resource(kernel_name, path))
+        return None
+
+
+class RoutingKernelSpecManager(AsyncRoutingKernelSpecManager):
+    """KernelSpecManager that routes to multiple nested kernel spec managers."""
+
+    def get_all_specs(self):
+        return run_sync(super().get_all_specs)()
+
+    def get_kernel_spec(self, kernel_name, *args, **kwargs):
+        return run_sync(super().get_kernel_spec)(kernel_name, *args, **kwargs)
+
+
+class RoutingKernelManager(ServerKernelManager):
+    kernel_id: t.Optional[str] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Enforce that our kernel_id is only set in the `start_kernel` method.
+        self.kernel_id = None
+
+    @property
+    def wrapped_multi_kernel_manager(self):
+        assert self.parent is not None
+        return self.parent.kernel_spec_manager.get_mapping_kernel_manager(self.kernel_name)
+
+    @property
+    def wrapped_kernel_manager(self):
+        if not self.kernel_id:
+            return None
+        return self.wrapped_multi_kernel_manager.get_kernel(self.kernel_id)
+
+    def create_websocket_connection(self, websocket_handler, config=None):
+        return self.wrapped_kernel_manager.create_websocket_connection(
+            websocket_handler=websocket_handler, config=config
+        )
+
+    @property
+    def session(self):
+        return self.wrapped_kernel_manager.session
+
+    @property
+    def has_kernel(self):
+        if not self.kernel_id:
+            return False
+        return self.wrapped_kernel_manager.has_kernel
+
+    async def is_alive(self):
+        if not self.has_kernel:
+            return False
+        return await self.wrapped_kernel_manager.is_alive()
+
+    def client(self, *args, **kwargs):
+        if not self.kernel_id:
+            return None
+        return self.wrapped_kernel_manager.client(*args, **kwargs)
+
+    @in_pending_state
+    async def start_kernel(self, *args, **kwargs):
+        km = self.wrapped_multi_kernel_manager
+        if isinstance(km, GatewayMappingKernelManager):
+            kwargs.pop("kernel_id", None)
+        self.kernel_id: str = await ensure_async(
+            km.start_kernel(kernel_name=self.kernel_name, **kwargs)
+        )
+        self.log.debug(f"Created kernel {self.kernel_id} in {km}")
+
+    async def shutdown_kernel(self, now=False, restart=False):
+        km = self.wrapped_multi_kernel_manager
+        await ensure_async(km.shutdown_kernel(self.kernel_id, now=now, restart=restart))
+
+    async def restart_kernel(self, now=False):
+        km = self.wrapped_multi_kernel_manager
+        return await ensure_async(km.restart_kernel(self.kernel_id, now=now))
+
+    async def interrupt_kernel(self):
+        km = self.wrapped_kernel_manager
+        return await ensure_async(km.interrupt_kernel())
+
+    async def model(self):
+        wrapped_model = await ensure_async(
+            self.wrapped_multi_kernel_manager.kernel_model(self.kernel_id)
+        )
+        model = copy.deepcopy(wrapped_model)
+        model["id"] = self.kernel_id
+        return model
+
+
+class RoutingMappingKernelManager(AsyncMappingKernelManager):
+    # We have to completely override the kernel management from the super classes so that
+    # we can effectively keep the set of kernels in sync with the nested managers.
+    _kernels: dict[str, RoutingKernelManager]
+
+    @default("kernel_manager_class")
+    def _default_kernel_manager_class(self):
+        return "jupyter_server.services.kernels.routing.RoutingKernelManager"
+
+    kernel_spec_manager = Instance(
+        "jupyter_server.services.kernels.routing.RoutingKernelSpecManager"
+    )
+
+    _routing_provider = None
+    routing_provider_class = Type(
+        klass=RoutingProvider,
+        config=True,
+        help=_i18n(
+            "The class defining how kernelspec and kernel requests are routed "
+            + "to the various supported managers."
+        ),
+    )
+
+    @default("routing_provider_class")
+    def _default_routing_provider_class(self):
+        gateway_config = GatewayClient.instance(parent=self.parent)
+        if gateway_config.gateway_enabled:
+            return RemoteOnlyRoutingProvider
+        return RoutingProvider
+
+    @property
+    def routing_provider(self):
+        if not self._routing_provider:
+            self._routing_provider = self.routing_provider_class(
+                parent=self.parent, log=self.log, connection_dir=self.connection_dir
+            )
+        return self._routing_provider
+
+    def remove_kernel(self, kernel_id):
+        return self._kernels.pop(kernel_id, None)
+
+    async def shutdown_kernel(self, kernel_id, now=False, restart=False):
+        km = self.get_kernel(kernel_id)
+        await ensure_async(km.shutdown_kernel(now=now, restart=restart))
+        self.remove_kernel(kernel_id)
+        return
+
+    async def shutdown_all(self, now=False):
+        kernels_to_shutdown = [kid for kid in self._kernels]
+        self.log.debug(f"Shutting down the kernels {kernels_to_shutdown}...")
+        for kid in kernels_to_shutdown:
+            await self.shutdown_kernel(kid, now=now)
+        return
+
+    async def restart_kernel(self, kernel_id, now=False, **kwargs):
+        km = self.get_kernel(kernel_id)
+        return await km.restart_kernel(now=now, **kwargs)
+
+    async def interrupt_kernel(self, kernel_id, **kwargs):
+        km = self.get_kernel(kernel_id)
+        return await km.interrupt_kernel()
+
+    async def list_kernels(self):
+        # We have might remote kernels, so we must call `list_kernels` on the
+        # wrapped Gateway kernel managers to update our kernel models.
+        updated_kernels = await ensure_async(self.routing_provider.primary_manager.list_kernels())
+        try:
+            for wrapped in self.routing_provider.additional_managers:
+                updated_kernels.extend(await ensure_async(wrapped.list_kernels()))
+        except Exception as ex:
+            self.log.exception("Failure listing kernels: %s", ex)
+            # Ignore the exception listing remote kernels, so that local kernels are still usable.
+        self.log.debug(f"Updated kernels: {updated_kernels}...")
+        updated_kernel_ids = [k.get("id", None) for k in updated_kernels]
+        for kid in [kid for kid in self._kernels]:
+            if kid not in updated_kernel_ids:
+                # The kernel may have been culled by the nested manager
+                self.log.debug(f"Kernel {kid} missing from the nested managers; possibly culled...")
+                self._kernels.pop(kid, None)
+        filtered_kernels = [
+            kernel for kernel in updated_kernels if kernel.get("id", None) in self._kernels
+        ]
+        return filtered_kernels
+
+    def kernel_model(self, kernel_id):
+        self._check_kernel_id(kernel_id)
+        kernel = self._kernels[kernel_id]
+        # Normally, calls to `run_sync` pose a danger of locking up Tornado's
+        # single-threaded event loop.
+        #
+        # However, the call below should be fine because it cannot block for an
+        # arbitrary amount of time.
+        #
+        # This call blocks on the `model` method defined below, which in turn
+        # blocks on the `GatewayMappingKernelManager`'s `kernel_model` method
+        # (https://github.com/jupyter-server/jupyter_server/blob/547f7a244d89f79dd09fa7d382322d1c40890a3f/jupyter_server/gateway/managers.py#L94).
+        #
+        # That will only take a small, deterministic amount of time to complete
+        # because that `kernel_model` only operates on existing, in-memory data
+        # and does not block on any outgoing network requests.
+        return run_sync(kernel.model)()
+
+    def _using_pending_kernels(self):
+        return False
+
+    async def start_kernel(self, kernel_name=None, kernel_id=None, **kwargs):
+        km, kernel_name, _ = self.pre_start_kernel(kernel_name, kwargs)
+        await km.start_kernel(kernel_id=kernel_id, **kwargs)
+        self._kernels[km.kernel_id] = km
+        return km.kernel_id
+
+    @property
+    def info(self):
+        return self.routing_provider.info
+
+
+KernelManagerABC.register(RoutingKernelManager)

--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -45,9 +45,14 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler):
             raise web.HTTPError(403)
 
         kernel = self.kernel_manager.get_kernel(self.kernel_id)
-        self.connection = self.kernel_websocket_connection_class(
-            parent=kernel, websocket_handler=self, config=self.config
-        )
+        if hasattr(kernel, "create_websocket_connection"):
+            self.connection = kernel.create_websocket_connection(
+                websocket_handler=self, config=self.config
+            )
+        else:
+            self.connection = self.kernel_websocket_connection_class(
+                parent=kernel, websocket_handler=self, config=self.config
+            )
 
         if self.get_argument("session_id", None):
             self.connection.session.session = self.get_argument("session_id")

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -18,6 +18,7 @@ except ImportError:
 
 from dataclasses import dataclass, fields
 
+from jupyter_client.manager import KernelManager
 from jupyter_core.utils import ensure_async
 from tornado import web
 from traitlets import Instance, TraitError, Unicode, validate
@@ -468,7 +469,13 @@ class SessionManager(LoggingConfigurable):
 
     async def kernel_culled(self, kernel_id: str) -> bool:
         """Checks if the kernel is still considered alive and returns true if its not found."""
-        return kernel_id not in self.kernel_manager
+        km: Optional[KernelManager] = None
+        try:
+            km = self.kernel_manager.get_kernel(kernel_id)
+        except Exception:
+            # Let exceptions here reflect culled kernel
+            pass
+        return km is None
 
     async def row_to_model(self, row, tolerate_culled=False):
         """Takes sqlite database session row and turns it into a dictionary"""

--- a/tests/base/test_call_context.py
+++ b/tests/base/test_call_context.py
@@ -7,7 +7,7 @@ from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.services.kernels.kernelmanager import AsyncMappingKernelManager
 
 
-async def test_jupyter_handler_contextvar(jp_fetch, monkeypatch):
+async def test_jupyter_handler_contextvar(jp_serverapp, jp_fetch, monkeypatch):
     # Create some mock kernel Ids
     kernel1 = "x-x-x-x-x"
     kernel2 = "y-y-y-y-y"
@@ -45,7 +45,7 @@ async def test_jupyter_handler_contextvar(jp_fetch, monkeypatch):
         context_tracker[kernel_id]["ended"] = current.current_user
         return {"id": kernel_id, "name": "blah"}
 
-    monkeypatch.setattr(AsyncMappingKernelManager, "kernel_model", kernel_model)
+    monkeypatch.setattr(jp_serverapp.kernel_manager.__class__, "kernel_model", kernel_model)
 
     # Make two requests in parallel.
     await asyncio.gather(

--- a/tests/services/kernels/test_connection.py
+++ b/tests/services/kernels/test_connection.py
@@ -20,7 +20,10 @@ async def test_websocket_connection(jp_serverapp: ServerApp) -> None:
     handler = KernelWebsocketHandler(app.web_app, request)
     handler.ws_connection = MagicMock()
     handler.ws_connection.is_closing = lambda: False
-    conn = ZMQChannelsWebsocketConnection(parent=kernel, websocket_handler=handler)
+    if hasattr(kernel, "create_websocket_connection"):
+        conn = kernel.create_websocket_connection(websocket_handler=handler, config=None)
+    else:
+        conn = ZMQChannelsWebsocketConnection(parent=kernel, websocket_handler=handler)
     handler.connection = conn
     await conn.prepare()
     conn.connect()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -439,7 +439,10 @@ def test_gateway_request_with_expiring_cookies(
 async def test_gateway_class_mappings(init_gateway, jp_serverapp):
     # Ensure appropriate class mappings are in place.
     assert jp_serverapp.kernel_manager_class.__name__ == "GatewayMappingKernelManager"
-    assert jp_serverapp.session_manager_class.__name__ == "GatewaySessionManager"
+    assert (
+        jp_serverapp.session_manager.kernel_manager.__class__.__name__
+        == "GatewayMappingKernelManager"
+    )
     assert jp_serverapp.kernel_spec_manager_class.__name__ == "GatewayKernelSpecManager"
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -438,12 +438,16 @@ def test_gateway_request_with_expiring_cookies(
 
 async def test_gateway_class_mappings(init_gateway, jp_serverapp):
     # Ensure appropriate class mappings are in place.
-    assert jp_serverapp.kernel_manager_class.__name__ == "GatewayMappingKernelManager"
+    assert jp_serverapp.kernel_manager_class.__name__ == "RoutingMappingKernelManager"
     assert (
         jp_serverapp.session_manager.kernel_manager.__class__.__name__
-        == "GatewayMappingKernelManager"
+        == "RoutingMappingKernelManager"
     )
-    assert jp_serverapp.kernel_spec_manager_class.__name__ == "GatewayKernelSpecManager"
+    assert jp_serverapp.kernel_spec_manager_class.__name__ == "RoutingKernelSpecManager"
+
+    primary_manager = jp_serverapp.kernel_manager.routing_provider.primary_manager
+    assert primary_manager.__class__.__name__ == "GatewayMappingKernelManager"
+    assert primary_manager.kernel_spec_manager.__class__.__name__ == "GatewayKernelSpecManager"
 
 
 async def test_gateway_get_kernelspecs(init_gateway, jp_fetch, jp_serverapp):


### PR DESCRIPTION
This PR extends the Jupyter server to support running kernels using multiple separate MappingKernelManagers simultaneously.

For example, you can run both local kernels and Kernel Gateway kernels at the same time without having to reconfigure (and restart) the server.

The topology for how these separate managers are plugged together is configurable, with the configuration being done by specifying a `RoutingProvider` class.

This has been discussed multiple times both in issues on the jupyter_server repo and in community meetings.

The most recent and up-to-date such discussion is [here](https://github.com/jupyter-server/team-compass/issues/72).

That issue was opened to give a single place for folks to talk about the overall proposal and to raise any objections or concerns they might have about it.

No such objections have been raised, so I am proceeding with a PR to actually implement the proposal.