### PR TITLE
Return `unresolved` stanza when kernel scope is unavailable for `resolvePath` (instead of failing with 404)

### DIFF
--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -389,11 +389,9 @@ paths:
       summary: Resolve path to a file
       responses:
         200:
-          description: Resolved path with scope details
+          description: Resolved path with scope details and optional unresolved scopes
           schema:
             $ref: "#/definitions/ResolvedPath"
-        410:
-          description: Kernel scope unavailable for path resolution
   /api/sessions/{session}:
     parameters:
       - $ref: "#/parameters/session"
@@ -1016,3 +1014,18 @@ definitions:
             path:
               type: string
               description: fully specified path for file
+      unresolved:
+        type: array
+        description: scopes for which path resolution could not be completed
+        items:
+          type: object
+          required:
+            - scope
+            - reason
+          properties:
+            scope:
+              type: string
+              description: the scope that failed to resolve
+            reason:
+              type: string
+              description: human-readable reason for the unresolved scope

--- a/jupyter_server/services/api/api.yaml
+++ b/jupyter_server/services/api/api.yaml
@@ -379,7 +379,7 @@ paths:
         in: query
         description: file path
         type: string
-      - name: kernel_id
+      - name: kernel
         required: false
         in: query
         description: kernel uuid
@@ -392,6 +392,8 @@ paths:
           description: Resolved path with scope details
           schema:
             $ref: "#/definitions/ResolvedPath"
+        410:
+          description: Kernel scope unavailable for path resolution
   /api/sessions/{session}:
     parameters:
       - $ref: "#/parameters/session"

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -153,19 +153,25 @@ class PathResolverHandler(APIHandler):
         path = self.get_query_argument("path")
         kernel_uuid = self.get_query_argument("kernel", default=None)
         scopes: dict[str, Any] = {"server": self.contents_manager}
+        unresolved: list[dict[str, str]] = []
         if kernel_uuid:
             try:
                 scopes["kernel"] = self.kernel_manager.get_kernel(kernel_uuid)
             except web.HTTPError as e:
                 if e.status_code == 404:
-                    raise web.HTTPError(410, "Kernel scope unavailable for path resolution") from e
-                raise
+                    unresolved.append(
+                        {"scope": "kernel", "reason": f"Kernel {kernel_uuid} could not be found"}
+                    )
+                else:
+                    raise
         resolved = [
             {"scope": name, "path": await ensure_async(scope.resolve_path(path))}
             for name, scope in scopes.items()
             if hasattr(scope, "resolve_path")
         ]
         response = {"resolved": [entry for entry in resolved if entry["path"] is not None]}
+        if unresolved:
+            response["unresolved"] = unresolved
         self.finish(json.dumps(response))
 
 

--- a/jupyter_server/services/api/handlers.py
+++ b/jupyter_server/services/api/handlers.py
@@ -154,7 +154,12 @@ class PathResolverHandler(APIHandler):
         kernel_uuid = self.get_query_argument("kernel", default=None)
         scopes: dict[str, Any] = {"server": self.contents_manager}
         if kernel_uuid:
-            scopes["kernel"] = self.kernel_manager.get_kernel(kernel_uuid)
+            try:
+                scopes["kernel"] = self.kernel_manager.get_kernel(kernel_uuid)
+            except web.HTTPError as e:
+                if e.status_code == 404:
+                    raise web.HTTPError(410, "Kernel scope unavailable for path resolution") from e
+                raise
         resolved = [
             {"scope": name, "path": await ensure_async(scope.resolve_path(path))}
             for name, scope in scopes.items()

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -345,16 +345,20 @@ async def test_resolve_path_missing(jp_fetch, jp_serverapp, jp_root_dir, pending
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_resolve_path_missing_kernel_returns_gone(jp_fetch, jp_serverapp):
+async def test_resolve_path_missing_kernel_reports_unresolved(jp_fetch, jp_serverapp):
     bad_id = "111-111-111-111-111"
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        await jp_fetch(
-            "api",
-            "resolvePath",
-            params={"kernel": bad_id, "path": "hello.py"},
-            method="GET",
-        )
-    assert expected_http_error(e, 410, "Kernel scope unavailable for path resolution")
+    r = await jp_fetch(
+        "api",
+        "resolvePath",
+        params={"kernel": bad_id, "path": "hello.py"},
+        method="GET",
+    )
+    assert r.code == 200
+    resolution = json.loads(r.body.decode())
+    assert resolution["resolved"] == []
+    assert resolution["unresolved"] == [
+        {"scope": "kernel", "reason": f"Kernel {bad_id} could not be found"}
+    ]
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -345,6 +345,19 @@ async def test_resolve_path_missing(jp_fetch, jp_serverapp, jp_root_dir, pending
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
+async def test_resolve_path_missing_kernel_returns_gone(jp_fetch, jp_serverapp):
+    bad_id = "111-111-111-111-111"
+    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+        await jp_fetch(
+            "api",
+            "resolvePath",
+            params={"kernel": bad_id, "path": "hello.py"},
+            method="GET",
+        )
+    assert expected_http_error(e, 410, "Kernel scope unavailable for path resolution")
+
+
+@pytest.mark.timeout(TEST_TIMEOUT)
 async def test_kernel_handler(jp_fetch, jp_serverapp, pending_kernel_is_ready):
     # Create a kernel
     r = await jp_fetch(


### PR DESCRIPTION
This change updates `/api/resolvePath` to return HTTP `410` when a provided kernel scope cannot be resolved, so clients can distinguish `stale/invalid` kernel scope from endpoint-level 404 behavior.

Refs: https://github.com/jupyterlab/jupyterlab/pull/18876#discussion_r3229545119