### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,10 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.9"
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
             python-version: "3.10"
@@ -196,7 +193,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install the latest release locally, make sure you have
 pip install jupyter_server
 ```
 
-Jupyter Server currently supports Python>=3.9 on Linux, OSX and Windows.
+Jupyter Server currently supports Python>=3.10 on Linux, OSX and Windows.
 
 ### Versioning and Branches
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -10,7 +10,7 @@ You need `python3` to build and run the server extensions.
 # Clone, create a conda env and install from source.
 git clone https://github.com/jupyter/jupyter_server && \
   cd jupyter_server/examples/simple && \
-  conda create -y -n jupyter-server-example python=3.9 && \
+  conda create -y -n jupyter-server-example python=3.10 && \
   conda activate jupyter-server-example && \
   pip install -e .[test]
 ```

--- a/examples/simple/pyproject.toml
+++ b/examples/simple/pyproject.toml
@@ -7,7 +7,7 @@ name = "jupyter-server-example"
 description = "Jupyter Server Example"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "jinja2",
     "jupyter_server",

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -3,8 +3,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import asyncio
+from collections.abc import Callable
 from functools import wraps
-from typing import Any, Callable, Optional, TypeVar, Union, cast
+from typing import Any, TypeVar, cast
 
 from jupyter_core.utils import ensure_async
 from tornado.log import app_log
@@ -16,9 +17,9 @@ FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 
 
 def authorized(
-    action: Optional[Union[str, FuncT]] = None,
-    resource: Optional[str] = None,
-    message: Optional[str] = None,
+    action: str | FuncT | None = None,
+    resource: str | None = None,
+    message: str | None = None,
 ) -> FuncT:
     """A decorator for tornado.web.RequestHandler methods
     that verifies whether the current user is authorized

--- a/jupyter_server/auth/identity.py
+++ b/jupyter_server/auth/identity.py
@@ -235,7 +235,7 @@ class IdentityProvider(LoggingConfigurable):
             raise TraitError(msg)
         return proposal["value"]
 
-    need_token: bool | Bool[bool, t.Union[bool, int]] = Bool(True)
+    need_token: bool | Bool[bool, bool | int] = Bool(True)
 
     def get_user(self, handler: web.RequestHandler) -> User | None | t.Awaitable[User | None]:
         """Get the authenticated user for a request

--- a/jupyter_server/base/websocket.py
+++ b/jupyter_server/base/websocket.py
@@ -1,7 +1,7 @@
 """Base websocket classes."""
 
 import warnings
-from typing import Optional, no_type_check
+from typing import no_type_check
 from urllib.parse import urlparse
 
 from tornado import ioloop, web
@@ -20,7 +20,7 @@ class WebSocketMixin:
     ping_callback = None
     last_ping = 0.0
     last_pong = 0.0
-    stream: Optional[IOStream] = None
+    stream: IOStream | None = None
 
     @property
     def ping_interval(self):
@@ -41,7 +41,7 @@ class WebSocketMixin:
         )
 
     @no_type_check
