### PR TITLE
Don't crash shutdown_server() on non-HTTP-scheme errors

### DIFF
--- a/docs/source/operators/public-server.rst
+++ b/docs/source/operators/public-server.rst
@@ -37,7 +37,7 @@ This document describes how you can
 
 .. _ZeroMQ: https://zeromq.org/
 
-.. _Tornado: http://www.tornadoweb.org/en/stable/
+.. _Tornado: https://www.tornadoweb.org/en/stable/
 
 .. _JupyterHub: https://jupyterhub.readthedocs.io/en/latest/
 

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -640,17 +640,26 @@ def shutdown_server(server_info, timeout=5, log=None):
             headers={"Authorization": "token " + server_info["token"]},
         )
     except Exception as ex:
-        if not str(ex) == "Unknown URL scheme.":
-            raise ex
-        if log:
-            log.debug("Was not a HTTP scheme. Treating as socket instead.")
-            log.debug("POST request to %s", url)
-        fetch(
-            url,
-            method="POST",
-            body=b"",
-            headers={"Authorization": "token " + server_info["token"]},
-        )
+        if str(ex) == "Unknown URL scheme.":
+            if log:
+                log.debug("Was not a HTTP scheme. Treating as socket instead.")
+                log.debug("POST request to %s", url)
+            try:
+                fetch(
+                    url,
+                    method="POST",
+                    body=b"",
+                    headers={"Authorization": "token " + server_info["token"]},
+                )
+            except Exception as sock_ex:
+                if log:
+                    log.debug("Failed to send shutdown request over socket: %s", sock_ex)
+        elif log:
+            # e.g. a connection error, or a 403 from a password-protected
+            # server that doesn't authenticate the (empty) token used here.
+            # Don't let this abort the whole shutdown attempt - fall through
+            # to the PID-based fallback below instead.
+            log.debug("Failed to send HTTP shutdown request to %s: %s", shutdown_url, ex)
 
     # Poll to see if it shut down.
     for _ in range(timeout * 10):

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -15,6 +15,7 @@ from traitlets import TraitError
 from traitlets.config import Config
 from traitlets.tests.utils import check_help_all_output
 
