### PR TITLE
Fix potential unraisable pytest error

### DIFF
--- a/tests/services/kernels/test_connection.py
+++ b/tests/services/kernels/test_connection.py
@@ -23,7 +23,7 @@ async def test_websocket_connection(jp_serverapp: ServerApp) -> None:
     conn = ZMQChannelsWebsocketConnection(parent=kernel, websocket_handler=handler)
     handler.connection = conn
     await conn.prepare()
-    conn.connect()
+    await conn.connect()
     await asyncio.wrap_future(conn.nudge())
     session: Session = kernel.session
     msg = session.msg("data_pub", content={"a": "b"})


### PR DESCRIPTION
```
pytest.PytestUnraisableExceptionWarning: Exception ignored while closing generator <coroutine object ZMQChannelsWebsocketConnection.nudge.<locals>.finish_nudge at 0x209963dc200>: None
```

ZMQChannelsWebsocketConnection.connect() is a sync method that internally calls nudge() and returns the resulting Task (so cleanup callbacks like replay/subscribe fire when the kernel is actually responsive). The test was calling conn.connect() without awaiting, discarding that Task, and then issuing a second, independent nudge() to wait on instead — leaving the connect()-side callbacks racing against the rest of the test.

Test failure affected #1617 on Python 3.14t, probably a race condition.