### PR TITLE
Fix saving user avatar URL

### DIFF
--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -354,6 +354,7 @@ class IdentityProvider(LoggingConfigurable):
                 "display_name": user.display_name,
                 "initials": user.initials,
                 "color": user.color,
+                "avatar_url": user.avatar_url,
             }
         )
         return cookie
@@ -366,7 +367,7 @@ class IdentityProvider(LoggingConfigurable):
             user["name"],
             user["display_name"],
             user["initials"],
-            None,
+            user["avatar_url"],
             user["color"],
         )
 

--- a/tests/auth/test_identity.py
+++ b/tests/auth/test_identity.py
@@ -178,6 +178,30 @@ def test_password_required(identity_provider_class, password_set, password_requi
         idp.validate_security(app, ssl_options=None)
 
 
+@pytest.mark.parametrize(
+    "user_fields",
+    [
+        {"username": "user"},
+        {"username": "user", "avatar_url": "https://example.com/avatar.png"},
+        {
+            "username": "user",
+            "name": "Real Name",
+            "display_name": "RN",
+            "initials": "RN",
+            "avatar_url": "img/avatar.jpg",
+            "color": "#abc",
+        },
+    ],
+)
+def test_user_cookie_roundtrip(user_fields):
+    """All user fields must survive user_to_cookie -> user_from_cookie."""
+    idp = IdentityProvider()
+    user = User(**user_fields)
+    cookie = idp.user_to_cookie(user)
+    restored = idp.user_from_cookie(cookie)
+    assert restored == user
+
+
 async def test_auth_disabled(request, jp_serverapp, jp_fetch):
     idp = PasswordIdentityProvider(
         parent=jp_serverapp,

--- a/tests/services/api/test_api.py
+++ b/tests/services/api/test_api.py
@@ -227,6 +227,7 @@ async def test_update_user_raise(jp_fetch, identity, password_identity_provider)
                 "name": "Updated Name",
                 "display_name": "Updated Display Name",
                 "color": "#000000",
+                "avatar_url": "some/url",
             },
         )
     ],
@@ -236,11 +237,12 @@ async def test_update_user_success_custom_updatable_fields(
 ):
     """Test successful user update."""
     password_identity_provider.mock_user = MockUser(**identity)
-    identity_provider.updatable_fields = ["name", "display_name", "color"]
+    password_identity_provider.updatable_fields = ["name", "display_name", "color", "avatar_url"]
     payload = {
         "name": expected["name"],
         "display_name": expected["display_name"],
         "color": expected["color"],
+        "avatar_url": expected["avatar_url"],
     }
     r = await jp_fetch(
         "/api/me",


### PR DESCRIPTION
This PR adds the user `avatar_url` in the user cookie data.

Related to https://github.com/jupyterlab/jupyter-collaboration/pull/582#issuecomment-4378277421