### PR TITLE
Show connectable URL for password authentication

### DIFF
--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -3152,9 +3152,16 @@ class ServerApp(JupyterApp):
         if self.open_browser and not self.sock:
             self.launch_browser()
 
-        if self.identity_provider.token and self.identity_provider.token_generated:
-            # log full URL with generated token, so there's a copy/pasteable link
-            # with auth info.
+        generated_token = bool(
+            self.identity_provider.token and self.identity_provider.token_generated
+        )
+        non_token_auth_on_wildcard = (
+            not self.identity_provider.token
+            and self.identity_provider.auth_enabled
+            and self.ip in WILDCARD_IPS
+        )
+        if generated_token or non_token_auth_on_wildcard:
+            # Log the generated token or a connectable hostname for non-token authentication.
             if self.sock:
                 self.log.critical(
                     "\n".join(

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -414,6 +414,30 @@ def test_connect_url(config, connect_url):
     ServerApp.clear_instance()
 
 
+def test_password_auth_logs_connect_url_for_wildcard():
+    config = Config()
+    config.PasswordIdentityProvider.hashed_password = "configured-password-hash"
+    app = ServerApp(
+        ip="0.0.0.0",
+        port=8889,
+        allow_root=True,
+        open_browser=False,
+        no_browser_open_file=True,
+        config=config,
+    )
+    app.init_configurables()
+    assert not app.identity_provider.token
+
+    with (
+        patch("socket.gethostname", return_value="myhost"),
+        patch.object(app, "write_server_info_file"),
+        patch.object(app.log, "critical") as log_critical,
+    ):
+        app.start_app()
+
+    assert any(f"http://myhost:{app.port}/" in call.args[0] for call in log_critical.call_args_list)
+
+
 # Preferred dir tests
 # ----------------------------------------------------------------------------
 @pytest.mark.filterwarnings("ignore::FutureWarning")


### PR DESCRIPTION
Password-authenticated servers do not generate a token, so wildcard binds skipped the startup block that prints the connectable hostname URL. Log that URL for authenticated non-token wildcard servers while preserving the generated-token behavior, with a regression test that fails on current `main` and passes with this change.

Fixes #1674
