### PR TITLE
Handle early-closed kernel websocket in subprotocol selection

### DIFF
--- a/jupyter_server/services/kernels/websocket.py
+++ b/jupyter_server/services/kernels/websocket.py
@@ -85,7 +85,10 @@ class KernelWebsocketHandler(WebSocketMixin, WebSocketHandler, JupyterHandler):
 
     def select_subprotocol(self, subprotocols):
         """Select the sub protocol for the socket."""
-        preferred_protocol = self.connection.kernel_ws_protocol
+        connection = self.connection
+        if connection is None:
+            return None
+        preferred_protocol = connection.kernel_ws_protocol
         if preferred_protocol is None:
             preferred_protocol = "v1.kernel.websocket.jupyter.org"
         elif preferred_protocol == "":

--- a/tests/services/kernels/test_connection.py
+++ b/tests/services/kernels/test_connection.py
@@ -50,6 +50,13 @@ async def test_websocket_connection(jp_serverapp: ServerApp) -> None:
     conn._on_error("shell", msg, session.serialize(msg))
 
 
+def test_select_subprotocol_after_early_close() -> None:
+    handler = object.__new__(KernelWebsocketHandler)
+    handler.connection = None
+
+    assert handler.select_subprotocol(["v1.kernel.websocket.jupyter.org"]) is None
+
+
 def _make_connection(app, kernel, session_id=None, timeout=0.01):
     """Build a ZMQChannelsWebsocketConnection with a mocked handler."""
     request = HTTPRequest("foo", "GET")


### PR DESCRIPTION
## Summary

Handle the websocket early-close race where `on_close()` has already cleared `self.connection` before Tornado asks the handler to select a subprotocol.

## Changes

- return the legacy/default `None` subprotocol when the connection is already closed
- leave all existing protocol-selection behavior unchanged for live connections
- add a focused regression test for the early-close path

This follows the maintainer direction in #1265 that a closed connection should be handled as an early return.

## Validation

Focused test:
`pytest -q tests/services/kernels/test_connection.py -k select_subprotocol`

Fixes #1265

<!-- pr-relay-job relay-62-be87fba4a080ee225aef -->