+from jupyter_server import serverapp as serverapp_module
 from jupyter_server.auth.decorator import allow_unauthenticated, authorized
 from jupyter_server.auth.security import passwd_check
 from jupyter_server.serverapp import (
@@ -25,6 +26,7 @@ from jupyter_server.serverapp import (
     _has_tornado_web_authenticated,
     list_running_servers,
     random_ports,
+    shutdown_server,
 )
 from jupyter_server.services.contents.filemanager import (
     AsyncFileContentsManager,
@@ -700,6 +702,52 @@ async def test_shutdown_no_activity(jp_serverapp):
 def test_running_server_info(jp_serverapp):
     app: ServerApp = jp_serverapp
     app.running_server_info(True)
+
+
+def test_shutdown_server_falls_back_on_http_error(monkeypatch):
+    """shutdown_server() must not propagate an HTTP error from the
+    /api/shutdown request (e.g. a 403 from a password-protected server
+    that doesn't accept the empty token used here) - it should log it and
+    fall through to the PID-based fallback instead, like it already does
+    for connections that turn out not to be HTTP at all.
+    """
+    calls = []
+
+    def fake_fetch(*args, **kwargs):
+        calls.append(args)
+        raise Exception("HTTP 403: Forbidden")
+
+    monkeypatch.setattr(serverapp_module, "fetch", fake_fetch)
+    monkeypatch.setattr(serverapp_module, "check_pid", lambda pid: False)
+
+    server_info = {"url": "http://127.0.0.1:12345/", "pid": 12345, "token": ""}
+
+    assert shutdown_server(server_info, timeout=1) is True
+    assert len(calls) == 1
+
+
+def test_shutdown_server_unix_socket_fallback_still_works(monkeypatch):
+    """The pre-existing "Unknown URL scheme." -> unix socket retry path
+    should be unaffected by the broader error handling above.
+    """
+    calls = []
+
+    def fake_fetch(url, **kwargs):
+        calls.append(url)
+        if len(calls) == 1:
+            raise Exception("Unknown URL scheme.")
+        return None
+
+    monkeypatch.setattr(serverapp_module, "fetch", fake_fetch)
+    monkeypatch.setattr(serverapp_module, "check_pid", lambda pid: False)
+
+    server_info = {"url": "http+unix://%2Ftmp%2Fsock.sock/", "pid": 12345, "token": ""}
+
+    assert shutdown_server(server_info, timeout=1) is True
+    # First call is the (failing) attempt at the joined shutdown URL, second
+    # is the retry directly against the raw socket URL.
+    assert len(calls) == 2
+    assert calls[1] == server_info["url"]
 
 
 @pytest.mark.parametrize("should_exist", [True, False])


### PR DESCRIPTION
Fixes #1008.

## What's going on

`shutdown_server()` sends a POST to `/api/shutdown` and only special-cases one exception: `"Unknown URL scheme."`, which means "this was actually a unix socket URL, retry it differently." Anything else it catches, it just re-raises - which aborts the whole function before it ever gets to the PID-based `SIGTERM`/`SIGKILL` fallback below (or, on Windows, before it can cleanly return `False` and print "Could not stop server on ...").

I actually reproduced #1008 against current `main` rather than just going off the old traceback in the issue: start a server with a password set and no token (`--IdentityProvider.token=""`), then run `jupyter server stop <port>`. It crashes with

```
tornado.httpclient.HTTPClientError: HTTP 403: Forbidden
```

Root cause, traced through `base/handlers.py`: `check_xsrf_cookie()` is only skipped for token-authenticated requests. With no token configured, `shutdown_server()`'s plain POST (no cookie, no XSRF token - it's a one-shot CLI request, not a browser session) hits XSRF protection and gets a 403 before auth is even evaluated. So this isn't really password-vs-token specific, it's "any time the shutdown POST fails for an HTTP-level reason that isn't the unix-socket special case, the function blows up instead of degrading gracefully."

## The fix

Catch the general case too, log it, and let execution continue to the existing PID-polling/signal fallback instead of propagating. The unix-socket retry path is unchanged.

## Testing

- Reproduced the crash for real against current `main` (password + no token, both by calling `shutdown_server()` directly and through the actual `jupyter server stop` CLI) - confirmed it's still there.
- With the fix, `jupyter server stop <port>` against the same password-protected server now prints `Could not stop server on <port>` and exits 1 instead of an unhandled traceback (I'm on Windows so I can't exercise the `SIGTERM` branch myself, but the same fall-through is what lets it get reached at all on Unix instead of crashing first).
- Confirmed the normal token-based happy path is untouched - `fetch()` succeeds, my `except` branch never runs, server shuts down and the existing test suite covers that already.
- Added two unit tests in `tests/test_serverapp.py` (mocking `fetch`/`check_pid`, no subprocess needed): one for the new "generic HTTP failure falls through" behavior (fails on unpatched code with the same exception, passes with the fix), one confirming the existing "Unknown URL scheme." unix-socket retry still works exactly as before.
- Full `pytest tests/` (minus the `integration_test`-marked subprocess tests, which need real signal handling this Windows box can't give a fair shake, and one pre-existing `test_server_extension_list[subprocess]` PATH-resolution failure that's unrelated to this change and present without it) passes, same as on `main`. Cross-checked the handful of unrelated failures/errors that do show up in a full-suite run (symlink-permission tests needing elevated Windows privileges, some async-teardown flakiness) against unpatched `main` too - identical either way, not introduced by this change.
- `ruff check` / `ruff format` / the repo's `pre-commit` hooks all pass on the changed files.

Small note on scope: this doesn't make `jupyter server stop` actually authenticate against a password-only server (it still can't produce a valid token/cookie for one) - it just stops that failure from being an unhandled crash and lets the existing signal-based fallback do its job like it's supposed to.