### PR TITLE
Fix zulip notification on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,8 +54,9 @@ jobs:
         run: |
           echo "Failed to Publish the Draft Release Url:"
           echo ${{ steps.populate-release.outputs.release_url }}
+
       - name: Send Zulip notification
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ success() }}
         continue-on-error: true
         uses: zulip/github-actions-zulip/send-message@08b6fbd07f5834e5b930a85bc7740e9fd44ab2e7
         with:
@@ -65,6 +66,6 @@ jobs:
           to: "Releases"
           type: "stream"
           topic: "jupyter_server"
-          content: | # pypi strips the v from the tag name in urls
-            Jupyter Server ${{ github.ref_name }} was just released on PyPI! 🎉
-            https://pypi.org/project/jupyter-server/${{ github.ref_name }}/
+          content: |
+            Jupyter Server was just released! 🎉
+            ${{ steps.finalize-release.outputs.release_url }}


### PR DESCRIPTION
This pipeline is not triggered on a tag (the tag is created during the pipeline) so github.ref does not exist and the step was skipped.

Unfortunately [jupyter_releaser's finalize-release does not expose the tag as output](https://github.com/jupyter-server/jupyter_releaser/blob/58a343c/.github/actions/finalize-release/action.yml#L32) and I did not want to add a step to do a sed here.