-    def check_origin(self, origin: Optional[str] = None) -> bool:
+    def check_origin(self, origin: str | None = None) -> bool:
         """Check Origin == Host or Access-Control-Allow-Origin.
 
         Tornado >= 4 calls this method automatically, raising 403 if it returns False.

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -60,7 +60,7 @@ class GatewayTokenRenewerBase(  # type:ignore[metaclass]
     def get_token(
         self,
         auth_header_key: str,
-        auth_scheme: ty.Union[str, None],
+        auth_scheme: str | None,
         auth_token: str,
         **kwargs: ty.Any,
     ) -> str:
@@ -78,7 +78,7 @@ class NoOpTokenRenewer(GatewayTokenRenewerBase):
     def get_token(
         self,
         auth_header_key: str,
-        auth_scheme: ty.Union[str, None],
+        auth_scheme: str | None,
         auth_token: str,
         **kwargs: ty.Any,
     ) -> str:

--- a/jupyter_server/gateway/handlers.py
+++ b/jupyter_server/gateway/handlers.py
@@ -10,7 +10,7 @@ import mimetypes
 import os
 import random
 import warnings
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from jupyter_client.session import Session
 from tornado import web
@@ -290,7 +290,7 @@ class GatewayResourceHandler(APIHandler):
     @web.authenticated
     async def get(self, kernel_name, path, include_body=True):
         """Get a gateway resource by name and path."""
-        mimetype: Optional[str] = None
+        mimetype: str | None = None
         ksm = self.kernel_spec_manager
         kernel_spec_res = await ksm.get_kernel_spec_resource(  # type:ignore[attr-defined]
             kernel_name, path

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -11,7 +11,7 @@ import os
 from queue import Empty, Queue
 from threading import Thread
 from time import monotonic
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import websocket
 from jupyter_client.asynchronous.client import AsyncKernelClient
@@ -361,7 +361,7 @@ class GatewaySessionManager(SessionManager):
 
     async def kernel_culled(self, kernel_id: str) -> bool:  # typing: ignore
         """Checks if the kernel is still considered alive and returns true if it's not found."""
-        km: Optional[GatewayKernelManager] = None
+        km: GatewayKernelManager | None = None
         try:
             # Since we keep the models up-to-date via client polling, use that state to determine
             # if this kernel no longer exists on the gateway server rather than perform a redundant
@@ -380,7 +380,7 @@ class GatewaySessionManager(SessionManager):
 class GatewayKernelManager(ServerKernelManager):
     """Manages a single kernel remotely via a Gateway Server."""
 
-    kernel_id: Optional[str] = None
+    kernel_id: str | None = None
     kernel = None
 
     @default("cache_ports")
@@ -596,7 +596,7 @@ KernelManagerABC.register(GatewayKernelManager)
 class ChannelQueue(Queue):  # type:ignore[type-arg]
     """A queue for a named channel."""
 
-    channel_name: Optional[str] = None
+    channel_name: str | None = None
     response_router_finished: bool
 
     def __init__(self, channel_name: str, channel_socket: websocket.WebSocket, log: Logger):
@@ -713,19 +713,19 @@ class GatewayKernelClient(AsyncKernelClient):
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin = False
     _channels_stopped: bool
-    _channel_queues: Optional[dict[str, ChannelQueue]]
-    _control_channel: Optional[ChannelQueue]
-    _hb_channel: Optional[ChannelQueue]
-    _stdin_channel: Optional[ChannelQueue]
-    _iopub_channel: Optional[ChannelQueue]
-    _shell_channel: Optional[ChannelQueue]
+    _channel_queues: dict[str, ChannelQueue] | None
+    _control_channel: ChannelQueue | None
+    _hb_channel: ChannelQueue | None
+    _stdin_channel: ChannelQueue | None
+    _iopub_channel: ChannelQueue | None
+    _shell_channel: ChannelQueue | None
 
     def __init__(self, kernel_id, **kwargs):
         """Initialize a gateway kernel client."""
         super().__init__(**kwargs)
         self.kernel_id = kernel_id
-        self.channel_socket: Optional[websocket.WebSocket] = None
-        self.response_router: Optional[Thread] = None
+        self.channel_socket: websocket.WebSocket | None = None
+        self.response_router: Thread | None = None
         self._channels_stopped = False
         self._channel_queues = {}
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -558,9 +558,7 @@ class ServerWebApplication(web.Application):
         sources.extend(self.settings["last_activity_times"].values())
         return max(sources)
 
-    def _check_handler_auth(
-        self, matcher: t.Union[str, Matcher], handler: type[web.RequestHandler]
-    ):
+    def _check_handler_auth(self, matcher: str | Matcher, handler: type[web.RequestHandler]):
         missing_authentication = []
         for method_name in handler.SUPPORTED_METHODS:
             method = getattr(handler, method_name.lower())
@@ -1216,7 +1214,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("min_open_files_limit")
-    def _default_min_open_files_limit(self) -> t.Optional[int]:
+    def _default_min_open_files_limit(self) -> int | None:
         if resource is None:
             # Ignoring min_open_files_limit because the limit cannot be adjusted (for example, on Windows)
             return None  # type:ignore[unreachable]
