### PR TITLE
fix: use percent-placeholder args in HTTPError to prevent Tornado from doubling percent signs in gateway URLs

### DIFF
--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -807,8 +807,10 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
 
         raise web.HTTPError(
             e.code,
-            f"Error from Gateway: [{error_message}] {error_reason}. "
+            "Error from Gateway: [%s] %s. "
             "Ensure gateway url is valid and the Gateway instance is running.",
+            error_message,
+            error_reason,
         ) from e
     except ConnectionError as e:
         gateway_client.emit(
@@ -816,8 +818,9 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
         )
         raise web.HTTPError(
             503,
-            f"ConnectionError was received from Gateway server url '{gateway_client.url}'.  "
+            "ConnectionError was received from Gateway server url '%s'.  "
             "Check to be sure the Gateway instance is running.",
+            gateway_client.url,
         ) from e
     except gaierror as e:
         gateway_client.emit(
@@ -825,8 +828,9 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
         )
         raise web.HTTPError(
             404,
-            f"The Gateway server specified in the gateway_url '{gateway_client.url}' doesn't "
-            f"appear to be valid.  Ensure gateway url is valid and the Gateway instance is running.",
+            "The Gateway server specified in the gateway_url '%s' doesn't "
+            "appear to be valid.  Ensure gateway url is valid and the Gateway instance is running.",
+            gateway_client.url,
         ) from e
     except Exception as e:
         gateway_client.emit(

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -782,6 +782,26 @@ async def test_websocket_connection_with_session_id(init_gateway, jp_serverapp, 
                 pytest.fail(f"Logs contain an error: {message}")
 
 
+def test_gateway_httperror_percent_not_doubled():
+    """Verify that % characters in gateway URLs are not doubled in error messages.
+
+    Tornado's HTTPError escapes '%' in log_message when called without trailing
+    args (replacing '%' with '%%'). By using '%s' placeholders with separate
+    args, gateway error messages preserve URLs that contain percent-encoded
+    characters such as 'http://host/?q=a%3Db'. Regression test for #1503.
+    """
+    url = "http://gateway-host/api?redirect=http%3A%2F%2Fexample.com"
+
+    # Without args: Tornado doubles '%' in log_message.
+    error_no_args = HTTPError(503, f"Gateway url '{url}' is unreachable.")
+    assert "%%" in error_no_args.log_message  # Tornado's escaping in effect
+
+    # With '%s' placeholder + args: log_message is kept as-is, URL goes to args.
+    error_with_args = HTTPError(503, "Gateway url '%s' is unreachable.", url)
+    assert "%%" not in error_with_args.log_message
+    assert url in error_with_args.args
+
+
 #
 # Test methods below...
 #


### PR DESCRIPTION
## Problem

Tornado's `web.HTTPError` escapes `%` as `%%` in the `log_message` string when no positional args are provided. This is by design — Tornado passes `log_message % args` through Python's `%`-formatting, so any literal `%` in the message must be doubled to survive.

The three `HTTPError` raises in `send_request_to_gateway()` used f-strings as `log_message` with no args. When the gateway URL contains percent-encoded characters like `http%3A%2F%2F`, Tornado's escaping doubled every `%`:

```
"ConnectionError was received from Gateway server url 'http%%3A%%2F%%2Fexample.com'."
```

Closes #1503.

## Fix

Replace f-string `log_message` arguments with `%s` placeholder strings and pass the URL/message values through the `args` parameter. Tornado only escapes `log_message` when `args` is empty, so URL percent characters are preserved correctly:

```python
# Before
raise web.HTTPError(503, f"...url '{gateway_client.url}'.")

# After
raise web.HTTPError(503, "...url '%s'.", gateway_client.url)
```

Applied to all three `HTTPError` raises in `gateway_request()`.

## Test

Added `test_gateway_httperror_percent_not_doubled()` that:

1. Creates an `HTTPError` the old way (f-string, no args) and asserts Tornado **does** double `%` — proves the old code was buggy.
2. Creates an `HTTPError` the new way (`%s` placeholder + args) and asserts `%%` is **not** present in `log_message` and the URL is intact in `args`.
