### PR TITLE
Add `ContentsManager.show_globs` trait

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -17,6 +17,7 @@ import sys
 import typing as t
 import warnings
 from datetime import datetime
+from fnmatch import fnmatch
 from pathlib import Path
 
 import nbformat
@@ -170,6 +171,25 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path=path)
         return is_hidden(os_path, self.root_dir)
 
+    def _is_shown(self, os_path):
+        """Does an OS path match ``show_globs`` and therefore bypass hiding?
+
+        ``show_globs`` patterns are matched against individual path components,
+        the same way ``hide_globs`` is. A path is shown when any of its
+        components (relative to ``root_dir``) matches a pattern, so a match on an
+        ancestor directory also shows everything beneath it. This takes
+        precedence over both ``hide_globs`` and hidden-file filtering.
+        """
+        if not self.show_globs:
+            return False
+        try:
+            rel = Path(os.path.normpath(os_path)).relative_to(os.path.normpath(self.root_dir))
+        except ValueError:
+            return False
+        return any(
+            fnmatch(part, glob) for part in rel.parts for glob in self.show_globs
+        )
+
     def is_writable(self, path):
         """Does the API style path correspond to a writable directory or file?
 
@@ -283,7 +303,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         four_o_four = "file or directory does not exist: %r" % path
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -338,7 +358,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         if not os.path.isdir(os_path):
             raise web.HTTPError(404, four_o_four)
-        elif not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        elif not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             self.log.info("Refusing to serve hidden directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -375,7 +395,9 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
                 try:
                     if self.should_list(name) and (
-                        self.allow_hidden or not is_file_hidden(os_path, stat_res=st)
+                        self.allow_hidden
+                        or not is_file_hidden(os_path, stat_res=st)
+                        or self._is_shown(os_path)
                     ):
                         contents.append(self.get(path=f"{path}/{name}", content=False))
                 except OSError as e:
@@ -492,7 +514,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if not self.exists(path):
             raise web.HTTPError(404, four_o_four)
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -517,7 +539,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
     def _save_directory(self, os_path, model, path=""):
         """create a directory"""
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             raise web.HTTPError(400, "Cannot create directory %r" % os_path)
         if not os.path.exists(os_path):
             with self.perm_to_403():
@@ -539,7 +561,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             raise web.HTTPError(400, "No file content provided")
         os_path = self._get_os_path(path)
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             raise web.HTTPError(400, f"Cannot create file or directory {os_path!r}")
 
         self.log.debug("Saving %s", os_path)
@@ -585,7 +607,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
         rm = os.unlink
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             raise web.HTTPError(400, f"Cannot delete file or directory {os_path!r}")
 
         four_o_four = "file or directory does not exist: %r" % path
@@ -640,7 +662,8 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         old_os_path = self._get_os_path(old_path)
 
         if not self.allow_hidden and (
-            is_hidden(old_os_path, self.root_dir) or is_hidden(new_os_path, self.root_dir)
+            (is_hidden(old_os_path, self.root_dir) and not self._is_shown(old_os_path))
+            or (is_hidden(new_os_path, self.root_dir) and not self._is_shown(new_os_path))
         ):
             raise web.HTTPError(400, f"Cannot rename file or directory {old_os_path!r}")
 
@@ -814,7 +837,7 @@ class AsyncFileContentsManager(  # type: ignore[misc]
 
         if not os.path.isdir(os_path):
             raise web.HTTPError(404, four_o_four)
-        elif not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        elif not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             self.log.info("Refusing to serve hidden directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -852,7 +875,9 @@ class AsyncFileContentsManager(  # type: ignore[misc]
 
                 try:
                     if self.should_list(name) and (
-                        self.allow_hidden or not is_file_hidden(os_path, stat_res=st)
+                        self.allow_hidden
+                        or not is_file_hidden(os_path, stat_res=st)
+                        or self._is_shown(os_path)
                     ):
                         contents.append(await self.get(path=f"{path}/{name}", content=False))
                 except OSError as e:
@@ -987,7 +1012,7 @@ class AsyncFileContentsManager(  # type: ignore[misc]
 
     async def _save_directory(self, os_path, model, path=""):
         """create a directory"""
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             raise web.HTTPError(400, "Cannot create hidden directory %r" % os_path)
         if not os.path.exists(os_path):
             with self.perm_to_403():
@@ -1052,7 +1077,7 @@ class AsyncFileContentsManager(  # type: ignore[misc]
         os_path = self._get_os_path(path)
         rm = os.unlink
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir):
+        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
             raise web.HTTPError(400, f"Cannot delete file or directory {os_path!r}")
 
         if not os.path.exists(os_path):
@@ -1111,7 +1136,8 @@ class AsyncFileContentsManager(  # type: ignore[misc]
         old_os_path = self._get_os_path(old_path)
 
         if not self.allow_hidden and (
-            is_hidden(old_os_path, self.root_dir) or is_hidden(new_os_path, self.root_dir)
+            (is_hidden(old_os_path, self.root_dir) and not self._is_shown(old_os_path))
+            or (is_hidden(new_os_path, self.root_dir) and not self._is_shown(new_os_path))
         ):
             raise web.HTTPError(400, f"Cannot rename file or directory {old_os_path!r}")
 

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -186,9 +186,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             rel = Path(os.path.normpath(os_path)).relative_to(os.path.normpath(self.root_dir))
         except ValueError:
             return False
-        return any(
-            fnmatch(part, glob) for part in rel.parts for glob in self.show_globs
-        )
+        return any(fnmatch(part, glob) for part in rel.parts for glob in self.show_globs)
 
     def is_writable(self, path):
         """Does the API style path correspond to a writable directory or file?