@@ -1276,7 +1274,7 @@ class ServerApp(JupyterApp):
     )
 
     def _warn_deprecated_config(
-        self, change: t.Any, clsname: str, new_name: t.Optional[str] = None
+        self, change: t.Any, clsname: str, new_name: str | None = None
     ) -> None:
         """Warn on deprecated config."""
         if new_name is None:
@@ -1620,7 +1618,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("kernel_manager_class")
-    def _default_kernel_manager_class(self) -> t.Union[str, type[AsyncMappingKernelManager]]:
+    def _default_kernel_manager_class(self) -> str | type[AsyncMappingKernelManager]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.managers.GatewayMappingKernelManager"
         return AsyncMappingKernelManager
@@ -1631,7 +1629,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("session_manager_class")
-    def _default_session_manager_class(self) -> t.Union[str, type[SessionManager]]:
+    def _default_session_manager_class(self) -> str | type[SessionManager]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.managers.GatewaySessionManager"
         return SessionManager
@@ -1645,7 +1643,7 @@ class ServerApp(JupyterApp):
     @default("kernel_websocket_connection_class")
     def _default_kernel_websocket_connection_class(
         self,
-    ) -> t.Union[str, type[ZMQChannelsWebsocketConnection]]:
+    ) -> str | type[ZMQChannelsWebsocketConnection]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.connections.GatewayWebSocketConnection"
         return ZMQChannelsWebsocketConnection
@@ -1696,7 +1694,7 @@ class ServerApp(JupyterApp):
     )
 
     @default("kernel_spec_manager_class")
-    def _default_kernel_spec_manager_class(self) -> t.Union[str, type[KernelSpecManager]]:
+    def _default_kernel_spec_manager_class(self) -> str | type[KernelSpecManager]:
         if self.gateway_config.gateway_enabled:
             return "jupyter_server.gateway.managers.GatewayKernelSpecManager"
         return KernelSpecManager
@@ -2049,7 +2047,7 @@ class ServerApp(JupyterApp):
         """Get the Extension that started this server."""
         return self._starter_app
 
-    def parse_command_line(self, argv: t.Optional[list[str]] = None) -> None:
+    def parse_command_line(self, argv: list[str] | None = None) -> None:
         """Parse the command line options."""
         super().parse_command_line(argv)
 
@@ -2343,7 +2341,7 @@ class ServerApp(JupyterApp):
             resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
 
     def _get_urlparts(
-        self, path: t.Optional[str] = None, include_token: bool = False
+        self, path: str | None = None, include_token: bool = False
     ) -> urllib.parse.ParseResult:
         """Constructs a urllib named tuple, ParseResult,
         with default values set by server config.
@@ -2782,7 +2780,7 @@ class ServerApp(JupyterApp):
     @catch_config_error
     def initialize(
         self,
-        argv: t.Optional[list[str]] = None,
+        argv: list[str] | None = None,
         find_extensions: bool = True,
         new_httpserver: bool = True,
         starter_extension: t.Any = None,
@@ -3028,7 +3026,7 @@ class ServerApp(JupyterApp):
             if e.errno != errno.ENOENT:
                 raise
 
-    def _prepare_browser_open(self) -> tuple[str, t.Optional[str]]:
+    def _prepare_browser_open(self) -> tuple[str, str | None]:
         """Prepare to open the browser."""
         if not self.use_redirect_file:
             uri = self.default_url[len(self.base_url) :]
@@ -3245,7 +3243,7 @@ class ServerApp(JupyterApp):
 
 
 def list_running_servers(
-    runtime_dir: t.Optional[str] = None, log: t.Optional[logging.Logger] = None
+    runtime_dir: str | None = None, log: logging.Logger | None = None
 ) -> t.Generator[t.Any, None, None]:
     """Iterate over the server info files of running Jupyter servers.
 

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from jupyter_core.utils import ensure_async
 from tornado import web, websocket
