### PR TITLE
Self-remove event subscriber on `WebSocketClosedError`

### DIFF
--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -62,7 +62,7 @@ class SubscribeWebsocket(
         because the peer disappeared without a clean close handshake, so
         ``on_close`` never fired — Tornado raises
         :class:`~tornado.websocket.WebSocketClosedError` from
-        ``write_message``; in that case ``event_listener`` will remove ourselves from the logger
+        ``write_message``; in that case ``event_listener`` will remove itself from the logger
         so subsequent events don't fan out one failing task per stale
         subscriber (an accumulation that can produce error-log storms
         proportional to event volume).

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -56,9 +56,26 @@ class SubscribeWebsocket(
     async def event_listener(
         self, logger: jupyter_events.logger.EventLogger, schema_id: str, data: dict[str, Any]
     ) -> None:
-        """Write an event message."""
+        """Write an event message to the subscribed WebSocket.
+
+        If the underlying socket has already been closed — typically
+        because the peer disappeared without a clean close handshake, so
+        ``on_close`` never fired — Tornado raises
+        :class:`~tornado.websocket.WebSocketClosedError` from
+        ``write_message``. Remove ourselves from the logger in that case
+        so subsequent events don't fan out one failing task per stale
+        subscriber (an accumulation that can produce error-log storms
+        proportional to event volume).
+        """
         capsule = dict(schema_id=schema_id, **data)
-        self.write_message(json.dumps(capsule))
+        try:
+            self.write_message(json.dumps(capsule))
+        except websocket.WebSocketClosedError:
+            self.log.debug(
+                "Event WebSocket for %s is closed; removing stale listener",
+                schema_id,
+            )
+            self.event_logger.remove_listener(listener=self.event_listener)
 
     def open(self) -> None:  # type: ignore[override]
         """Routes events that are emitted by Jupyter Server's

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -64,8 +64,7 @@ class SubscribeWebsocket(
         :class:`~tornado.websocket.WebSocketClosedError` from
         ``write_message``; in that case ``event_listener`` will remove itself from the logger
         so subsequent events don't fan out one failing task per stale
-        subscriber (an accumulation that can produce error-log storms
-        proportional to event volume).
+        subscriber.
         """
         capsule = dict(schema_id=schema_id, **data)
         try:

--- a/jupyter_server/services/events/handlers.py
+++ b/jupyter_server/services/events/handlers.py
@@ -62,7 +62,7 @@ class SubscribeWebsocket(
         because the peer disappeared without a clean close handshake, so
         ``on_close`` never fired — Tornado raises
         :class:`~tornado.websocket.WebSocketClosedError` from
-        ``write_message``. Remove ourselves from the logger in that case
+        ``write_message``; in that case ``event_listener`` will remove ourselves from the logger
         so subsequent events don't fan out one failing task per stale
         subscriber (an accumulation that can produce error-log storms
         proportional to event volume).

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -42,6 +42,46 @@ async def test_subscribe_websocket(event_logger, jp_ws_fetch):
     assert event_data.get("event_message") == "Hello, world!"
 
 
+async def test_subscribe_websocket_self_removes_on_closed_socket(
+    event_logger, jp_ws_fetch
+):
+    """When the subscriber's socket has died without a clean close
+    handshake (so ``on_close`` never fired), the listener should remove
+    itself from the event logger the next time an event fires, instead
+    of remaining pinned in ``_modified_listeners`` and pinning its
+    handler instance with it.
+    """
+    schema_id = "http://event.mock.jupyter.org/message"
+
+    ws = await jp_ws_fetch("/api/events/subscribe")
+
+    # The ``open()`` hook adds our bound ``event_listener`` to the
+    # logger. Grab it back so we can reach the underlying handler
+    # instance and assert removal later.
+    listeners = event_logger._modified_listeners.get(schema_id, set())
+    assert len(listeners) == 1, "expected exactly one subscriber listener"
+    (listener,) = listeners
+    handler = listener.__self__
+
+    # Simulate an abrupt server-side teardown: clear ``ws_connection``
+    # without calling ``on_close``. Tornado's own ``write_message`` will
+    # then raise ``WebSocketClosedError`` on the next emit, exercising
+    # the self-removal path.
+    handler.ws_connection = None
+
+    event_logger.emit(schema_id=schema_id, data={"event_message": "hi"})
+    await event_logger.gather_listeners()
+
+    remaining = event_logger._modified_listeners.get(schema_id, set())
+    assert listener not in remaining, "listener should have removed itself"
+
+    # A second emit must be a no-op (no accumulated failing tasks).
+    event_logger.emit(schema_id=schema_id, data={"event_message": "hi again"})
+    await event_logger.gather_listeners()
+
+    ws.close()
+
+
 payload_1 = """\
 {
     "schema_id": "http://event.mock.jupyter.org/message",

--- a/tests/services/events/test_api.py
+++ b/tests/services/events/test_api.py
@@ -42,9 +42,7 @@ async def test_subscribe_websocket(event_logger, jp_ws_fetch):
     assert event_data.get("event_message") == "Hello, world!"
 
 
-async def test_subscribe_websocket_self_removes_on_closed_socket(
-    event_logger, jp_ws_fetch
-):
+async def test_subscribe_websocket_self_removes_on_closed_socket(event_logger, jp_ws_fetch):
     """When the subscriber's socket has died without a clean close
     handshake (so ``on_close`` never fired), the listener should remove
     itself from the event logger the next time an event fires, instead


### PR DESCRIPTION
`SubscribeWebsocket.event_listener` writes to the subscriber's WebSocket without guarding against `WebSocketClosedError`, and only cleans up through `on_close`, which isn't reliably fired when the peer disappears without a clean close handshake (network drop, browser tab killed, stream reset).

When that happens, the stale bound `event_listener` stays in `event_logger._modified_listeners`. Since it's a bound method, it keeps a strong reference to its `SubscribeWebsocket` instance, and therefore to the tornado WebSocket handler, the request, and any state captured during the handshake. Nothing ever removes it, so it lives until the process exits. This is a memory leak that grows linearly with the number of unclean disconnects over the server's lifetime.

The fix guards `write_message` with a `WebSocketClosedError` handler and removes the listener from the logger when the write fails. `EventLogger.remove_listener` uses `set.discard`, so double-remove is a no-op.