### PR TITLE
Drop Pin preventing testing Python 3.15 pre-releases

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -131,8 +131,7 @@ jobs:
         with:
           dependency_type: pre
           python_package_manager: pip
-          # pyO3 dependencies can't build on dev python
-          python_version: "3.14"
+          python_version: "3.15"
       - name: Run the tests
         run: |
           hatch run test:nowarn || hatch -v run test:nowarn --lf


### PR DESCRIPTION
- Reverts https://github.com/jupyter-server/jupyter_server/pull/1599 since new pyo3 version now supports 3.15 pre-releases.
- Let's see if it will pick up https://github.com/jupyter-server/jupyter_server/issues/1610