### PR TITLE
Fix three file descriptor leaks in kernel connection lifecycle (#1506)

### DIFF
--- a/jupyter_server/services/kernels/connection/channels.py
+++ b/jupyter_server/services/kernels/connection/channels.py
@@ -426,6 +426,14 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
         if self._open_sessions.get(self.session_key) is self.websocket_handler:
             self._open_sessions.pop(self.session_key)
 
+        # Close any pending kernel_info_channel. If the kernel never replied to
+        # the kernel_info_request (e.g. hung/rogue), _handle_kernel_info_reply
+        # will not have fired to close it. This must run before the
+        # start_buffering early-return below, otherwise the channel leaks.
+        if self.kernel_info_channel is not None and not self.kernel_info_channel.closed():
+            self.kernel_info_channel.close()
+        self.kernel_info_channel = None
+
         if self.kernel_id in self.multi_kernel_manager:
             self.multi_kernel_manager.notify_disconnect(self.kernel_id)
             self.multi_kernel_manager.remove_restart_callback(

--- a/jupyter_server/services/kernels/connection/channels.py
+++ b/jupyter_server/services/kernels/connection/channels.py
@@ -207,11 +207,17 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
         def cleanup(_=None):
             """Common cleanup"""
             loop.remove_timeout(nudge_handle)
-            iopub_channel.stop_on_recv()
+            # Close the transient shell/control sockets we own first, so they
+            # are released even if the shared iopub channel was already torn
+            # down (e.g. by a concurrent websocket disconnect). Previously
+            # iopub.stop_on_recv() raised OSError here and aborted cleanup,
+            # leaking the shell+control FDs on every such race.
             if not shell_channel.closed():
                 shell_channel.close()
             if not control_channel.closed():
                 control_channel.close()
+            if not iopub_channel.closed():
+                iopub_channel.stop_on_recv()
 
         # trigger cleanup when both message futures are resolved
         all_done.add_done_callback(cleanup)

--- a/jupyter_server/services/kernels/connection/channels.py
+++ b/jupyter_server/services/kernels/connection/channels.py
@@ -361,7 +361,11 @@ class ZMQChannelsWebsocketConnection(BaseKernelWebsocketConnection):
             self.log.info("Restoring connection for %s", self.session_key)
             if self.multi_kernel_manager.ports_changed(self.kernel_id):
                 # If the kernel's ports have changed (some restarts trigger this)
-                # then reset the channels so nudge() is using the correct iopub channel
+                # then reset the channels so nudge() is using the correct iopub channel.
+                # Close the stale buffered channels first to avoid leaking FDs.
+                for stream in buffer_info["channels"].values():
+                    if not stream.closed():
+                        stream.close()
                 self.create_stream()
             else:
                 # The kernel's ports have not changed; use the channels captured in the buffer

--- a/tests/services/kernels/test_connection.py
+++ b/tests/services/kernels/test_connection.py
@@ -2,9 +2,11 @@ import asyncio
 import json
 from unittest.mock import MagicMock
 
+import pytest
 from jupyter_client.jsonutil import json_clean, json_default
 from jupyter_client.session import Session
 from tornado.httpserver import HTTPRequest
+from zmq.eventloop.zmqstream import ZMQStream
 
 from jupyter_server.serverapp import ServerApp
 from jupyter_server.services.kernels.connection.channels import ZMQChannelsWebsocketConnection
@@ -43,3 +45,68 @@ async def test_websocket_connection(jp_serverapp: ServerApp) -> None:
     conn.on_kernel_restarted()
     conn.on_restart_failed()
     conn._on_error("shell", msg, session.serialize(msg))
+
+
+def _make_connection(app, kernel, session_id=None, timeout=0.01):
+    """Build a ZMQChannelsWebsocketConnection with a mocked handler."""
+    request = HTTPRequest("foo", "GET")
+    request.connection = MagicMock()
+    handler = KernelWebsocketHandler(app.web_app, request)
+    handler.ws_connection = MagicMock()
+    handler.ws_connection.is_closing = lambda: False
+    conn = ZMQChannelsWebsocketConnection(parent=kernel, websocket_handler=handler)
+    handler.connection = conn
+    if session_id:
+        conn.session.session = session_id
+    conn.kernel_info_timeout = timeout
+    return conn
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_nudge_cleanup_closes_transient_channels_when_iopub_closed(
+    jp_serverapp: ServerApp,
+) -> None:
+    """If iopub is closed before nudge's cleanup callback fires (websocket
+    teardown race), cleanup must still close the transient shell/control
+    sockets it owns. Previously iopub.stop_on_recv() raised OSError inside
+    the done-callback and aborted cleanup, leaving shell+control open."""
+    app = jp_serverapp
+    km = app.kernel_manager
+    kernel_id = await km.start_kernel()
+    kernel = km.get_kernel(kernel_id)
+    await asyncio.sleep(1)
+
+    conn = _make_connection(app, kernel)
+    await conn.prepare()
+    conn.create_stream()
+    conn.kernel_info_timeout = 0.1
+
+    # Track transient ZMQStreams created by nudge() from this point forward.
+    created: list = []
+    orig_init = ZMQStream.__init__
+
+    def tracking_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        created.append(self)
+
+    ZMQStream.__init__ = tracking_init  # type: ignore[method-assign]
+    try:
+        # nudge() synchronously registers on_recv callbacks on iopub, then
+        # returns. Close iopub immediately after so that when the cleanup
+        # done-callback eventually fires, iopub is already closed and
+        # iopub.stop_on_recv() hits the OSError path.
+        f = conn.nudge()
+        conn.channels["iopub"].close()
+        try:
+            await asyncio.wait_for(asyncio.wrap_future(f), timeout=2.0)
+        except Exception:
+            pass
+        await asyncio.sleep(0.2)
+    finally:
+        ZMQStream.__init__ = orig_init  # type: ignore[method-assign]
+
+    still_open = [s for s in created if not s.closed()]
+    assert not still_open, (
+        f"nudge leaked {len(still_open)} transient ZMQStream(s) when iopub "
+        f"was closed before cleanup fired"
+    )

--- a/tests/services/kernels/test_connection.py
+++ b/tests/services/kernels/test_connection.py
@@ -1,6 +1,9 @@
 import asyncio
+import gc
 import json
-from unittest.mock import MagicMock
+import os
+import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 from jupyter_client.jsonutil import json_clean, json_default
@@ -109,4 +112,66 @@ async def test_nudge_cleanup_closes_transient_channels_when_iopub_closed(
     assert not still_open, (
         f"nudge leaked {len(still_open)} transient ZMQStream(s) when iopub "
         f"was closed before cleanup fired"
+    )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Requires /proc/self/fd")
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_no_fd_leak_on_buffer_restore_with_port_change(jp_serverapp: ServerApp) -> None:
+    """Verify that stale buffered channels are closed when ports change on reconnect."""
+    app = jp_serverapp
+    km = app.kernel_manager
+    kernel_id = await km.start_kernel()
+    kernel = km.get_kernel(kernel_id)
+    await asyncio.sleep(1)
+
+    session_id = "fixed-session-for-test"
+
+    # Warm up
+    conn = _make_connection(app, kernel, session_id=session_id)
+    conn.create_stream()
+    try:
+        await conn.nudge()
+    except Exception:
+        pass
+    for s in conn.channels.values():
+        if not s.closed():
+            s.close()
+    gc.collect()
+    await asyncio.sleep(1)
+
+    baseline_fds = len(os.listdir(f"/proc/{os.getpid()}/fd"))
+
+    for _ in range(100):
+        conn1 = _make_connection(app, kernel, session_id=session_id)
+        conn1.create_stream()
+        try:
+            await conn1.nudge()
+        except Exception:
+            pass
+        km._kernel_connections.setdefault(kernel_id, 0)
+        km._kernel_connections[kernel_id] = 0
+        km.start_buffering(kernel_id, conn1.session_key, conn1.channels)
+
+        conn2 = _make_connection(app, kernel, session_id=session_id)
+        km._kernel_connections[kernel_id] = 1
+        with patch.object(km, "ports_changed", return_value=True):
+            connected = conn2.connect()
+        if connected:
+            try:
+                await connected
+            except Exception:
+                pass
+        for s in conn2.channels.values():
+            if not s.closed():
+                s.close()
+        conn2.channels = {}
+
+    gc.collect()
+    await asyncio.sleep(2)
+    gc.collect()
+    final_fds = len(os.listdir(f"/proc/{os.getpid()}/fd"))
+    assert final_fds - baseline_fds <= 5, (
+        f"FD leak detected: {final_fds - baseline_fds} FDs leaked "
+        f"after 100 buffer-restore-with-port-change cycles"
     )

--- a/tests/services/kernels/test_connection.py
+++ b/tests/services/kernels/test_connection.py
@@ -175,3 +175,50 @@ async def test_no_fd_leak_on_buffer_restore_with_port_change(jp_serverapp: Serve
         f"FD leak detected: {final_fds - baseline_fds} FDs leaked "
         f"after 100 buffer-restore-with-port-change cycles"
     )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Requires /proc/self/fd")
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_no_fd_leak_on_disconnect_with_orphaned_kernel_info_channel(
+    jp_serverapp: ServerApp,
+) -> None:
+    """When a kernel does not reply to kernel_info_request (e.g. rogue/hung),
+    kernel_info_channel is left open after nudge. It must be closed on
+    disconnect, including the single-tab last-connection path that triggers
+    start_buffering."""
+    app = jp_serverapp
+    km = app.kernel_manager
+    kernel_id = await km.start_kernel()
+    kernel = km.get_kernel(kernel_id)
+    await asyncio.sleep(1)
+
+    # Warm up
+    conn = _make_connection(app, kernel)
+    conn.create_stream()
+    conn.kernel_info_channel = km.connect_shell(kernel_id)
+    ZMQChannelsWebsocketConnection._open_sockets.add(conn)
+    km._kernel_connections[kernel_id] = 1
+    conn.disconnect()
+    gc.collect()
+    await asyncio.sleep(1)
+
+    baseline_fds = len(os.listdir(f"/proc/{os.getpid()}/fd"))
+
+    for _ in range(100):
+        conn = _make_connection(app, kernel)
+        conn.create_stream()
+        # Simulate rogue kernel: kernel_info_channel opened but reply never arrives
+        conn.kernel_info_channel = km.connect_shell(kernel_id)
+        ZMQChannelsWebsocketConnection._open_sockets.add(conn)
+        # Natural single-tab flow: last connection disconnects -> start_buffering
+        km._kernel_connections[kernel_id] = 1
+        conn.disconnect()
+
+    gc.collect()
+    await asyncio.sleep(2)
+    gc.collect()
+    final_fds = len(os.listdir(f"/proc/{os.getpid()}/fd"))
+    assert final_fds - baseline_fds <= 5, (
+        f"FD leak detected: {final_fds - baseline_fds} FDs leaked after 100 "
+        f"disconnects with orphaned kernel_info_channel"
+    )


### PR DESCRIPTION
Fixes #1506.

Three independent FD leaks in `ZMQChannelsWebsocketConnection`:

1. **`nudge()` cleanup race** (`channels.py:207`). The cleanup done-callback called `iopub_channel.stop_on_recv()` before closing the transient shell/control sockets it owns. If iopub was closed by a concurrent websocket disconnect, `stop_on_recv` raised `OSError("Stream is closed")` inside the callback, aborting cleanup and leaking 4 FDs. Triggered by routine tab close or reload during the nudge window; surfaces in server logs as an unraisable `OSError` traceback pointing at `nudge.<locals>.cleanup`.

2. **Stale buffered channels on reconnect with port change** (`channels.py:357`). When a kernel restart changes ZMQ ports, `connect()` replaces `self.channels` via `create_stream()` without closing the previously-buffered set. Those streams stay registered with the Tornado IOLoop and never get reclaimed. 8 FDs per reconnect-after-restart; triggered by kernels that auto-restart under load.

3. **Orphaned `kernel_info_channel` on disconnect** (`channels.py:423`). If the kernel never replies to `kernel_info_request` (hung/rogue), `_handle_kernel_info_reply` never fires to close the channel, and `disconnect()` didn't close it either. Hoisted the close above the `start_buffering` early-return so the common single-tab disconnect path releases it. 2 FDs per disconnect-after-failed-nudge.

## Likely primary root cause

Leak 1 is literally on the `nudge()` code path the reporter narrowed to, is triggered by common UI actions (tab close or reload during connection establishment), and leaves a log signature that matches a "narrow by grep" investigation methodology. Leak 2 is a strong secondary given the higher per-event cost under rogue-kernel workloads that cause frequent restarts. Leak 3 is narrower but real and worth fixing while we're here.

## Tests

One commit per leak. Each fix ships with a regression test that fails on the pre-fix code and passes after. Verified locally: \`pytest tests/services/kernels/\` → 47 passed.

---

Contributed by @tonyx93, opus, hickory, chestnut.