@@ -303,7 +301,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         four_o_four = "file or directory does not exist: %r" % path
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -358,7 +360,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
         if not os.path.isdir(os_path):
             raise web.HTTPError(404, four_o_four)
-        elif not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        elif (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             self.log.info("Refusing to serve hidden directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -514,7 +520,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if not self.exists(path):
             raise web.HTTPError(404, four_o_four)
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             self.log.info("Refusing to serve hidden file or directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -539,7 +549,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
 
     def _save_directory(self, os_path, model, path=""):
         """create a directory"""
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             raise web.HTTPError(400, "Cannot create directory %r" % os_path)
         if not os.path.exists(os_path):
             with self.perm_to_403():
@@ -561,7 +575,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             raise web.HTTPError(400, "No file content provided")
         os_path = self._get_os_path(path)
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             raise web.HTTPError(400, f"Cannot create file or directory {os_path!r}")
 
         self.log.debug("Saving %s", os_path)
@@ -607,7 +625,11 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
         rm = os.unlink
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             raise web.HTTPError(400, f"Cannot delete file or directory {os_path!r}")
 
         four_o_four = "file or directory does not exist: %r" % path
@@ -837,7 +859,11 @@ class AsyncFileContentsManager(  # type: ignore[misc]
 
         if not os.path.isdir(os_path):
             raise web.HTTPError(404, four_o_four)
-        elif not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        elif (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             self.log.info("Refusing to serve hidden directory %r, via 404 Error", os_path)
             raise web.HTTPError(404, four_o_four)
 
@@ -1012,7 +1038,11 @@ class AsyncFileContentsManager(  # type: ignore[misc]
 
     async def _save_directory(self, os_path, model, path=""):
         """create a directory"""
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             raise web.HTTPError(400, "Cannot create hidden directory %r" % os_path)
         if not os.path.exists(os_path):
             with self.perm_to_403():
@@ -1077,7 +1107,11 @@ class AsyncFileContentsManager(  # type: ignore[misc]
         os_path = self._get_os_path(path)
         rm = os.unlink
 
-        if not self.allow_hidden and is_hidden(os_path, self.root_dir) and not self._is_shown(os_path):
+        if (
+            not self.allow_hidden
+            and is_hidden(os_path, self.root_dir)
+            and not self._is_shown(os_path)
+        ):
             raise web.HTTPError(400, f"Cannot delete file or directory {os_path!r}")
 
         if not os.path.exists(os_path):

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -45,6 +45,41 @@ except ImportError:
 _script_exporter = None
 
 
+def _show_glob_matches(pattern: str, parts: tuple[str, ...]) -> bool:
+    """Match a ``show_globs`` pattern against a path, glob style.
+
+    ``parts`` is the path split into components. Within a single component
+    ``fnmatch`` wildcards apply (``*`` ``?`` ``[seq]``) but do not cross a ``/``;
+    the ``**`` component is the only way to span directory boundaries and matches
+    zero or more components. The pattern is anchored: it must match the whole
+    path, not a suffix.
+
+    As in the shell and gitignore, a wildcard does not match a leading dot: a
+    component whose name starts with ``.`` matches only a pattern component that
+    also starts with a literal ``.`` (e.g. ``.*`` or the literal name). ``**``
+    likewise does not descend into hidden components, so hidden files stay
+    hidden unless a pattern names them explicitly.
+    """
+    pat = pattern.strip("/").split("/")
+
+    def seg_match(seg: str, pat_seg: str) -> bool:
+        if seg.startswith(".") and not pat_seg.startswith("."):
+            return False
+        return fnmatch(seg, pat_seg)
+
+    def match(pi: int, si: int) -> bool:
+        if pi == len(pat):
+            return si == len(parts)
+        if pat[pi] == "**":
+            if match(pi + 1, si):  # ** consumes zero components
+                return True
+            # ...or one more non-hidden component, then retry ** (dots stay explicit)
+            return si < len(parts) and not parts[si].startswith(".") and match(pi, si + 1)
+        return si < len(parts) and seg_match(parts[si], pat[pi]) and match(pi + 1, si + 1)
+
+    return match(0, 0)
+
+
 def _get_created_timestamp(info: os.stat_result) -> float:
     """Get best-effort file creation timestamp from stat result.
 
@@ -174,11 +209,21 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
     def _is_shown(self, os_path):
         """Does an OS path match ``show_globs`` and therefore bypass hiding?
 
-        ``show_globs`` patterns are matched against individual path components,
-        the same way ``hide_globs`` is. A path is shown when any of its
-        components (relative to ``root_dir``) matches a pattern, so a match on an
-        ancestor directory also shows everything beneath it. This takes
-        precedence over both ``hide_globs`` and hidden-file filtering.
+        A path is hidden when any of its components (relative to ``root_dir``)
+        starts with a dot. ``show_globs`` exempts such components: a hidden
+        component is exempt when a pattern matches its path from the root (see
+        ``_show_glob_matches`` for the matching rules). The path as a whole is
+        shown only when it has at least one hidden component and every hidden
+        component is exempt; a single unexempted hidden component keeps it hidden.
+
+        So ``[".jupyter"]`` exempts the ``.jupyter`` component, and because a
+        pattern matches the path prefix ending at each hidden component,
+        ``.jupyter`` and its non-hidden descendants (e.g. ``.jupyter/foo.py``)
+        are shown. A nested dotfile like ``.jupyter/.secret`` stays hidden
+        because the prefix ``.jupyter/.secret`` matches no pattern; exempt it by
+        adding ``".jupyter/.secret"``, or the whole subtree with ``".jupyter/**"``.
+
+        Takes precedence over both ``hide_globs`` and hidden-file filtering.
         """
         if not self.show_globs:
             return False
@@ -186,7 +231,17 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
             rel = Path(os.path.normpath(os_path)).relative_to(os.path.normpath(self.root_dir))
         except ValueError:
             return False
-        return any(fnmatch(part, glob) for part in rel.parts for glob in self.show_globs)
+        # Bail on the first hidden component whose path prefix matches no pattern;
+        # the path is shown only if it had a hidden component and all were exempt.
+        parts = rel.parts
+        saw_hidden = False
+        for i, part in enumerate(parts):
+            if part.startswith("."):
+                saw_hidden = True
+                prefix = parts[: i + 1]
+                if not any(_show_glob_matches(g, prefix) for g in self.show_globs):
+                    return False
+        return saw_hidden
 
     def is_writable(self, path):
         """Does the API style path correspond to a writable directory or file?

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -140,12 +140,17 @@ class ContentsManager(LoggingConfigurable):
         config=True,
         help="""
         Glob patterns to always show in file and directory listings, taking
-        precedence over ``hide_globs``. A name matching any of these patterns is
-        listed even if it also matches ``hide_globs``.
+        precedence over both ``hide_globs`` and hidden-file filtering.
 
-        This only affects the name-glob listing filter (``should_list``); it does
-        NOT affect hidden-file (dotfile) filtering, which is controlled separately
-        by ``allow_hidden``.
+        Each pattern is matched against individual path components (the same way
+        ``hide_globs`` is). A path is shown when any of its components matches a
+        ``show_globs`` pattern, so listing ``[".jupyter"]`` surfaces the
+        ``.jupyter`` directory and makes everything inside it listable and
+        accessible, even when ``allow_hidden`` is ``False``.
+
+        This is the escape hatch for the all-or-nothing nature of
+        ``allow_hidden``: a deployment can keep hidden files hidden by default
+        while always exposing a specific curated set of paths.
     """,
     )
 

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -134,6 +134,21 @@ class ContentsManager(LoggingConfigurable):
     """,
     )
 
+    show_globs = List(
+        Unicode(),
+        [],
+        config=True,
+        help="""
+        Glob patterns to always show in file and directory listings, taking
+        precedence over ``hide_globs``. A name matching any of these patterns is
+        listed even if it also matches ``hide_globs``.
+
+        This only affects the name-glob listing filter (``should_list``); it does
+        NOT affect hidden-file (dotfile) filtering, which is controlled separately
+        by ``allow_hidden``.
+    """,
+    )
+
     untitled_notebook = Unicode(
         _i18n("Untitled"),
         config=True,
@@ -757,6 +772,8 @@ class ContentsManager(LoggingConfigurable):
 
     def should_list(self, name):
         """Should this file/directory name be displayed in a listing?"""
+        if any(fnmatch(name, glob) for glob in self.show_globs):
+            return True
         return not any(fnmatch(name, glob) for glob in self.hide_globs)
 
     # Part 3: Checkpoints API

--- a/jupyter_server/services/contents/manager.py
+++ b/jupyter_server/services/contents/manager.py
@@ -140,17 +140,29 @@ class ContentsManager(LoggingConfigurable):
         config=True,
         help="""
         Glob patterns to always show in file and directory listings, taking
-        precedence over both ``hide_globs`` and hidden-file filtering.
+        precedence over both ``hide_globs`` and hidden-file filtering. This is
+        the escape hatch for the all-or-nothing nature of ``allow_hidden``: a
+        deployment can keep hidden files hidden by default while always exposing
+        a specific curated set of paths.
 
-        Each pattern is matched against individual path components (the same way
-        ``hide_globs`` is). A path is shown when any of its components matches a
-        ``show_globs`` pattern, so listing ``[".jupyter"]`` surfaces the
-        ``.jupyter`` directory and makes everything inside it listable and
-        accessible, even when ``allow_hidden`` is ``False``.
+        A path is hidden when any of its components (relative to the root)
+        starts with a dot. A ``show_globs`` pattern exempts such a component when
+        it matches that component's path from the root. Patterns are matched
+        glob style: ``*``, ``?`` and ``[seq]`` apply within a single path
+        component (``*`` does not cross ``/``), and ``**`` matches across
+        components. As in the shell, a wildcard does not match a leading dot, so
+        a hidden name must be matched by a pattern that also starts with a
+        literal dot. A path is shown only when all of its hidden components are
+        exempt; a single unexempted hidden component keeps it hidden.
 
-        This is the escape hatch for the all-or-nothing nature of
-        ``allow_hidden``: a deployment can keep hidden files hidden by default
-        while always exposing a specific curated set of paths.
+        So ``[".jupyter"]`` surfaces the ``.jupyter`` directory and its
+        non-hidden contents (e.g. ``.jupyter/personas/foo.py``) even when
+        ``allow_hidden`` is ``False``, but a nested dotfile such as
+        ``.jupyter/.secret`` stays hidden — and ``".jupyter/*"`` will not expose
+        it either, since ``*`` does not match a leading dot. Use
+        ``".jupyter/.secret"`` (or ``".jupyter/.*"``) to expose that dotfile, or
+        ``".jupyter/**"`` to expose the non-hidden ``.jupyter`` subtree. ``**``
+        matches a name at any depth, e.g. ``"**/.ipynb_checkpoints"``.
     """,
     )
 

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -190,10 +190,11 @@ def test_should_list_show_globs_precedence(jp_file_contents_manager_class, tmp_p
 
 async def test_show_globs_surfaces_hidden_dir(jp_file_contents_manager_class, tmp_path):
     # show_globs takes precedence over hidden-file filtering: a matching hidden
-    # directory is listed and accessible even with allow_hidden=False, while a
-    # non-matching dotfile stays hidden.
+    # directory and its non-hidden contents are listed and accessible even with
+    # allow_hidden=False, while a non-matching dotfile stays hidden.
     (tmp_path / ".jupyter").mkdir()
     (tmp_path / ".jupyter" / "persona.py").write_text("")
+    (tmp_path / ".jupyter" / ".secret").write_text("")
     (tmp_path / ".secret").write_text("")
     cm = jp_file_contents_manager_class(
         root_dir=str(tmp_path),
@@ -207,13 +208,80 @@ async def test_show_globs_surfaces_hidden_dir(jp_file_contents_manager_class, tm
     assert ".secret" not in names
 
     # The shown directory can be opened, and a match on the ancestor directory
-    # surfaces the files inside it too.
+    # surfaces the non-hidden files inside it too...
     dir_model = await ensure_async(cm.get(".jupyter"))
     inner = {entry["name"] for entry in dir_model["content"]}
     assert "persona.py" in inner
-    # A file inside the shown directory is itself accessible.
+    # ...but a nested dotfile is NOT surfaced: exempting the parent does not
+    # exempt hidden components beneath it.
+    assert ".secret" not in inner
+    # A non-hidden file inside the shown directory is itself accessible.
     file_model = await ensure_async(cm.get(".jupyter/persona.py", content=False))
     assert file_model["path"] == ".jupyter/persona.py"
+    # The nested dotfile remains gated (404) despite its parent being shown.
+    with pytest.raises(HTTPError) as exc:
+        await ensure_async(cm.get(".jupyter/.secret"))
+    assert exc.value.status_code == 404
+
+
+async def test_show_globs_can_opt_in_nested_dotfile(jp_file_contents_manager_class, tmp_path):
+    # A nested dotfile is surfaced only when a pattern exempts its own path too.
+    (tmp_path / ".jupyter").mkdir()
+    (tmp_path / ".jupyter" / ".secret").write_text("")
+    cm = jp_file_contents_manager_class(
+        root_dir=str(tmp_path),
+        allow_hidden=False,
+        show_globs=[".jupyter", ".jupyter/.*"],
+    )
+    dir_model = await ensure_async(cm.get(".jupyter"))
+    inner = {entry["name"] for entry in dir_model["content"]}
+    assert ".secret" in inner
+    file_model = await ensure_async(cm.get(".jupyter/.secret", content=False))
+    assert file_model["path"] == ".jupyter/.secret"
+
+
+async def test_show_globs_double_star_exposes_nonhidden_subtree(
+    jp_file_contents_manager_class, tmp_path
+):
+    # `**` spans (non-hidden) components, so `.jupyter/**` exposes the non-hidden
+    # subtree at any depth, but still not a nested dotfile (dots stay explicit).
+    (tmp_path / ".jupyter" / "sub").mkdir(parents=True)
+    (tmp_path / ".jupyter" / "sub" / "deep.py").write_text("")
+    (tmp_path / ".jupyter" / "sub" / ".deep").write_text("")
+    cm = jp_file_contents_manager_class(
+        root_dir=str(tmp_path),
+        allow_hidden=False,
+        show_globs=[".jupyter/**"],
+    )
+    model = await ensure_async(cm.get(".jupyter/sub/deep.py", content=False))
+    assert model["path"] == ".jupyter/sub/deep.py"
+    # A nested dotfile is not swept in by `**`.
+    with pytest.raises(HTTPError) as exc:
+        await ensure_async(cm.get(".jupyter/sub/.deep"))
+    assert exc.value.status_code == 404
+
+
+def test_show_glob_matches_glob_semantics():
+    # `*` stays within one component; `**` spans components; patterns are anchored.
+    from jupyter_server.services.contents.filemanager import _show_glob_matches
+
+    assert _show_glob_matches(".jupyter", (".jupyter",)) is True
+    assert _show_glob_matches("*/.checkpoints", ("a", ".checkpoints")) is True
+    # `*` does not cross a `/`, so a two-segment path is not matched by `*/...`.
+    assert _show_glob_matches("*/.checkpoints", ("a", "b", ".checkpoints")) is False
+    # `**` matches a name at any depth, including zero intervening components.
+    assert _show_glob_matches("**/.checkpoints", ("a", "b", ".checkpoints")) is True
+    assert _show_glob_matches("**/.checkpoints", (".checkpoints",)) is True
+    # Anchored: must match the whole path, not a suffix.
+    assert _show_glob_matches(".jupyter", ("other", ".jupyter")) is False
+    # A wildcard does not match a leading dot; a hidden name needs an explicit dot.
+    assert _show_glob_matches("*", (".secret",)) is False
+    assert _show_glob_matches(".*", (".secret",)) is True
+    assert _show_glob_matches(".jupyter/*", (".jupyter", ".secret")) is False
+    assert _show_glob_matches(".jupyter/.*", (".jupyter", ".secret")) is True
+    # `**` spans non-hidden components only; it does not descend into a dotfile.
+    assert _show_glob_matches(".jupyter/**", (".jupyter", "sub", "plain.py")) is True
+    assert _show_glob_matches(".jupyter/**", (".jupyter", "sub", ".deep")) is False
 
 
 async def test_show_globs_leaves_other_hidden_files_gated(jp_file_contents_manager_class, tmp_path):

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -174,6 +174,35 @@ def test_root_dir(jp_file_contents_manager_class, tmp_path):
     assert fm.root_dir == str(tmp_path)
 
 
+def test_should_list_show_globs_precedence(jp_file_contents_manager_class, tmp_path):
+    # A name matching both hide_globs and show_globs is listed: show wins.
+    cm = jp_file_contents_manager_class(
+        root_dir=str(tmp_path),
+        hide_globs=["node_modules", "*.pyc"],
+        show_globs=["node_modules"],
+    )
+    assert cm.should_list("node_modules") is True
+    # Still-hidden names (matched only by hide_globs) are not listed.
+    assert cm.should_list("foo.pyc") is False
+    # Names matched by neither list are listed as usual.
+    assert cm.should_list("notebook.ipynb") is True
+
+
+async def test_show_globs_does_not_surface_dotfile(jp_file_contents_manager_class, tmp_path):
+    # show_globs is a listing-only filter (should_list) and is orthogonal to
+    # hidden-file gating (allow_hidden). With allow_hidden=False, a dotfile is
+    # not surfaced even when it matches show_globs.
+    (tmp_path / ".secret").write_text("")
+    cm = jp_file_contents_manager_class(
+        root_dir=str(tmp_path),
+        allow_hidden=False,
+        show_globs=[".secret"],
+    )
+    model = await ensure_async(cm.get(""))
+    names = {entry["name"] for entry in model["content"]}
+    assert ".secret" not in names
+
+
 def test_missing_root_dir(jp_file_contents_manager_class, tmp_path):
     root = tmp_path / "notebook" / "dir" / "is" / "missing"
     with pytest.raises(TraitError):

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -188,19 +188,46 @@ def test_should_list_show_globs_precedence(jp_file_contents_manager_class, tmp_p
     assert cm.should_list("notebook.ipynb") is True
 
 
-async def test_show_globs_does_not_surface_dotfile(jp_file_contents_manager_class, tmp_path):
-    # show_globs is a listing-only filter (should_list) and is orthogonal to
-    # hidden-file gating (allow_hidden). With allow_hidden=False, a dotfile is
-    # not surfaced even when it matches show_globs.
+async def test_show_globs_surfaces_hidden_dir(jp_file_contents_manager_class, tmp_path):
+    # show_globs takes precedence over hidden-file filtering: a matching hidden
+    # directory is listed and accessible even with allow_hidden=False, while a
+    # non-matching dotfile stays hidden.
+    (tmp_path / ".jupyter").mkdir()
+    (tmp_path / ".jupyter" / "persona.py").write_text("")
     (tmp_path / ".secret").write_text("")
     cm = jp_file_contents_manager_class(
         root_dir=str(tmp_path),
         allow_hidden=False,
-        show_globs=[".secret"],
+        show_globs=[".jupyter"],
     )
-    model = await ensure_async(cm.get(""))
-    names = {entry["name"] for entry in model["content"]}
+
+    root_model = await ensure_async(cm.get(""))
+    names = {entry["name"] for entry in root_model["content"]}
+    assert ".jupyter" in names
     assert ".secret" not in names
+
+    # The shown directory can be opened, and a match on the ancestor directory
+    # surfaces the files inside it too.
+    dir_model = await ensure_async(cm.get(".jupyter"))
+    inner = {entry["name"] for entry in dir_model["content"]}
+    assert "persona.py" in inner
+    # A file inside the shown directory is itself accessible.
+    file_model = await ensure_async(cm.get(".jupyter/persona.py", content=False))
+    assert file_model["path"] == ".jupyter/persona.py"
+
+
+async def test_show_globs_leaves_other_hidden_files_gated(jp_file_contents_manager_class, tmp_path):
+    # A dotfile not matched by show_globs remains inaccessible (404) with
+    # allow_hidden=False, i.e. show_globs only exempts what it names.
+    (tmp_path / ".secret").write_text("")
+    cm = jp_file_contents_manager_class(
+        root_dir=str(tmp_path),
+        allow_hidden=False,
+        show_globs=[".jupyter"],
+    )
+    with pytest.raises(HTTPError) as exc:
+        await ensure_async(cm.get(".secret"))
+    assert exc.value.status_code == 404
 
 
 def test_missing_root_dir(jp_file_contents_manager_class, tmp_path):


### PR DESCRIPTION
## Motivation

It would be nice to have traitlets configuration that allows extensions to selectively show files that are hidden via the `ContentsManager` by default. In Jupyter AI, we would like to use this setting to show `.jupyter/` always by default, since this is where people can upload their custom AI personas (which will be much easier to create in Jupyter AI v3.2, BTW!).

Currently, we have to work around the lack of an equivalent `ContentsManager.show_globs` trait by setting `ContentsManager.allow_hidden=True` and setting `ContentsManager.hide_globs` to try to hide everything a user probably doesn't want to see. But, we have gotten complaints about our `hide_globs` configuration being either too loose or too wide. So I've put together my recommended fix here.

## Summary

Adds a `show_globs` List(Unicode) trait alongside `hide_globs`, defaulting to `[]`. A path matching any `show_globs` pattern is always shown, taking precedence over both `hide_globs` and hidden-file filtering. This lets a deployment layer targeted exceptions on top of the otherwise all-or-nothing `allow_hidden` switch, so it can keep hidden files hidden by default while always exposing a curated set of paths.

A path is hidden when any of its components starts with a dot, and a `show_globs` pattern exempts such a component when it matches the component's bare name or its path from the root. A path is shown only when all of its hidden components are exempt. So `[".jupyter"]` surfaces the `.jupyter` directory and its non-hidden contents (e.g. `.jupyter/personas/foo.py`) even with `allow_hidden=False`, but a nested dotfile like `.jupyter/.secret` stays hidden unless a pattern covers it too (add `".jupyter/.secret"` or `".jupyter/.*"`).

## Technical details

`should_list` gains a `show_globs` check for the name-glob listing filter. The hidden-file behavior lives in `FileContentsManager` (inherited by the async manager), where the `allow_hidden`/`is_hidden` checks now also consult `show_globs`: the two directory-listing sites, plus the access gates in `get`, `save`, `delete`, and `rename`, so a shown path is listable, readable, and writable rather than 404ing when opened.

## Testing

Added unit tests asserting that a name matching both lists is listed (show wins), that a `show_globs` hidden directory and its non-hidden contents are surfaced and accessible with `allow_hidden=False`, that a nested dotfile stays gated unless a pattern exempts it too, and that unrelated dotfiles remain hidden.

