### PR TITLE
Add query param to sanitize HTML in GET /nbconvert/html

### DIFF
--- a/jupyter_server/nbconvert/handlers.py
+++ b/jupyter_server/nbconvert/handlers.py
@@ -95,9 +95,19 @@ class NbconvertFileHandler(JupyterHandler):
     @web.authenticated
     @authorized
     async def get(self, format, path):
-        """Get a notebook file in a desired format."""
+        """Get a notebook file in a desired format.
+
+        download: bool, optional
+            If true, set Content-Disposition: attachment
+        sanitize_html: bool, optional (html format only)
+            If true, sanitize HTML (sets sanitize_html flag on nbconvert)
+        """
         self.check_xsrf_cookie()
         exporter = get_exporter(format, config=self.config, log=self.log)
+        if format == "html":
+            sanitize = self.get_argument("sanitize_html", None)
+            if sanitize is not None:
+                exporter.sanitize_html = sanitize.lower() == "true"
 
         path = path.strip("/")
         # If the notebook relates to a real file (default contents manager),

--- a/jupyter_server/nbconvert/handlers.py
+++ b/jupyter_server/nbconvert/handlers.py
@@ -97,6 +97,8 @@ class NbconvertFileHandler(JupyterHandler):
     async def get(self, format, path):
         """Get a notebook file in a desired format.
 
+        Parameters
+        ----------
         download: bool, optional
             If true, set Content-Disposition: attachment
         sanitize_html: bool, optional (html format only)

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -35,6 +35,12 @@ def notebook(jp_root_dir):
             execution_count=1,
         )
     )
+    cc1.outputs.append(
+        new_output(
+            output_type="display_data",
+            data={"text/html": '<script>alert("xss")</script>'},
+        )
+    )
     nb.cells.append(cc1)
 
     # Write file to tmp dir.
@@ -131,6 +137,32 @@ async def test_from_post(jp_fetch, notebook):
     assert r.code == 200
     assert "text/x-python" in r.headers["Content-Type"]
     assert "print(2*6)" in r.body.decode()
+
+
+async def test_from_file_sanitize_html(jp_fetch, notebook):
+    # flag explicitly set to true
+    r = await jp_fetch(
+        "nbconvert", "html", "foo", "testnb.ipynb", method="GET",
+        params={"sanitize_html": "true"},
+    )
+    assert r.code == 200
+    assert "<script>" not in r.body.decode()
+    assert "&lt;script&gt;" in r.body.decode()
+
+    # flag explicitly set to false
+    r = await jp_fetch(
+        "nbconvert", "html", "foo", "testnb.ipynb", method="GET",
+        params={"sanitize_html": "false"},
+    )
+    assert r.code == 200
+    assert "<script>" in r.body.decode()
+
+    # flag not set
+    r = await jp_fetch(
+        "nbconvert", "html", "foo", "testnb.ipynb", method="GET",
+    )
+    assert r.code == 200
+    assert "<script>" in r.body.decode()
 
 
 async def test_from_post_zip(jp_fetch, notebook):

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -142,7 +142,11 @@ async def test_from_post(jp_fetch, notebook):
 async def test_from_file_sanitize_html(jp_fetch, notebook):
     # flag explicitly set to true
     r = await jp_fetch(
-        "nbconvert", "html", "foo", "testnb.ipynb", method="GET",
+        "nbconvert",
+        "html",
+        "foo",
+        "testnb.ipynb",
+        method="GET",
         params={"sanitize_html": "true"},
     )
     assert r.code == 200
@@ -151,7 +155,11 @@ async def test_from_file_sanitize_html(jp_fetch, notebook):
 
     # flag explicitly set to false
     r = await jp_fetch(
-        "nbconvert", "html", "foo", "testnb.ipynb", method="GET",
+        "nbconvert",
+        "html",
+        "foo",
+        "testnb.ipynb",
+        method="GET",
         params={"sanitize_html": "false"},
     )
     assert r.code == 200
@@ -159,7 +167,11 @@ async def test_from_file_sanitize_html(jp_fetch, notebook):
 
     # flag not set
     r = await jp_fetch(
-        "nbconvert", "html", "foo", "testnb.ipynb", method="GET",
+        "nbconvert",
+        "html",
+        "foo",
+        "testnb.ipynb",
+        method="GET",
     )
     assert r.code == 200
     assert "<script>" in r.body.decode()

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -38,7 +38,10 @@ def notebook(jp_root_dir):
     cc1.outputs.append(
         new_output(
             output_type="display_data",
-            data={"text/html": '<script>alert("xss")</script>'},
+            data={
+                "text/html": '<script>alert("xss")</script>',
+                "text/plain": "Fallback xss test for Non-html backend",
+            },
         )
     )
     nb.cells.append(cc1)
@@ -107,7 +110,7 @@ async def test_from_file_download(jp_fetch, notebook):
     assert "testnb.py" in content_disposition
 
 
-async def test_from_file_zip(jp_fetch, notebook):
+async def test_from_file_zip_to_latex(jp_fetch, notebook):
     r = await jp_fetch(
         "nbconvert",
         "latex",


### PR DESCRIPTION
New optional `sanitize_html` query param that defaults to false (nbconvert's default).

To be used by jupyterlab, specifically for this pull request: https://github.com/jupyterlab/jupyterlab/pull/18765

### Backwards compatibility

OK because the flag is optional. 
To conditionally display the "sanitize" toggle in jupyterlab, it will rely on jupyter server's version (see https://github.com/jupyterlab/jupyterlab/pull/18765).

<img width="350" height="230" alt="image" src="https://github.com/user-attachments/assets/c4204f82-e779-4eca-b2aa-e4eb00d7e40f" />
