### PR TITLE
Start to test on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14", "3.14.t"]
+        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
           - os: ubuntu-latest
             python-version: "pypy-3.9"
@@ -37,8 +37,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install texlive-plain-generic inkscape texlive-xetex
           sudo apt-get install xvfb x11-utils libxkbcommon-x11-0
-          # pandoc is not up to date in the ubuntu repos, so we install directly
-          wget https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-1-amd64.deb && sudo dpkg -i pandoc-3.1.2-1-amd64.deb
       - name: Run the tests on posix
         if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
         run: hatch run cov:test --cov-fail-under 75 || hatch -v run test:test --lf

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,8 +20,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         include:
-          - os: ubuntu-latest
-            python-version: "pypy-3.9"
           - os: macos-latest
             python-version: "3.10"
           - os: ubuntu-latest
@@ -38,11 +36,8 @@ jobs:
           sudo apt-get install texlive-plain-generic inkscape texlive-xetex
           sudo apt-get install xvfb x11-utils libxkbcommon-x11-0
       - name: Run the tests on posix
-        if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
+        if: ${{!startsWith(matrix.os, 'windows') }}
         run: hatch run cov:test --cov-fail-under 75 || hatch -v run test:test --lf
-      - name: Run the tests on pypy
-        if: ${{ startsWith(matrix.python-version, 'pypy') }}
-        run: hatch run test:nowarn || hatch -v run test:nowarn --lf
       - name: Run the tests on windows
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: hatch run cov:nowarn -s || hatch -v run cov:nowarn --lf
@@ -206,16 +201,6 @@ jobs:
         run: hatch -v run cov:integration
       - uses: jupyterlab/maintainer-tools/.github/actions/upload-coverage@v1
 
-  integration_check_pypy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-        with:
-          python_version: "pypy-3.9"
-      - name: Run the tests
-        run: hatch -v run test:nowarn --integration_tests=true
-
   coverage:
     runs-on: ubuntu-latest
     needs:
@@ -226,23 +211,3 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/report-coverage@v1
         with:
           fail_under: 80
-
-  tests_check: # This job does nothing and is only used for the branch protection
-    if: always()
-    needs:
-      - coverage
-      - integration_check_pypy
-      - test_docs
-      - test_lint
-      - test_examples
-      - test_minimum_versions
-      - test_prereleases
-      - check_links
-      - check_release
-      - test_sdist
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,10 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14", "3.14.t"]
         include:
-          - os: windows-latest
-            python-version: "3.9"
           - os: ubuntu-latest
             python-version: "pypy-3.9"
           - os: macos-latest

--- a/tests/base/test_websocket.py
+++ b/tests/base/test_websocket.py
@@ -1,6 +1,7 @@
 """Test Base Websocket classes"""
 
 import logging
+import sysconfig
 import time
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +17,8 @@ from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.base.websocket import WebSocketMixin
 from jupyter_server.serverapp import ServerApp
 from jupyter_server.utils import JupyterServerAuthWarning, url_path_join
+
+is_freethreaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 
 class MockHandler(WebSocketMixin, WebSocketHandler):
@@ -165,6 +168,7 @@ class PermissivePlainWebsocketHandler(MockHandler):
         return super().get(*args, **kwargs)
 
 
+@pytest.mark.xfail(is_freethreaded, reason="warnings are finicky on free-threaded python")
 @pytest.mark.parametrize(
     "jp_server_config",
     [


### PR DESCRIPTION
Remove duplicate windows + 3.9

I think it would be good to drop 3.9, 3.10 soon (after next release).

Drop Pypy3.9 (too old)

Remove all_check, this is now a native option of github if we want.
it just adds extra noise to CI results

Marking tests that rely on warning and free-threading as xfail as
capturing warnings on this platform is notoriously finicky