### PR TITLE
Fix confusing terminal output when using ServerApp.ip=0.0.0.0

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2341,22 +2341,27 @@ class ServerApp(JupyterApp):
             resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
 
     def _get_urlparts(
-        self, path: str | None = None, include_token: bool = False
+        self,
+        path: str | None = None,
+        include_token: bool = False,
+        ip: str | None = None,
     ) -> urllib.parse.ParseResult:
         """Constructs a urllib named tuple, ParseResult,
         with default values set by server config.
         The returned tuple can be manipulated using the `_replace` method.
         """
+        if ip is None:
+            ip = self.ip
         if self.sock:
             scheme = "http+unix"
             netloc = urlencode_unix_socket_path(self.sock)
         else:
             # Empty string means "unset", fallback to localhost so the url
             # is valid e.g. in k8s where gethostname() != localhost #743
-            if not self.ip:
+            if not ip:
                 ip = "localhost"
             else:
-                ip = f"[{self.ip}]" if ":" in self.ip else self.ip
+                ip = f"[{ip}]" if ":" in ip else ip
             netloc = f"{ip}:{self.port}"
             scheme = "https" if self.certfile else "http"
         if not path:
@@ -2410,6 +2415,23 @@ class ServerApp(JupyterApp):
     def connection_url(self) -> str:
         urlparts = self._get_urlparts(path=self.base_url)
         return urlparts.geturl()
+
+    @property
+    def connect_url(self) -> str:
+        """Human readable string with URLs for connecting to the running
+        Jupyter Server.
+
+        If `ip` is the wildcard address, add a text hint but keep
+        the machine hostname in the link as 0.0.0.0 is not connectable.
+        """
+        if self.ip not in ("0.0.0.0", "::"):  # noqa: S104
+            return self.display_url
+        public = self._get_urlparts(include_token=True, ip=socket.gethostname()).geturl()
+        hint = _i18n(
+            "The server is listening on all interfaces, "
+            "so any hostname or IP of this machine will work."
+        )
+        return f"{public}\n    {self.local_url}\n{hint}"
 
     def init_signal(self) -> None:
         """Initialize signal handlers."""
@@ -3137,7 +3159,7 @@ class ServerApp(JupyterApp):
                     message = [
                         "\n",
                         _i18n("To access the server, copy and paste one of these URLs:"),
-                        "    %s" % self.display_url,
+                        "    %s" % self.connect_url,
                     ]
                 else:
                     message = [
@@ -3149,7 +3171,7 @@ class ServerApp(JupyterApp):
                         _i18n(
                             "Or copy and paste one of these URLs:",
                         ),
-                        "    %s" % self.display_url,
+                        "    %s" % self.connect_url,
                     ]
 
                 self.log.critical("\n".join(message))

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2351,11 +2351,10 @@ class ServerApp(JupyterApp):
             scheme = "http+unix"
             netloc = urlencode_unix_socket_path(self.sock)
         else:
+            # Empty string means "unset", fallback to localhost so the url
+            # is valid e.g. in k8s where gethostname() != localhost #743
             if not self.ip:
                 ip = "localhost"
-            # Handle nonexplicit hostname.
-            elif self.ip in ("0.0.0.0", "::"):  # noqa: S104
-                ip = "%s" % socket.gethostname()
             else:
                 ip = f"[{self.ip}]" if ":" in self.ip else self.ip
             netloc = f"{ip}:{self.port}"

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -317,10 +317,25 @@ def test_resolve_file_to_run_and_root_dir(prefix_path, root_dir, file_to_run, ex
             "http+unix://%2Ftmp%2Fjp-test.sock/",
         ),
         (
+            # https://github.com/jupyter-server/jupyter_server/issues/743
             {"ip": ""},
             "http://localhost:8888/?token=<generated>",
             "http://127.0.0.1:8888/?token=<generated>",
             "http://localhost:8888/",
+        ),
+        (
+            # https://github.com/jupyterlab/jupyterlab/issues/15520
+            {"ip": "0.0.0.0"},
+            "http://0.0.0.0:8888/?token=<generated>",
+            "http://127.0.0.1:8888/?token=<generated>",
+            "http://0.0.0.0:8888/",
+        ),
+        (
+            # https://github.com/jupyterlab/jupyterlab/issues/15520
+            {"ip": "::"},
+            "http://[::]:8888/?token=<generated>",
+            "http://[::1]:8888/?token=<generated>",
+            "http://[::]:8888/",
         ),
     ],
 )

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -358,6 +358,61 @@ def test_urls(config, public_url, local_url, connection_url):
     ServerApp.clear_instance()
 
 
