### PR TITLE
Grab the port from `bind_sockets` in case its different

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2712,9 +2712,9 @@ class ServerApp(JupyterApp):
         for port in random_ports(self.port, self.port_retries + 1):
             try:
                 sockets = bind_sockets(port, self.ip)
-                # This will return the port that's used. Usually the same as `port`
-                # but if `port`=0 bind_sockets assigns a new one so we return it here.
-                port = sockets[0].getsockname()[1]
+                # When port=0 the OS assigns a free port, so we read it back here.
+                if port == 0:
+                    port = sockets[0].getsockname()[1]
                 for s in sockets:
                     s.close()
             except OSError as e:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2712,6 +2712,9 @@ class ServerApp(JupyterApp):
         for port in random_ports(self.port, self.port_retries + 1):
             try:
                 sockets = bind_sockets(port, self.ip)
+                # This will return the port that's used. Usually the same as `port`
+                # but if `port`=0 bind_sockets assigns a new one so we return it here.
+                port = sockets[0].getsockname()[1]
                 for s in sockets:
                     s.close()
             except OSError as e:

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -734,6 +734,14 @@ def test_tornado_authentication_detection(method, expected):
     assert _has_tornado_web_authenticated(method) == expected
 
 
+def test_find_http_port_zero_resolves_real_port(jp_configurable_serverapp):
+    """port=0 should resolve to the real OS-assigned port, not stay 0 (#1650)."""
+    app = jp_configurable_serverapp()
+    app.port = 0
+    app._find_http_port()
+    assert app.port != 0
+
+
 def test_bind_http_server_tcp_success(jp_configurable_serverapp):
     """Normal case: listen succeeds, returns True."""
     app = jp_configurable_serverapp()


### PR DESCRIPTION
This asks a socket for the port that it has bound to, so that if the port changes (ie, when `port=0` and the machine selects a new open port to return), it correctly makes it back into the build logs etc

Locally, I got this before the PR:

```
$ jupyter server --ServerApp.port=0 --no-browser
...
[I 2026-05-29 15:42:18.443 ServerApp] http://localhost:0/
...
```

And this after:

```
$ jupyter server --ServerApp.port=0 --no-browser
...
[I 2026-05-29 15:42:18.443 ServerApp] http://localhost:59976/
...
```
---

- fixes #1650 