### PR TITLE
Fix `test_authorizer` having a spurious comma in params

### DIFF
--- a/tests/auth/test_authorizer.py
+++ b/tests/auth/test_authorizer.py
@@ -246,7 +246,7 @@ class AsyncAuthorizerTest(Authorizer):
 
 
 @pytest.mark.parametrize(
-    "jp_server_config,",
+    "jp_server_config",
     [
         {
             "ServerApp": {"authorizer_class": AsyncAuthorizerTest},


### PR DESCRIPTION
Fixes CI failure seen on `main` and in PRs (#1662 and #1656)