### PR TITLE
Fix HTTP port selection race

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2627,6 +2627,8 @@ class ServerApp(JupyterApp):
             pc = ioloop.PeriodicCallback(self.shutdown_no_activity, 60000)
             pc.start()
 
+    _http_server_sockets: list[socket.socket] | None = None
+
     @property
     def http_server(self) -> httpserver.HTTPServer:
         """An instance of Tornado's HTTPServer class for the Server Web Application."""
@@ -2701,9 +2703,17 @@ class ServerApp(JupyterApp):
 
     def _bind_http_server_tcp(self) -> bool:
         """Bind a tcp server."""
+        sockets = self._http_server_sockets
         try:
-            self.http_server.listen(self.port, self.ip)
+            if sockets is None:
+                self.http_server.listen(self.port, self.ip)
+            else:
+                self.http_server.add_sockets(sockets)
         except OSError as e:
+            if sockets is not None:
+                for sock in sockets:
+                    sock.close()
+                self._http_server_sockets = None
             if e.errno == errno.EADDRINUSE:
                 self.log.warning(_i18n("The port %i is already in use.") % self.port)
                 return False
@@ -2713,6 +2723,8 @@ class ServerApp(JupyterApp):
             else:
                 raise
         else:
+            if sockets is not None:
+                self._http_server_sockets = None
             return True
 
     def _find_http_port(self) -> None:
@@ -2725,8 +2737,6 @@ class ServerApp(JupyterApp):
                 # When port=0 the OS assigns a free port, so we read it back here.
                 if port == 0:
                     port = sockets[0].getsockname()[1]
-                for s in sockets:
-                    s.close()
             except OSError as e:
                 if e.errno == errno.EADDRINUSE:
                     if self.port_retries:
@@ -2746,6 +2756,7 @@ class ServerApp(JupyterApp):
             else:
                 success = True
                 self.port = port
+                self._http_server_sockets = sockets
                 break
         if not success:
             if self.port_retries:

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -740,6 +740,34 @@ def test_find_http_port_zero_resolves_real_port(jp_configurable_serverapp):
     app.port = 0
     app._find_http_port()
     assert app.port != 0
+    reserved_sockets = app._http_server_sockets
+    assert reserved_sockets is not None
+    for sock in reserved_sockets:
+        sock.close()
+
+
+def test_find_http_port_reserves_port_until_bind(jp_configurable_serverapp):
+    """Keep the selected port reserved until HTTPServer takes ownership (#1609)."""
+    app = jp_configurable_serverapp()
+    app.ip = "127.0.0.1"
+    app.port = 0
+    app._find_http_port()
+    reserved_sockets = app._http_server_sockets
+    assert reserved_sockets is not None
+    assert reserved_sockets
+    assert all(sock.fileno() != -1 for sock in reserved_sockets)
+
+    mock_server = MagicMock()
+    try:
+        with patch.object(
+            type(app), "http_server", new_callable=lambda: property(lambda self: mock_server)
+        ):
+            assert app._bind_http_server_tcp() is True
+        mock_server.add_sockets.assert_called_once_with(reserved_sockets)
+        assert app._http_server_sockets is None
+    finally:
+        for sock in reserved_sockets:
+            sock.close()
 
 
 def test_bind_http_server_tcp_success(jp_configurable_serverapp):


### PR DESCRIPTION
Fixes #1609.

`_find_http_port()` closed the sockets used to select a port before `_bind_http_server()` ran on the event loop, leaving a window where another process could claim it. Keep those sockets open and hand them to Tornado's `add_sockets()` during the existing callback instead.

The regression test verifies the reservation and handoff; the full suite passes (1,153 passed, 30 skipped).
