### PR TITLE
Fix name when copying filenames/directories containing "-Copy"

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -677,7 +677,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if not is_destination_specified:
             to_path = from_dir
         if self.dir_exists(to_path):
-            name = copy_pat.sub(".", from_name)
+            if to_path.strip("/") == from_dir:
+                name = copy_pat.sub(".", from_name)
+            else:
+                # Different directory copy, keep original name
+                name = from_name
             to_name = super().increment_filename(name, to_path, insert="-Copy")
         to_path = f"{to_path}/{to_name}"
 
@@ -1160,7 +1164,11 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         if not is_destination_specified:
             to_path = from_dir
         if await self.dir_exists(to_path):
-            name = copy_pat.sub(".", from_name)
+            if to_path.strip("/") == from_dir:
+                name = copy_pat.sub(".", from_name)
+            else:
+                # Different directory copy, keep original name
+                name = from_name
             to_name = await super().increment_filename(name, to_path, insert="-Copy")
         to_path = f"{to_path}/{to_name}"
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -672,7 +672,11 @@ class ContentsManager(LoggingConfigurable):
         if not is_destination_specified:
             to_path = from_dir
         if self.dir_exists(to_path):
-            name = copy_pat.sub(".", from_name)
+            if to_path.strip("/") == from_dir:
+                name = copy_pat.sub(".", from_name)
+            else:
+                # Different directory copy, keep original name
+                name = from_name
             to_name = self.increment_filename(name, to_path, insert="-Copy")
             to_path = f"{to_path}/{to_name}"
         elif is_destination_specified:
@@ -1048,7 +1052,11 @@ class AsyncContentsManager(ContentsManager):
         if not is_destination_specified:
             to_path = from_dir
         if await ensure_async(self.dir_exists(to_path)):
-            name = copy_pat.sub(".", from_name)
+            if to_path.strip("/") == from_dir:
+                name = copy_pat.sub(".", from_name)
+            else:
+                # Different directory, keep original name
+                name = from_name
             to_name = await self.increment_filename(name, to_path, insert="-Copy")
             to_path = f"{to_path}/{to_name}"
         elif is_destination_specified:


### PR DESCRIPTION
This adds a condition to keep the original file/directory name when copying to a new directory. 
- Issue where file containing "-Copy" into a new directory was being stripped (reported in https://github.com/jupyterlab/jupyterlab/issues/12236)
   - Also addresses related issue which happens when you copy a file "test" and another file "test-Copy" (which was previously stripped to just "test") and this resulted in mismatched file contents (reported in https://github.com/jupyterlab/jupyterlab/issues/12237)