@@ -92,7 +92,7 @@ def validate_model(
         raise Exception(message)
 
 
-def get_timestamp(data: dict[str, Any]) -> Optional[datetime]:
+def get_timestamp(data: dict[str, Any]) -> datetime | None:
     """Parses timestamp from the JSON request body"""
     try:
         if "timestamp" in data:

--- a/jupyter_server/services/kernels/connection/base.py
+++ b/jupyter_server/services/kernels/connection/base.py
@@ -68,7 +68,7 @@ def deserialize_binary_message(bmsg):
     offsets = list(struct.unpack("!" + "I" * nbufs, bmsg[4 : 4 * (nbufs + 1)]))
     offsets.append(None)
     bufs = []
-    for start, stop in zip(offsets[:-1], offsets[1:]):
+    for start, stop in zip(offsets[:-1], offsets[1:], strict=False):
         bufs.append(bmsg[start:stop])
     msg = json.loads(bufs[0].decode("utf8"))
     msg["header"] = extract_dates(msg["header"])

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -5,7 +5,7 @@
 import os
 import pathlib
 import uuid
-from typing import Any, NewType, Optional, Union, cast
+from typing import Any, NewType, cast
 
 KernelName = NewType("KernelName", str)
 ModelName = NewType("ModelName", str)
@@ -41,8 +41,8 @@ class KernelSessionRecord:  # noqa: PLW1641 - TODO: implement __hash__
     associated with them.
     """
 
-    session_id: Optional[str] = None
-    kernel_id: Optional[str] = None
+    session_id: str | None = None
+    kernel_id: str | None = None
 
     def __eq__(self, other: object) -> bool:
         """Whether a record equals another."""
@@ -112,7 +112,7 @@ class KernelSessionRecordList:
         """The string representation of a record list."""
         return str(self._records)
 
-    def __contains__(self, record: Union[KernelSessionRecord, str]) -> bool:
+    def __contains__(self, record: KernelSessionRecord | str) -> bool:
         """Search for records by kernel_id and session_id"""
         if isinstance(record, KernelSessionRecord) and record in self._records:
             return True
@@ -127,7 +127,7 @@ class KernelSessionRecordList:
         """The length of the record list."""
         return len(self._records)
 
-    def get(self, record: Union[KernelSessionRecord, str]) -> KernelSessionRecord:
+    def get(self, record: KernelSessionRecord | str) -> KernelSessionRecord:
         """Return a full KernelSessionRecord from a session_id, kernel_id, or
         incomplete KernelSessionRecord.
         """
@@ -262,11 +262,11 @@ class SessionManager(LoggingConfigurable):
 
     async def create_session(
         self,
-        path: Optional[str] = None,
-        name: Optional[ModelName] = None,
-        type: Optional[str] = None,
-        kernel_name: Optional[KernelName] = None,
-        kernel_id: Optional[str] = None,
+        path: str | None = None,
+        name: ModelName | None = None,
+        type: str | None = None,
+        kernel_name: KernelName | None = None,
+        kernel_id: str | None = None,
     ) -> dict[str, Any]:
         """Creates a session and returns its model
 
@@ -293,9 +293,7 @@ class SessionManager(LoggingConfigurable):
         self._pending_sessions.remove(record)
         return cast("dict[str, Any]", result)
 
-    def get_kernel_env(
-        self, path: Optional[str], name: Optional[ModelName] = None
-    ) -> dict[str, str]:
+    def get_kernel_env(self, path: str | None, name: ModelName | None = None) -> dict[str, str]:
         """Return the environment variables that need to be set in the kernel
 
         Parameters
@@ -315,10 +313,10 @@ class SessionManager(LoggingConfigurable):
     async def start_kernel_for_session(
         self,
         session_id: str,
-        path: Optional[str],
-        name: Optional[ModelName],
-        type: Optional[str],
-        kernel_name: Optional[KernelName],
+        path: str | None,
+        name: ModelName | None,
+        type: str | None,
+        kernel_name: KernelName | None,
     ) -> str:
         """Start a new kernel for a given session.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "anyio>=3.1.0",
     "argon2-cffi>=21.1",
@@ -139,7 +139,7 @@ line-length = 100
 docstring-code-format = true
 
 [tool.ruff.lint]
-ignore = ["ARG", "TRY", "RUF012", "TID252", "G", "INP001", "E402", "F401", "BLE001", "UP045", "PLC0415"]
+ignore = ["ARG", "TRY", "RUF012", "TID252", "G", "INP001", "E402", "F401", "BLE001", "PLC0415"]
 extend-select = [
   "B",  # flake8-bugbear
   "I",  # isort
@@ -157,7 +157,7 @@ unfixable = [
 
 [tool.ruff.lint.extend-per-file-ignores]
 "jupyter_server/*" = ["S101", "RET", "S110", "UP031", "FBT", "FA100", "SLF001", "A002",
-                      "SIM105", "A001", "UP007", "PLR2004", "T201", "N818", "F403"]
+                      "SIM105", "A001", "PLR2004", "T201", "N818", "F403"]
 "jupyter_server/gateway/*" = ["TCH" ]
 "tests/*" = ["UP031", "PT", 'EM', "TRY", "RET", "SLF", "C408", "F841", "FBT", "A002", "FLY", "N",
             "PERF", "ASYNC", "T201", "FA100", "E711", "INP", "TCH", "SIM105", "A001", "PLW0603",
@@ -216,7 +216,7 @@ pydist_resource_paths = ["jupyter_server/static/style/bootstrap.min.css", "jupyt
 post-version-spec = "dev"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 explicit_package_bases = true
 strict = true
 pretty = true

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -4,7 +4,6 @@ import shutil
 import sys
 import time
 from itertools import combinations
-from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -113,7 +112,7 @@ def add_invalid_cell(notebook):
 
 
 async def prepare_notebook(
-    jp_contents_manager: FileContentsManager, make_invalid: Optional[bool] = False
+    jp_contents_manager: FileContentsManager, make_invalid: bool | None = False
 ) -> tuple[dict, str]:
     cm = jp_contents_manager
     model = await ensure_async(cm.new_untitled(type="notebook"))

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -184,10 +184,6 @@ async def test_main_kernel_handler(jp_fetch, jp_base_url, jp_serverapp, pending_
     await pending_kernel_is_ready(kernel3["id"])
 
 
-@pytest.mark.skipif(
-    ipykernel.version_info < (7, 0),
-    reason="requires ipykernel 7, which is not compatible with Python 3.9",
-)
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_resolve_path_kernel(jp_fetch, jp_serverapp, jp_root_dir, pending_kernel_is_ready):
     query_path = "hello.py"
@@ -267,10 +263,6 @@ async def test_resolve_path_server(jp_fetch, jp_serverapp, jp_root_dir):
     assert path["path"] == server_path.name
 
 
-@pytest.mark.skipif(
-    ipykernel.version_info < (7, 0),
-    reason="requires ipykernel 7, which is not compatible with Python 3.9",
-)
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_resolve_path_server_and_kernel(
     jp_fetch, jp_serverapp, jp_root_dir, pending_kernel_is_ready

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from queue import Empty
-from typing import Any, Union
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -222,7 +222,7 @@ class CustomTestTokenRenewer(GatewayTokenRenewerBase):  # type:ignore[misc]
     config_var_2: str = Unicode(config=True)  # type:ignore[assignment]
 
     def get_token(
-        self, auth_header_key: str, auth_scheme: Union[str, None], auth_token: str, **kwargs: Any
+        self, auth_header_key: str, auth_scheme: str | None, auth_token: str, **kwargs: Any
     ) -> str:
         return f"{self.config_var_2}{self.config_var_1}"
 


### PR DESCRIPTION
Python 3.9 reached End of Life over 6 months ago (https://devguide.python.org/versions/) and the CI is now failing across the board for 3.9. I don't think there is value in maintaining it; we kept the support a bit longer to publish one final version with security fixes, but now that `2.18.x` stabilised it's time to drop it.