### PR TITLE
Add a reminder to merge GHSA before release

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -16,6 +16,10 @@ on:
         description: "Set a placeholder in the changelog and don't publish the release."
         required: false
         type: boolean
+      security_reminder:
+        description: "I have asked a security maintainer to check that no security fixes are waiting to be merged and released in (GHSA)[https://github.com/jupyter-server/jupyter_server/security/advisories?state=draft]"
+        required: false
+        type: boolean
       since:
         description: "Use PRs with activity since this date or git reference"
         required: false

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -16,15 +16,15 @@ on:
         description: "Set a placeholder in the changelog and don't publish the release."
         required: false
         type: boolean
-      security_reminder:
-        description: "I have asked a security maintainer to check that no security fixes are waiting to be merged and released in (GHSA)[https://github.com/jupyter-server/jupyter_server/security/advisories?state=draft]"
-        required: false
-        type: boolean
       since:
         description: "Use PRs with activity since this date or git reference"
         required: false
       since_last_stable:
         description: "Use PRs with activity since the last stable git tag"
+        required: false
+        type: boolean
+      security_reminder:
+        description: "Recommended: check with a security maintainer if a patch is waiting to be merged. https://github.com/jupyter-server/jupyter_server/security/advisories?state=draft"
         required: false
         type: boolean
 jobs:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,8 @@ The recommended way to make a release is to use [`jupyter_releaser`](https://jup
 Note that we must use manual versions since Jupyter Releaser does not
 yet support "next" or "patch" when dev versions are used.
 
+Note about Security Advisories: some patches are developed in private hidden forks that only the [security team](https://github.com/jupyter/security) can access; please check with them that no patch is waiting be be merged before releasing.
+
 ## Manual Release
 
 To create a manual release, perform the following steps:


### PR DESCRIPTION
Sometimes GHSAs are forgotten during releases.

This adds a visual-only reminder

An alternative solution exists: we could say that it is the duty of security maintainers to do security releases so that "regular" releases do not have to bother with this. What do you think

<img width="409" height="735" alt="image" src="https://github.com/user-attachments/assets/12b95fff-a376-4088-ba97-363aa9f76b25" />
