### PR TITLE
Update gateway tests for Tornado start_line

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -16,7 +16,7 @@ import tornado
 from jupyter_core.utils import ensure_async
 from tornado.concurrent import Future
 from tornado.httpclient import HTTPRequest, HTTPResponse
-from tornado.httputil import HTTPHeaders, HTTPServerRequest
+from tornado.httputil import HTTPHeaders, HTTPServerRequest, RequestStartLine
 from tornado.queues import Queue
 from tornado.web import HTTPError
 from traitlets import Int, Unicode
@@ -720,7 +720,7 @@ async def test_websocket_connection_closed(init_gateway, jp_serverapp, jp_fetch,
     km: GatewayKernelManager = jp_serverapp.kernel_manager.get_kernel(kernel_id)
 
     # Create the KernelWebsocketHandler...
-    request = HTTPServerRequest("foo", "GET")
+    request = HTTPServerRequest(start_line=RequestStartLine("foo", "GET", "HTTP/1.0"))
     request.connection = MagicMock()
     handler = KernelWebsocketHandler(jp_serverapp.web_app, request)
 
@@ -754,7 +754,7 @@ async def test_websocket_connection_with_session_id(init_gateway, jp_serverapp, 
     km: GatewayKernelManager = jp_serverapp.kernel_manager.get_kernel(kernel_id)
 
     # Create the KernelWebsocketHandler...
-    request = HTTPServerRequest("foo", "GET")
+    request = HTTPServerRequest(start_line=RequestStartLine("foo", "GET", "HTTP/1.0"))
     request.connection = MagicMock()
     handler = KernelWebsocketHandler(jp_serverapp.web_app, request)
     # Create the GatewayWebSocketConnection and attach it to the handler...


### PR DESCRIPTION
## Summary

I updated the two manually constructed `HTTPServerRequest` instances in the
gateway websocket tests to pass an explicit `RequestStartLine`.

This keeps the tests compatible with Tornado's planned removal of the
`method` and `uri` constructor arguments while preserving the values previously
used by each test. The change is limited to tests.

Closes #1661

## Validation

- `python -m pytest tests/test_gateway.py -q` — 29 passed with Tornado 6.5.7
- `python -m pytest tests/test_gateway.py -q` — 29 passed with Tornado 6.6.dev1
- `python -m ruff check tests/test_gateway.py`
- `python -m ruff format --check tests/test_gateway.py`
- `git diff --check`
