### PR TITLE
fix: use %s placeholders in HTTPError to prevent Tornado from doubling % in gateway URLs

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -807,8 +807,10 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
 
         raise web.HTTPError(
             e.code,
-            f"Error from Gateway: [{error_message}] {error_reason}. "
+            "Error from Gateway: [%s] %s. "
             "Ensure gateway url is valid and the Gateway instance is running.",
+            error_message,
+            error_reason,
         ) from e
     except ConnectionError as e:
         gateway_client.emit(
@@ -816,8 +818,9 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
         )
         raise web.HTTPError(
             503,
-            f"ConnectionError was received from Gateway server url '{gateway_client.url}'.  "
+            "ConnectionError was received from Gateway server url '%s'.  "
             "Check to be sure the Gateway instance is running.",
+            gateway_client.url,
         ) from e
     except gaierror as e:
         gateway_client.emit(
@@ -825,8 +828,9 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
         )
         raise web.HTTPError(
             404,
-            f"The Gateway server specified in the gateway_url '{gateway_client.url}' doesn't "
-            f"appear to be valid.  Ensure gateway url is valid and the Gateway instance is running.",
+            "The Gateway server specified in the gateway_url '%s' doesn't "
+            "appear to be valid.  Ensure gateway url is valid and the Gateway instance is running.",
+            gateway_client.url,
         ) from e
     except Exception as e:
         gateway_client.emit(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -782,6 +782,26 @@ async def test_websocket_connection_with_session_id(init_gateway, jp_serverapp, 
                 pytest.fail(f"Logs contain an error: {message}")
 
 
+def test_gateway_httperror_percent_not_doubled():
+    """Verify that % characters in gateway URLs are not doubled in error messages.
+
+    Tornado's HTTPError escapes '%' in log_message when called without trailing
+    args (replacing '%' with '%%'). By using '%s' placeholders with separate
+    args, gateway error messages preserve URLs that contain percent-encoded
+    characters such as 'http://host/?q=a%3Db'. Regression test for #1503.
+    """
+    url = "http://gateway-host/api?redirect=http%3A%2F%2Fexample.com"
+
+    # Without args: Tornado doubles '%' in log_message.
+    error_no_args = HTTPError(503, f"Gateway url '{url}' is unreachable.")
+    assert "%%" in error_no_args.log_message  # Tornado's escaping in effect
+
+    # With '%s' placeholder + args: log_message is kept as-is, URL goes to args.
+    error_with_args = HTTPError(503, "Gateway url '%s' is unreachable.", url)
+    assert "%%" not in error_with_args.log_message
+    assert url in error_with_args.args
+
+
 #
 # Test methods below...
 #


### PR DESCRIPTION
## Problem

Closes #1503.

When the Gateway server is unreachable or returns an error, send_request_to_gateway() raises web.HTTPError passing the error message as an f-string. Tornado's HTTPError.__init__ escapes % → %% in log_message **when no positional args are provided**. This caused URLs containing percent-encoded characters (e.g. http://host/?redirect=http%3A%2F%2Fexample.com) to appear with doubled percent signs in error responses and logs.

From Tornado's source:
\\\python
if log_message and not args:
    self.log_message = log_message.replace('%', '%%')
\\\

## Fix

Replace the three f-string log_message arguments in send_request_to_gateway() with %s format strings and pass URLs / messages as positional rgs. When rgs is non-empty Tornado skips the escaping, so percent-encoded characters in gateway URLs are preserved correctly.

## Changes

- **\jupyter_server/gateway/gateway_client.py\**: changed all three \web.HTTPError\ raises in \send_request_to_gateway()\ to use \%s\ placeholders + positional args.
- **\	ests/test_gateway.py\**: added \	est_gateway_httperror_percent_not_doubled()\ which directly verifies that the old f-string approach doubles \%\ in \log_message\ and the new placeholder+args approach does not.

## Test

\\\
29 passed in 5.10s
\\\
