### PR TITLE
Use urllib for Unix socket path encoding

### DIFF
--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -234,12 +234,12 @@ async def run_sync_in_loop(maybe_async):
 
 def urlencode_unix_socket_path(socket_path: str) -> str:
     """Encodes a UNIX socket path string from a socket path for the `http+unix` URI form."""
-    return socket_path.replace("/", "%2F")
+    return quote(socket_path, safe="")
 
 
 def urldecode_unix_socket_path(socket_path: str) -> str:
     """Decodes a UNIX sock path string from an encoded sock path for the `http+unix` URI form."""
-    return socket_path.replace("%2F", "/")
+    return unquote(socket_path)
 
 
 def urlencode_unix_socket(socket_path: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,6 +24,8 @@ from jupyter_server.utils import (
     url2path,
     url_escape,
     url_unescape,
+    urldecode_unix_socket_path,
+    urlencode_unix_socket_path,
 )
 
 
@@ -127,6 +129,20 @@ def test_unix_socket_in_use(tmp_path):
     sock.listen(0)
     assert unix_socket_in_use(server_address)
     sock.close()
+
+
+@pytest.mark.parametrize(
+    "socket_path, encoded_socket_path",
+    [
+        ("/tmp/jupyter server.sock", "%2Ftmp%2Fjupyter%20server.sock"),
+        ("/tmp/socket%2Fname.sock", "%2Ftmp%2Fsocket%252Fname.sock"),
+    ],
+)
+def test_unix_socket_path_url_encoding(socket_path, encoded_socket_path):
+    encoded = urlencode_unix_socket_path(socket_path)
+
+    assert encoded == encoded_socket_path
+    assert urldecode_unix_socket_path(encoded) == socket_path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1663

### Summary
- use `urllib.parse.quote` and `unquote` for HTTP+UNIX socket path conversion
- encode spaces and other reserved characters while preserving a reversible path
- add regression coverage for spaces and literal percent-encoded text

### Validation
- `uv run --extra test pytest tests/test_utils.py -q` (38 passed)
- `uv run --extra test ruff check jupyter_server/utils.py tests/test_utils.py`

Prepared with AI assistance; I reviewed the implementation and validation output.