### PR TITLE
Use hostname in wildcard browser redirect files

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2998,7 +2998,12 @@ class ServerApp(JupyterApp):
         """Write the browser open file."""
         if self.identity_provider.token:
             url = url_concat(url, {"token": self.identity_provider.token})
-        url = url_path_join(self.connection_url, url)
+        connection_url = self.connection_url
+        if self.ip in ("0.0.0.0", "::"):  # noqa: S104
+            connection_url = self._get_urlparts(
+                path=self.base_url, ip=socket.gethostname()
+            ).geturl()
+        url = url_path_join(connection_url, url)
 
         jinja2_env = self.web_app.settings["jinja2_env"]
         template = jinja2_env.get_template("browser-open.html")

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -207,6 +207,7 @@ JUPYTER_SERVICE_HANDLERS = {
 
 # Added for backwards compatibility from classic notebook server.
 DEFAULT_SERVER_PORT = DEFAULT_JUPYTER_SERVER_PORT
+WILDCARD_IPS = ("0.0.0.0", "::")  # noqa: S104
 
 # -----------------------------------------------------------------------------
 # Helper functions
@@ -2423,7 +2424,9 @@ class ServerApp(JupyterApp):
 
     @property
     def connection_url(self) -> str:
-        urlparts = self._get_urlparts(path=self.base_url)
+        """Return a connectable URL, replacing wildcard addresses with the hostname."""
+        ip = socket.gethostname() if self.ip in WILDCARD_IPS else None
+        urlparts = self._get_urlparts(path=self.base_url, ip=ip)
         return urlparts.geturl()
 
     @property
@@ -2434,7 +2437,7 @@ class ServerApp(JupyterApp):
         If `ip` is the wildcard address, add a text hint but keep
         the machine hostname in the link as 0.0.0.0 is not connectable.
         """
-        if self.ip not in ("0.0.0.0", "::"):  # noqa: S104
+        if self.ip not in WILDCARD_IPS:
             return self.display_url
         public = self._get_urlparts(include_token=True, ip=socket.gethostname()).geturl()
         hint = _i18n(
@@ -2998,12 +3001,7 @@ class ServerApp(JupyterApp):
         """Write the browser open file."""
         if self.identity_provider.token:
             url = url_concat(url, {"token": self.identity_provider.token})
-        connection_url = self.connection_url
-        if self.ip in ("0.0.0.0", "::"):  # noqa: S104
-            connection_url = self._get_urlparts(
-                path=self.base_url, ip=socket.gethostname()
-            ).geturl()
-        url = url_path_join(connection_url, url)
+        url = url_path_join(self.connection_url, url)
 
         jinja2_env = self.web_app.settings["jinja2_env"]
         template = jinja2_env.get_template("browser-open.html")

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -328,14 +328,14 @@ def test_resolve_file_to_run_and_root_dir(prefix_path, root_dir, file_to_run, ex
             {"ip": "0.0.0.0"},
             "http://0.0.0.0:8888/?token=<generated>",
             "http://127.0.0.1:8888/?token=<generated>",
-            "http://0.0.0.0:8888/",
+            "http://myhost:8888/",
         ),
         (
             # https://github.com/jupyterlab/jupyterlab/issues/15520
             {"ip": "::"},
             "http://[::]:8888/?token=<generated>",
             "http://[::1]:8888/?token=<generated>",
-            "http://[::]:8888/",
+            "http://myhost:8888/",
         ),
     ],
 )
@@ -353,7 +353,8 @@ def test_urls(config, public_url, local_url, connection_url):
         connection_url = connection_url.replace("<generated>", token)
     assert serverapp.public_url == public_url
     assert serverapp.local_url == local_url
-    assert serverapp.connection_url == connection_url
+    with patch("socket.gethostname", return_value="myhost"):
+        assert serverapp.connection_url == connection_url
     # Cleanup singleton after test.
     ServerApp.clear_instance()
 

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -687,6 +687,17 @@ async def test_browser_open_files(jp_configurable_serverapp, should_exist, caplo
     assert url_messages if should_exist else not url_messages
 
 
+def test_browser_open_file_uses_hostname_for_wildcard(jp_configurable_serverapp):
+    app = jp_configurable_serverapp(ip="0.0.0.0")
+
+    with patch("socket.gethostname", return_value="myhost"):
+        app.write_browser_open_file()
+
+    browser_open_file = pathlib.Path(app.browser_open_file).read_text(encoding="utf-8")
+    assert "http://myhost:" in browser_open_file
+    assert "http://0.0.0.0:" not in browser_open_file
+
+
 def test_deprecated_notebook_dir_priority(jp_configurable_serverapp, tmp_path):
     notebook_dir = tmp_path / "notebook"
     notebook_dir.mkdir()


### PR DESCRIPTION
## Summary

Fixes #1672.

Use the machine hostname instead of an IPv4 or IPv6 wildcard bind address in generated browser-open redirect files. This keeps `connection_url` as the literal listening address while making the redirect URL connectable.

## Context

The browser-open file continued to use `connection_url` after connectable display URLs were separated from literal bind URLs. For wildcard binds, the redirect therefore pointed at `0.0.0.0` or `[::]` and could not reliably carry the token into a browser session.

The change is limited to browser-open HTML generation and adds a regression test for the reported IPv4 wildcard behavior.

## Testing

- `.venv/bin/python -m pytest tests/test_serverapp.py -k 'browser_open_file or connect_url' -vv`
- `.venv/bin/python -m pytest tests/test_serverapp.py -q`
- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest -q`
- `.venv/bin/pre-commit run --files jupyter_server/serverapp.py tests/test_serverapp.py`
- `.venv/bin/pre-commit run --hook-stage manual mypy --files jupyter_server/serverapp.py`

The default full suite passed with its configured platform, integration, service, and missing-pandoc skips.

Note: I used Codex while preparing this change, reviewed the final diff, and ran the checks listed above locally.