### PR TITLE
Exclude problematic `pywinpty` 3.0.4 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,11 @@ dependencies = [
     "nbformat>=5.3.0",
     "packaging>=22.0",
     "prometheus_client>=0.9",
-    "pywinpty>=2.0.1;os_name=='nt'",
+    # pywinpty 3.0.4 ships broken Windows wheels: winpty.dll (amd64) and all native
+    # binaries (arm64) are no longer bundled, so the .pyd fails to load -> import winpty
+    # raises ImportError -> terminado falls back to `object` -> object.spawn AttributeError.
+    # See https://github.com/andfoy/pywinpty/issues/573 (regressed in 3.0.4, 2026-06-10).
+    "pywinpty>=2.0.1,!=3.0.4;os_name=='nt'",
     "pyzmq>=24",
     "Send2Trash>=1.8.2",
     "terminado>=0.8.3",


### PR DESCRIPTION
Fixes #1657. Hopefully it will be yanked on PyPI but for now users won't run into a bad state when installing locally.