### PR TITLE
TEST pass request start line in gateway fixtures

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -16,7 +16,7 @@ import tornado
 from jupyter_core.utils import ensure_async
 from tornado.concurrent import Future
 from tornado.httpclient import HTTPRequest, HTTPResponse
-from tornado.httputil import HTTPHeaders, HTTPServerRequest
+from tornado.httputil import HTTPHeaders, HTTPServerRequest, RequestStartLine
 from tornado.queues import Queue
 from tornado.web import HTTPError
 from traitlets import Int, Unicode
@@ -720,7 +720,7 @@ async def test_websocket_connection_closed(init_gateway, jp_serverapp, jp_fetch,
     km: GatewayKernelManager = jp_serverapp.kernel_manager.get_kernel(kernel_id)
 
     # Create the KernelWebsocketHandler...
-    request = HTTPServerRequest("foo", "GET")
+    request = HTTPServerRequest(start_line=RequestStartLine("GET", "foo", "HTTP/1.0"))
     request.connection = MagicMock()
     handler = KernelWebsocketHandler(jp_serverapp.web_app, request)
 
@@ -754,7 +754,7 @@ async def test_websocket_connection_with_session_id(init_gateway, jp_serverapp, 
     km: GatewayKernelManager = jp_serverapp.kernel_manager.get_kernel(kernel_id)
 
     # Create the KernelWebsocketHandler...
-    request = HTTPServerRequest("foo", "GET")
+    request = HTTPServerRequest(start_line=RequestStartLine("GET", "foo", "HTTP/1.0"))
     request.connection = MagicMock()
     handler = KernelWebsocketHandler(jp_serverapp.web_app, request)
     # Create the GatewayWebSocketConnection and attach it to the handler...


### PR DESCRIPTION
Closes #1661

Update the two gateway websocket test fixtures to construct `HTTPServerRequest` with an explicit `RequestStartLine`, matching Tornado's upcoming requirement while keeping the change scoped to tests.

Validation: `uv run --extra test pytest -q tests/test_gateway.py -k "websocket_connection_closed or websocket_connection_with_session_id"` (2 passed).