### PR TITLE
Avoid destructive fallback on busy directory rename

### DIFF
--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -69,6 +69,16 @@ def _get_created_timestamp(info: os.stat_result) -> float:
     return info.st_ctime
 
 
+def _safe_move(src: str, dst: str) -> None:
+    """Move a path without copying after a non-cross-device rename error."""
+    try:
+        os.rename(src, dst)
+    except OSError as error:
+        if error.errno != errno.EXDEV:
+            raise
+        shutil.move(src, dst)
+
+
 class FileContentsManager(FileManagerMixin, ContentsManager):
     """A file contents manager."""
 
@@ -651,7 +661,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         # Move the file
         try:
             with self.perm_to_403():
-                shutil.move(old_os_path, new_os_path)
+                _safe_move(old_os_path, new_os_path)
         except web.HTTPError:
             raise
         except FileNotFoundError:
@@ -1122,7 +1132,7 @@ class AsyncFileContentsManager(  # type: ignore[misc]
         # Move the file
         try:
             with self.perm_to_403():
-                await run_sync(shutil.move, old_os_path, new_os_path)
+                await run_sync(_safe_move, old_os_path, new_os_path)
         except web.HTTPError:
             raise
         except FileNotFoundError:

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -1,3 +1,4 @@
+import errno
 import math
 import os
 import shutil
@@ -854,6 +855,20 @@ async def test_rename(jp_contents_manager):
 
     # Created a notebook in the renamed directory should work
     await ensure_async(cm.new_untitled("foo/bar_diff", ext=".ipynb"))
+
+
+async def test_rename_busy_directory_does_not_move_contents(jp_contents_manager):
+    cm = jp_contents_manager
+    await make_populated_dir(cm, "busy")
+
+    error = OSError(errno.EBUSY, "Device or resource busy")
+    with patch("jupyter_server.services.contents.filemanager.os.rename", side_effect=error):
+        with pytest.raises(HTTPError) as excinfo:
+            await ensure_async(cm.rename_file("busy", "renamed"))
+
+    assert excinfo.value.status_code == 500
+    await check_populated_dir_files(cm, "busy")
+    assert await ensure_async(cm.dir_exists("renamed")) is False
 
 
 async def test_rename_nonexistent(jp_contents_manager):


### PR DESCRIPTION
Closes #1458

`shutil.move()` falls back to copying and deleting a directory after any `os.rename()` error, so an `EBUSY` mount-point rename can move the contents before failing to remove the source directory. This change only permits that fallback for `EXDEV`; other rename errors now fail without touching the source contents.

Tests: `python -m pytest -q tests/services/contents/test_manager.py` (142 passed, 4 skipped); Ruff check and format on both changed files.