+@pytest.mark.parametrize(
+    "config,connect_url",
+    [
+        # Non-wildcard addresses: mirrors display_url.
+        (
+            {"ip": ""},
+            "http://localhost:8888/?token=<generated>\n    http://127.0.0.1:8888/?token=<generated>",
+        ),
+        (
+            {"ip": "127.0.0.1"},
+            "http://127.0.0.1:8888/?token=<generated>",
+        ),
+        # Sockets: mirrors display_url.
+        (
+            {"sock": "/tmp/jp-test.sock"},
+            "http+unix://%2Ftmp%2Fjp-test.sock/?token=<generated>",
+        ),
+        # Wildcard addresses are not connectable: use the machine's
+        # hostname instead, with a trailing note that any address works.
+        (
+            {"ip": "0.0.0.0"},
+            "http://myhost:8888/?token=<generated>\n"
+            "    http://127.0.0.1:8888/?token=<generated>\n"
+            "The server is listening on all interfaces, "
+            "so any hostname or IP of this machine will work.",
+        ),
+        # Wildcard but ipv6
+        (
+            {"ip": "::"},
+            "http://myhost:8888/?token=<generated>\n"
+            "    http://[::1]:8888/?token=<generated>\n"
+            "The server is listening on all interfaces, "
+            "so any hostname or IP of this machine will work.",
+        ),
+    ],
+)
+def test_connect_url(config, connect_url):
+    # Verify we're working with a clean instance.
+    ServerApp.clear_instance()
+    serverapp = ServerApp.instance(**config)
+    serverapp.init_configurables()
+    token = serverapp.identity_provider.token
+    if serverapp.identity_provider.token_generated:
+        connect_url = connect_url.replace("<generated>", token)
+
+    with patch("socket.gethostname", return_value="myhost"):
+        assert serverapp.connect_url == connect_url
+
+    # The wildcard address is never advertised as connectable.
+    assert "0.0.0.0" not in serverapp.connect_url
+    assert "[::]" not in serverapp.connect_url
+    # Cleanup singleton after test.
+    ServerApp.clear_instance()
+
+
 # Preferred dir tests
 # ----------------------------------------------------------------------------
 @pytest.mark.filterwarnings("ignore::FutureWarning")


### PR DESCRIPTION
Pointed out in https://github.com/jupyterlab/jupyterlab/issues/15520,

When using `--ip=::` or `0.0.0.0`, terminal displays:

```
    Or copy and paste one of these URLs:
        http://xxx.local:8888/lab?token=xxx
        http://127.0.0.1:8888/lab?token=xxx
```

Which makes it look like it does not listen on all interfaces, but in fact it does.

After this fix:

```
    Or copy and paste one of these URLs:
        http://0.0.0.0:8888/?token=xxx
        http://127.0.0.1:8888/?token=xxx
```

Fixed with https://github.com/jupyter-server/jupyter_server/issues/743 in mind to avoid a regression in k8s.

### Steps to test

`jupyter server --ip 0.0.0.0`

And check for no regressions on `jupyter server --ip ""`, `jupyter server --ip 127.0.0.1`, `jupyter server --ip <arbitrary ip>`

These are unit-tested too.

### AI disclosure

Claude code, only to dig up the history of previous changes to avoid a regression.